### PR TITLE
Backport upstream PR#4841, PR#4846, PR#4872, PR#4878

### DIFF
--- a/src/d3d11/d3d11_blend.cpp
+++ b/src/d3d11/d3d11_blend.cpp
@@ -8,7 +8,7 @@ namespace dxvk {
     const D3D11_BLEND_DESC1&  desc,
           Container*          container)
   : D3D11StateObject<ID3D11BlendState1, D3D11BlendState>(device, container),
-    m_desc(desc), m_d3d10(this) {
+    m_desc(desc), m_d3d10(this), m_destructionNotifier(this) {
     // If Independent Blend is disabled, we must ignore the
     // blend modes for render target 1 to 7. In Vulkan, all
     // blend modes need to be identical in that case.
@@ -58,7 +58,12 @@ namespace dxvk {
       *ppvObject = ref(&m_d3d10);
       return S_OK;
     }
-    
+
+    if (riid == __uuidof(ID3DDestructionNotifier)) {
+      *ppvObject = ref(&m_destructionNotifier);
+      return S_OK;
+    }
+
     if (logQueryInterfaceError(__uuidof(ID3D11BlendState), riid)) {
       Logger::warn("D3D11BlendState::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));

--- a/src/d3d11/d3d11_blend.h
+++ b/src/d3d11/d3d11_blend.h
@@ -71,6 +71,8 @@ namespace dxvk {
 
     D3D10BlendState               m_d3d10;
 
+    D3DDestructionNotifier        m_destructionNotifier;
+
     static DxvkBlendMode DecodeBlendMode(
       const D3D11_RENDER_TARGET_BLEND_DESC1& BlendDesc);
     

--- a/src/d3d11/d3d11_buffer.cpp
+++ b/src/d3d11/d3d11_buffer.cpp
@@ -12,7 +12,8 @@ namespace dxvk {
   : D3D11DeviceChild<ID3D11Buffer>(pDevice),
     m_desc        (*pDesc),
     m_resource    (this, pDevice),
-    m_d3d10       (this) {
+    m_d3d10       (this),
+    m_destructionNotifier(this) {
     DxvkBufferCreateInfo info;
     info.flags  = 0;
     info.size   = pDesc->ByteWidth;
@@ -159,7 +160,12 @@ namespace dxvk {
        *ppvObject = ref(&m_resource);
        return S_OK;
     }
-    
+
+    if (riid == __uuidof(ID3DDestructionNotifier)) {
+      *ppvObject = ref(&m_destructionNotifier);
+      return S_OK;
+    }
+
     if (logQueryInterfaceError(__uuidof(ID3D11Buffer), riid)) {
       Logger::warn("D3D11Buffer::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));

--- a/src/d3d11/d3d11_buffer.h
+++ b/src/d3d11/d3d11_buffer.h
@@ -200,6 +200,8 @@ namespace dxvk {
     D3D11DXGIResource             m_resource;
     D3D10Buffer                   m_d3d10;
 
+    D3DDestructionNotifier        m_destructionNotifier;
+
     BOOL CheckFormatFeatureSupport(
             VkFormat              Format,
             VkFormatFeatureFlags2 Features) const;

--- a/src/d3d11/d3d11_class_linkage.cpp
+++ b/src/d3d11/d3d11_class_linkage.cpp
@@ -5,7 +5,8 @@ namespace dxvk {
   
   D3D11ClassLinkage::D3D11ClassLinkage(
           D3D11Device*                pDevice)
-  : D3D11DeviceChild<ID3D11ClassLinkage>(pDevice) {
+  : D3D11DeviceChild<ID3D11ClassLinkage>(pDevice),
+    m_destructionNotifier(this) {
     
   }
   
@@ -28,6 +29,11 @@ namespace dxvk {
       return S_OK;
     }
     
+    if (riid == __uuidof(ID3DDestructionNotifier)) {
+      *ppvObject = ref(&m_destructionNotifier);
+      return S_OK;
+    }
+
     if (logQueryInterfaceError(__uuidof(ID3D11ClassLinkage), riid)) {
       Logger::warn("D3D11ClassLinkage::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));

--- a/src/d3d11/d3d11_class_linkage.h
+++ b/src/d3d11/d3d11_class_linkage.h
@@ -32,7 +32,11 @@ namespace dxvk {
             LPCSTR              pClassInstanceName,
             UINT                InstanceIndex,
             ID3D11ClassInstance **ppInstance);  
+
+  private:
     
+    D3DDestructionNotifier m_destructionNotifier;
+
   };
   
 }

--- a/src/d3d11/d3d11_cmdlist.cpp
+++ b/src/d3d11/d3d11_cmdlist.cpp
@@ -9,7 +9,7 @@ namespace dxvk {
           D3D11Device*  pDevice,
           UINT          ContextFlags)
   : D3D11DeviceChild<ID3D11CommandList>(pDevice),
-    m_contextFlags(ContextFlags) { }
+    m_contextFlags(ContextFlags), m_destructionNotifier(this) { }
   
   
   D3D11CommandList::~D3D11CommandList() {
@@ -29,7 +29,12 @@ namespace dxvk {
       *ppvObject = ref(this);
       return S_OK;
     }
-    
+
+    if (riid == __uuidof(ID3DDestructionNotifier)) {
+      *ppvObject = ref(&m_destructionNotifier);
+      return S_OK;
+    }
+
     if (logQueryInterfaceError(__uuidof(ID3D11CommandList), riid)) {
       Logger::warn("D3D11CommandList::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));

--- a/src/d3d11/d3d11_cmdlist.h
+++ b/src/d3d11/d3d11_cmdlist.h
@@ -49,11 +49,13 @@ namespace dxvk {
       uint64_t          chunkId;
     };
 
-    UINT m_contextFlags;
-    
+    UINT m_contextFlags = 0u;
+
     std::vector<DxvkCsChunkRef>         m_chunks;
     std::vector<Com<D3D11Query, false>> m_queries;
     std::vector<TrackedResource>        m_resources;
+
+    D3DDestructionNotifier              m_destructionNotifier;
 
     void TrackResourceSequenceNumber(
       const D3D11ResourceRef&   Resource,

--- a/src/d3d11/d3d11_context.cpp
+++ b/src/d3d11/d3d11_context.cpp
@@ -927,9 +927,6 @@ namespace dxvk {
         ctx->resolveImage(cDstImage, cSrcImage, region, format,
           getDefaultResolveMode(format), VK_RESOLVE_MODE_NONE);
       });
-
-      if constexpr (!IsDeferred)
-        GetTypedContext()->m_hasPendingMsaaResolve = false;
     }
 
     if (dstTextureInfo->HasSequenceNumber())
@@ -5243,7 +5240,6 @@ namespace dxvk {
       return;
 
     bool needsUpdate = false;
-    bool isMultisampled = false;
 
     if (likely(NumRTVs != D3D11_KEEP_RENDER_TARGETS_AND_DEPTH_STENCIL)) {
       // Native D3D11 does not change the render targets if
@@ -5263,9 +5259,6 @@ namespace dxvk {
 
           if (NumUAVs == D3D11_KEEP_UNORDERED_ACCESS_VIEWS)
             ResolveOmUavHazards(rtv);
-
-          if (rtv && rtv->GetSampleCount() > 1u)
-            isMultisampled = true;
         }
       }
 
@@ -5275,9 +5268,6 @@ namespace dxvk {
         m_state.om.dsv = dsv;
         needsUpdate = true;
         ResolveOmSrvHazards(dsv);
-
-        if (dsv && dsv->GetSampleCount() > 1u)
-          isMultisampled = true;
       }
 
       m_state.om.maxRtv = NumRTVs;
@@ -5322,15 +5312,8 @@ namespace dxvk {
     if (needsUpdate) {
       BindFramebuffer();
 
-      if constexpr (!IsDeferred) {
-        // Doing this makes it less likely to flush during render passes
-        auto imm = GetTypedContext();
-
-        if (!imm->m_hasPendingMsaaResolve || !m_device->perfHints().preferRenderPassOps)
-          imm->ConsiderFlush(GpuFlushType::ImplicitMediumHint);
-
-        imm->m_hasPendingMsaaResolve |= isMultisampled;
-      }
+      if constexpr (!IsDeferred)
+        GetTypedContext()->NotifyRenderPassBoundary();
     }
   }
 

--- a/src/d3d11/d3d11_context.cpp
+++ b/src/d3d11/d3d11_context.cpp
@@ -691,114 +691,65 @@ namespace dxvk {
     auto vov = dynamic_cast<D3D11VideoProcessorOutputView*>(pView);
 
     // Retrieve underlying resource view
-    Rc<DxvkBufferView> bufView;
-    Rc<DxvkImageView>  imgView;
+    if (dsv) {
+      Rc<DxvkImageView> imgView = dsv->GetImageView();
 
-    if (dsv != nullptr)
-      imgView = dsv->GetImageView();
+      if (imgView)
+        ClearImageView(std::move(imgView), Color, pRect, NumRects);
+    } else if (rtv) {
+      Rc<DxvkImageView> imgView = rtv->GetImageView();
 
-    if (rtv != nullptr)
-      imgView = rtv->GetImageView();
+      if (imgView)
+        ClearImageView(std::move(imgView), Color, pRect, NumRects);
+    } else if (uav) {
+      Rc<DxvkImageView> imgView = uav->GetImageView();
+      Rc<DxvkBufferView> bufView = uav->GetBufferView();
 
-    if (uav != nullptr) {
-      bufView = uav->GetBufferView();
-      imgView = uav->GetImageView();
-    }
+      if (imgView)
+        ClearImageView(std::move(imgView), Color, pRect, NumRects);
 
-    if (vov != nullptr)
-      imgView = vov->GetView();
+      if (bufView)
+        ClearBufferView(std::move(bufView), Color, pRect, NumRects);
+    } else if (vov) {
+      auto views = vov->GetCommon().GetViews();
+      auto shadow = vov->GetCommon().GetShadow();
 
-    // 3D views are unsupported
-    if (imgView != nullptr
-     && imgView->info().viewType == VK_IMAGE_VIEW_TYPE_3D)
-      return;
+      // If we have to assume that the image is only partially cleared,
+      // make sure to properly sync it with the shadow image.
+      VkImageSubresourceLayers imageLayers = vov->GetCommon().GetImageSubresource();
 
-    // Query the view format. We'll have to convert
-    // the clear color based on the format's data type.
-    VkFormat format = VK_FORMAT_UNDEFINED;
+      VkImageSubresourceLayers shadowLayers = { };
+      shadowLayers.aspectMask = imageLayers.aspectMask;
+      shadowLayers.layerCount = imageLayers.layerCount;
 
-    if (bufView != nullptr)
-      format = bufView->info().format;
+      if (shadow && NumRects)
+        SyncImage(shadow, shadowLayers, vov->GetCommon().GetImage(), imageLayers);
 
-    if (imgView != nullptr)
-      format = imgView->info().format;
+      // Assume that planar video formats use Y - Cb - Cr
+      // order for the purpose of mapping color components.
+      uint32_t component = 0u;
+      FLOAT planeColor[4] = { };
 
-    if (format == VK_FORMAT_UNDEFINED)
-      return;
+      for (uint32_t i = 0u; i < views.size(); i++) {
+        if (!views[i])
+          break;
 
-    // We'll need the format info to determine the buffer
-    // element size, and we also need it for depth images.
-    const DxvkFormatInfo* formatInfo = lookupFormatInfo(format);
+        // Extract relevant color components from the clear color
+        // and shift the input array accordingly.
+        uint32_t n = bit::popcnt(views[i]->formatInfo()->componentMask);
 
-    // Convert the clear color format. ClearView takes
-    // the clear value for integer formats as a set of
-    // integral floats, so we'll have to convert.
-    VkClearValue        clearValue  = ConvertColorValue(Color, formatInfo);
-    VkImageAspectFlags  clearAspect = formatInfo->aspectMask & (VK_IMAGE_ASPECT_COLOR_BIT | VK_IMAGE_ASPECT_DEPTH_BIT);
+        for (uint32_t c = 0u; c < 4u; c++)
+          planeColor[c] = c < n && component + c < 4u ? Color[c] : 0.0f;
 
-    // Clear all the rectangles that are specified
-    for (uint32_t i = 0; i < NumRects || i < 1; i++) {
-      if (NumRects) {
-        if (pRect[i].left >= pRect[i].right
-         || pRect[i].top >= pRect[i].bottom)
-          continue;
+        component += n;
+
+        // Perform the actual clear. Rects will be adjusted by called method.
+        ClearImageView(std::move(views[i]), planeColor, pRect, NumRects);
       }
 
-      if (bufView != nullptr) {
-        VkDeviceSize offset = 0;
-        VkDeviceSize length = bufView->info().size / formatInfo->elementSize;
-
-        if (NumRects) {
-          offset = pRect[i].left;
-          length = pRect[i].right - pRect[i].left;
-        }
-
-        EmitCs([
-          cBufferView   = bufView,
-          cRangeOffset  = offset,
-          cRangeLength  = length,
-          cClearValue   = clearValue
-        ] (DxvkContext* ctx) {
-          ctx->clearBufferView(
-            cBufferView,
-            cRangeOffset,
-            cRangeLength,
-            cClearValue.color);
-        });
-      }
-
-      if (imgView != nullptr) {
-        VkOffset3D offset = { 0, 0, 0 };
-        VkExtent3D extent = imgView->mipLevelExtent(0);
-
-        if (NumRects) {
-          offset = { pRect[i].left, pRect[i].top, 0 };
-          extent = {
-            uint32_t(pRect[i].right - pRect[i].left),
-            uint32_t(pRect[i].bottom - pRect[i].top), 1 };
-        }
-
-        EmitCs([
-          cImageView    = imgView,
-          cAreaOffset   = offset,
-          cAreaExtent   = extent,
-          cClearAspect  = clearAspect,
-          cClearValue   = clearValue
-        ] (DxvkContext* ctx) {
-          const VkImageUsageFlags rtUsage =
-            VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT |
-            VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
-
-          bool isFullSize = cImageView->mipLevelExtent(0) == cAreaExtent;
-
-          if ((cImageView->info().usage & rtUsage) && isFullSize) {
-            ctx->clearRenderTarget(cImageView, cClearAspect, cClearValue, 0u);
-          } else {
-            ctx->clearImageView(cImageView, cAreaOffset, cAreaExtent,
-              cClearAspect, cClearValue);
-          }
-        });
-      }
+      // If the video view has a shadow image, copy it back to the base image
+      if (shadow)
+        SyncImage(vov->GetCommon().GetImage(), imageLayers, shadow, shadowLayers);
     }
   }
 
@@ -4056,6 +4007,110 @@ namespace dxvk {
 
 
   template<typename ContextType>
+  void D3D11CommonContext<ContextType>::ClearImageView(
+          Rc<DxvkImageView>                 View,
+    const FLOAT                             Color[4],
+    const D3D11_RECT*                       pRects,
+          UINT                              NumRects) {
+    // 3D views are unsupported
+    if (View->info().viewType == VK_IMAGE_VIEW_TYPE_3D)
+      return;
+
+    // Convert clear value
+    auto clearValue = ConvertColorValue(Color, View->formatInfo());
+
+    VkExtent3D extent3D = View->mipLevelExtent(0);
+    VkExtent2D extent2D = { extent3D.width, extent3D.height };
+
+    // Figure out which plane we're clearing for subsampling
+    const DxvkPlaneFormatInfo* plane = nullptr;
+    auto imageFormatInfo = View->image()->formatInfo();
+
+    if (imageFormatInfo->flags.test(DxvkFormatFlag::MultiPlane))
+      plane = &imageFormatInfo->planes[vk::getPlaneIndex(View->info().aspects)];
+
+    // Clear all non-empty rectangles
+    EmitCsCmd<VkRect2D>(D3D11CmdType::None, std::max(NumRects, 1u), [
+      cView       = std::move(View),
+      cClearValue = clearValue
+    ] (DxvkContext* ctx, const VkRect2D* rects, size_t count) {
+      constexpr VkImageUsageFlags rtUsage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+      VkImageAspectFlags clearAspect = cView->formatInfo()->aspectMask & (VK_IMAGE_ASPECT_COLOR_BIT | VK_IMAGE_ASPECT_DEPTH_BIT);
+
+      for (size_t i = 0; i < count; i++) {
+        VkOffset3D offset = { rects[i].offset.x, rects[i].offset.y, 0 };
+        VkExtent3D extent = { rects[i].extent.width, rects[i].extent.height, 1u };
+
+        if (extent.width && extent.height) {
+          bool isFullSize = cView->mipLevelExtent(0) == extent;
+
+          if ((cView->info().usage & rtUsage) && isFullSize)
+            ctx->clearRenderTarget(cView, clearAspect, cClearValue, 0u);
+          else
+            ctx->clearImageView(cView, offset, extent, clearAspect, cClearValue);
+        }
+      }
+    });
+
+    if (NumRects) {
+      for (uint32_t i = 0; i < NumRects; i++) {
+        D3D11_RECT subsampledRect = pRects[i];
+
+        if (plane) {
+          subsampledRect.left   /= plane->blockSize.width;
+          subsampledRect.top    /= plane->blockSize.height;
+          subsampledRect.right  /= plane->blockSize.width;
+          subsampledRect.bottom /= plane->blockSize.height;
+        }
+
+        new (m_csData->at(i)) VkRect2D(ConvertRect(subsampledRect, extent2D));
+      }
+    } else {
+      auto vkRect = new (m_csData->first()) VkRect2D();
+      vkRect->offset = VkOffset2D { 0, 0 };
+      vkRect->extent = extent2D;
+    }
+  }
+
+
+  template<typename ContextType>
+  void D3D11CommonContext<ContextType>::ClearBufferView(
+          Rc<DxvkBufferView>                View,
+    const FLOAT                             Color[4],
+    const D3D11_RECT*                       pRects,
+          UINT                              NumRects) {
+    // Convert clear value
+    auto formatInfo = View->formatInfo();
+    auto clearValue = ConvertColorValue(Color, formatInfo);
+
+    // Just pass the rectangles through, even though we only need one dimension
+    VkExtent2D extent2D = { uint32_t(View->info().size / formatInfo->elementSize), 1u };
+
+    EmitCsCmd<VkRect2D>(D3D11CmdType::None, std::max(NumRects, 1u), [
+      cView       = std::move(View),
+      cClearValue = clearValue
+    ] (DxvkContext* ctx, const VkRect2D* rects, size_t count) {
+      for (size_t i = 0; i < count; i++) {
+        if (rects[i].extent.width) {
+          ctx->clearBufferView(cView,
+            rects[i].offset.x, rects[i].extent.width,
+            cClearValue.color);
+        }
+      }
+    });
+
+    if (NumRects) {
+      for (uint32_t i = 0; i < NumRects; i++)
+        new (m_csData->at(i)) VkRect2D(ConvertRect(pRects[i], extent2D));
+    } else {
+      auto vkRect = new (m_csData->first()) VkRect2D();
+      vkRect->offset = VkOffset2D { 0, 0 };
+      vkRect->extent = extent2D;
+    }
+  }
+
+
+  template<typename ContextType>
   VkClearValue D3D11CommonContext<ContextType>::ConvertColorValue(
     const FLOAT                             Color[4],
     const DxvkFormatInfo*                   pFormatInfo) {
@@ -4075,6 +4130,27 @@ namespace dxvk {
       result.depthStencil.stencil = 0;
     }
 
+    return result;
+  }
+
+
+  template<typename ContextType>
+  VkRect2D D3D11CommonContext<ContextType>::ConvertRect(
+          D3D11_RECT                        Rect,
+          VkExtent2D                        Extent) {
+    Rect.left   = std::max<int32_t>(Rect.left,   0);
+    Rect.top    = std::max<int32_t>(Rect.top,    0);
+    Rect.right  = std::min<int32_t>(Rect.right,  Extent.width);
+    Rect.bottom = std::min<int32_t>(Rect.bottom, Extent.height);
+
+    if (Rect.left >= Rect.right || Rect.top >= Rect.bottom)
+      return VkRect2D();
+
+    VkRect2D result = { };
+    result.offset.x = Rect.left;
+    result.offset.y = Rect.top;
+    result.extent.width = Rect.right - Rect.left;
+    result.extent.height = Rect.bottom - Rect.top;
     return result;
   }
 
@@ -5335,6 +5411,26 @@ namespace dxvk {
 
       BindDrawBuffers(argBuffer, cntBuffer);
     }
+  }
+
+
+  template<typename ContextType>
+  void D3D11CommonContext<ContextType>::SyncImage(
+    const Rc<DxvkImage>&                    DstImage,
+    const VkImageSubresourceLayers&         DstLayers,
+    const Rc<DxvkImage>&                    SrcImage,
+    const VkImageSubresourceLayers&         SrcLayers) {
+    EmitCs([
+      cDstImage = DstImage,
+      cDstLayers = DstLayers,
+      cSrcImage = SrcImage,
+      cSrcLayers = SrcLayers
+    ] (DxvkContext* ctx) {
+      ctx->copyImage(
+        cDstImage, cDstLayers, VkOffset3D(),
+        cSrcImage, cSrcLayers, VkOffset3D(),
+        cDstImage->mipLevelExtent(cDstLayers.mipLevel));
+    });
   }
 
 

--- a/src/d3d11/d3d11_context.h
+++ b/src/d3d11/d3d11_context.h
@@ -918,10 +918,26 @@ namespace dxvk {
             UINT                              Slot,
             D3D11UnorderedAccessView*         pUav);
 
+    void ClearImageView(
+            Rc<DxvkImageView>                 View,
+      const FLOAT                             Color[4],
+      const D3D11_RECT*                       pRects,
+            UINT                              NumRects);
+
+    void ClearBufferView(
+            Rc<DxvkBufferView>                View,
+      const FLOAT                             Color[4],
+      const D3D11_RECT*                       pRects,
+            UINT                              NumRects);
+
     VkClearValue ConvertColorValue(
       const FLOAT                             Color[4],
       const DxvkFormatInfo*                   pFormatInfo);
-    
+
+    VkRect2D ConvertRect(
+            D3D11_RECT                        Rect,
+            VkExtent2D                        Extent);
+
     void CopyBuffer(
             D3D11Buffer*                      pDstBuffer,
             VkDeviceSize                      DstOffset,
@@ -1089,6 +1105,12 @@ namespace dxvk {
     void SetDrawBuffers(
             ID3D11Buffer*                     pBufferForArgs,
             ID3D11Buffer*                     pBufferForCount);
+
+    void SyncImage(
+      const Rc<DxvkImage>&                    DstImage,
+      const VkImageSubresourceLayers&         DstLayers,
+      const Rc<DxvkImage>&                    SrcImage,
+      const VkImageSubresourceLayers&         SrcLayers);
 
     bool TestRtvUavHazards(
             UINT                              NumRTVs,

--- a/src/d3d11/d3d11_context_def.cpp
+++ b/src/d3d11/d3d11_context_def.cpp
@@ -8,11 +8,22 @@ namespace dxvk {
     const Rc<DxvkDevice>& Device,
           UINT            ContextFlags)
   : D3D11CommonContext<D3D11DeferredContext>(pParent, Device, ContextFlags, 0u),
-    m_commandList (CreateCommandList()) {
+    m_commandList(CreateCommandList()),
+    m_destructionNotifier(this) {
     ResetContextState();
   }
   
   
+  HRESULT STDMETHODCALLTYPE D3D11DeferredContext::QueryInterface(REFIID riid, void** ppvObject) {
+    if (riid == __uuidof(ID3DDestructionNotifier)) {
+      *ppvObject = ref(&m_destructionNotifier);
+      return S_OK;
+    }
+
+    return D3D11CommonContext<D3D11DeferredContext>::QueryInterface(riid, ppvObject);
+  }
+
+
   HRESULT STDMETHODCALLTYPE D3D11DeferredContext::GetData(
           ID3D11Asynchronous*               pAsync,
           void*                             pData,

--- a/src/d3d11/d3d11_context_def.h
+++ b/src/d3d11/d3d11_context_def.h
@@ -21,6 +21,10 @@ namespace dxvk {
       const Rc<DxvkDevice>& Device,
             UINT            ContextFlags);
     
+    HRESULT STDMETHODCALLTYPE QueryInterface(
+            REFIID                      riid,
+            void**                      ppvObject);
+
     HRESULT STDMETHODCALLTYPE GetData(
             ID3D11Asynchronous*         pAsync,
             void*                       pData,
@@ -89,6 +93,8 @@ namespace dxvk {
 
     // Chunk ID within the current command list
     uint64_t m_chunkId = 0ull;
+
+    D3DDestructionNotifier m_destructionNotifier;
 
     HRESULT MapBuffer(
             ID3D11Resource*               pResource,

--- a/src/d3d11/d3d11_context_imm.h
+++ b/src/d3d11/d3d11_context_imm.h
@@ -131,12 +131,12 @@ namespace dxvk {
     VkDeviceSize            m_discardMemoryCounter = 0u;
     VkDeviceSize            m_discardMemoryOnFlush = 0u;
 
-    bool                    m_hasPendingMsaaResolve = false;
-
     D3D10Multithread        m_multithread;
     D3D11VideoContext       m_videoContext;
 
     Com<D3D11DeviceContextState, false> m_stateObject;
+
+    D3DDestructionNotifier  m_destructionNotifier;
 
     std::string             m_flushReason;
 
@@ -211,6 +211,8 @@ namespace dxvk {
 
     void ThrottleDiscard(
             VkDeviceSize                Size);
+
+    void NotifyRenderPassBoundary();
 
     DxvkStagingBufferStats GetStagingMemoryStatistics();
 

--- a/src/d3d11/d3d11_depth_stencil.cpp
+++ b/src/d3d11/d3d11_depth_stencil.cpp
@@ -8,7 +8,7 @@ namespace dxvk {
     const D3D11_DEPTH_STENCIL_DESC& desc,
           Container*                container)
   : D3D11StateObject<ID3D11DepthStencilState, D3D11DepthStencilState>(device, container),
-    m_desc(desc), m_d3d10(this) {
+    m_desc(desc), m_d3d10(this), m_destructionNotifier(this) {
     m_state.setDepthTest(desc.DepthEnable);
     m_state.setDepthWrite(desc.DepthWriteMask == D3D11_DEPTH_WRITE_MASK_ALL);
     m_state.setStencilTest(desc.StencilEnable);
@@ -43,7 +43,12 @@ namespace dxvk {
       *ppvObject = ref(&m_d3d10);
       return S_OK;
     }
-    
+
+    if (riid == __uuidof(ID3DDestructionNotifier)) {
+      *ppvObject = ref(&m_destructionNotifier);
+      return S_OK;
+    }
+
     if (logQueryInterfaceError(__uuidof(ID3D11DepthStencilState), riid)) {
       Logger::warn("D3D11DepthStencilState::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));

--- a/src/d3d11/d3d11_depth_stencil.h
+++ b/src/d3d11/d3d11_depth_stencil.h
@@ -50,7 +50,9 @@ namespace dxvk {
     D3D11_DEPTH_STENCIL_DESC  m_desc;
     DxvkDepthStencilState     m_state = { };
     D3D10DepthStencilState    m_d3d10;
-    
+
+    D3DDestructionNotifier    m_destructionNotifier;
+
     DxvkStencilOp DecodeStencilOpState(
       const D3D11_DEPTH_STENCILOP_DESC& StencilDesc,
       const D3D11_DEPTH_STENCIL_DESC&   Desc) const;

--- a/src/d3d11/d3d11_device.cpp
+++ b/src/d3d11/d3d11_device.cpp
@@ -3402,7 +3402,8 @@ namespace dxvk {
     m_d3d11Reflex   (this, &m_d3d11Device),
     m_d3d11on12     (this, &m_d3d11Device, pD3D12Device, pD3D12Queue),
     m_metaDevice    (this),
-    m_dxvkFactory   (this, &m_d3d11Device) {
+    m_dxvkFactory   (this, &m_d3d11Device),
+    m_destructionNotifier(this) {
 
   }
   
@@ -3491,13 +3492,18 @@ namespace dxvk {
       return context->QueryInterface(riid, ppvObject);
     }
 
+    if (riid == __uuidof(ID3DDestructionNotifier)) {
+      *ppvObject = ref(&m_destructionNotifier);
+      return S_OK;
+    }
+
     if (riid == __uuidof(ID3D11Debug))
       return E_NOINTERFACE;      
-    
+
     // Undocumented interfaces that are queried by some games
     if (riid == GUID{0xd56e2a4c,0x5127,0x8437,{0x65,0x8a,0x98,0xc5,0xbb,0x78,0x94,0x98}})
       return E_NOINTERFACE;
-    
+
     if (logQueryInterfaceError(__uuidof(IDXGIDXVKDevice), riid)) {
       Logger::warn("D3D11DXGIDevice::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));

--- a/src/d3d11/d3d11_device.h
+++ b/src/d3d11/d3d11_device.h
@@ -990,9 +990,11 @@ namespace dxvk {
     D3D11ReflexDevice   m_d3d11Reflex;
     D3D11on12Device     m_d3d11on12;
     DXGIDXVKDevice      m_metaDevice;
-    
+
     DXGIVkSwapChainFactory   m_dxvkFactory;
-    
+
+    D3DDestructionNotifier   m_destructionNotifier;
+
     uint32_t m_frameLatency = DefaultFrameLatency;
 
   };

--- a/src/d3d11/d3d11_fence.cpp
+++ b/src/d3d11/d3d11_fence.cpp
@@ -9,15 +9,17 @@ namespace dxvk {
           UINT64              InitialValue,
           D3D11_FENCE_FLAG    Flags,
           HANDLE              hFence)
-  : D3D11DeviceChild<ID3D11Fence>(pDevice) {
-    DxvkFenceCreateInfo fenceInfo;
+  : D3D11DeviceChild<ID3D11Fence>(pDevice),
+    m_flags(Flags), m_destructionNotifier(this) {
+    DxvkFenceCreateInfo fenceInfo = { };
     fenceInfo.initialValue = InitialValue;
-    m_flags = Flags;
 
     if (Flags & D3D11_FENCE_FLAG_SHARED) {
       fenceInfo.sharedType = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D11_FENCE_BIT;
-      if (hFence == nullptr)
+
+      if (!hFence)
         hFence = INVALID_HANDLE_VALUE;
+
       fenceInfo.sharedHandle = hFence;
     }
 
@@ -45,6 +47,11 @@ namespace dxvk {
      || riid == __uuidof(ID3D11DeviceChild)
      || riid == __uuidof(ID3D11Fence)) {
       *ppvObject = ref(this);
+      return S_OK;
+    }
+
+    if (riid == __uuidof(ID3DDestructionNotifier)) {
+      *ppvObject = ref(&m_destructionNotifier);
       return S_OK;
     }
 

--- a/src/d3d11/d3d11_fence.h
+++ b/src/d3d11/d3d11_fence.h
@@ -41,8 +41,10 @@ namespace dxvk {
     
   private:
     
-    Rc<DxvkFence> m_fence;
-    D3D11_FENCE_FLAG m_flags;
+    Rc<DxvkFence>           m_fence;
+    D3D11_FENCE_FLAG        m_flags = D3D11_FENCE_FLAG_NONE;
+
+    D3DDestructionNotifier  m_destructionNotifier;
 
   };
   

--- a/src/d3d11/d3d11_input_layout.cpp
+++ b/src/d3d11/d3d11_input_layout.cpp
@@ -12,7 +12,8 @@ namespace dxvk {
   : D3D11DeviceChild<ID3D11InputLayout>(pDevice),
     m_attributeCount  (numAttributes),
     m_bindingCount    (numBindings),
-    m_d3d10           (this) {
+    m_d3d10           (this),
+    m_destructionNotifier(this) {
     for (uint32_t i = 0; i < numAttributes; i++)
       m_inputs[i] = DxvkVertexInput(pAttributes[i]);
 
@@ -45,6 +46,11 @@ namespace dxvk {
       return S_OK;
     }
     
+    if (riid == __uuidof(ID3DDestructionNotifier)) {
+      *ppvObject = ref(&m_destructionNotifier);
+      return S_OK;
+    }
+
     if (logQueryInterfaceError(__uuidof(ID3D11InputLayout), riid)) {
       Logger::warn("D3D11InputLayout::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));

--- a/src/d3d11/d3d11_input_layout.h
+++ b/src/d3d11/d3d11_input_layout.h
@@ -52,6 +52,8 @@ namespace dxvk {
     std::array<DxvkVertexInput, MaxNumVertexAttributes + MaxNumVertexBindings> m_inputs = { };
 
     D3D10InputLayout m_d3d10;
+
+    D3DDestructionNotifier m_destructionNotifier;
     
   };
   

--- a/src/d3d11/d3d11_query.cpp
+++ b/src/d3d11/d3d11_query.cpp
@@ -9,7 +9,8 @@ namespace dxvk {
   : D3D11DeviceChild<ID3D11Query1>(device),
     m_desc(desc),
     m_state(D3D11_VK_QUERY_INITIAL),
-    m_d3d10(this) {
+    m_d3d10(this),
+    m_destructionNotifier(this) {
     Rc<DxvkDevice> dxvkDevice = m_parent->GetDXVKDevice();
 
     switch (m_desc.Query) {
@@ -119,7 +120,12 @@ namespace dxvk {
         return S_OK;
       }
     }
-    
+
+    if (riid == __uuidof(ID3DDestructionNotifier)) {
+      *ppvObject = ref(&m_destructionNotifier);
+      return S_OK;
+    }
+
     if (logQueryInterfaceError(__uuidof(ID3D11Query), riid)) {
       Logger::warn("D3D11Query: Unknown interface query");
       Logger::warn(str::format(riid));

--- a/src/d3d11/d3d11_query.h
+++ b/src/d3d11/d3d11_query.h
@@ -113,6 +113,8 @@ namespace dxvk {
 
     std::atomic<uint32_t> m_resetCtr = { 0u };
 
+    D3DDestructionNotifier m_destructionNotifier;
+
     UINT64 GetTimestampQueryFrequency() const;
     
   };

--- a/src/d3d11/d3d11_rasterizer.cpp
+++ b/src/d3d11/d3d11_rasterizer.cpp
@@ -8,7 +8,7 @@ namespace dxvk {
     const D3D11_RASTERIZER_DESC2&         desc,
           Container*                      container)
   : D3D11StateObject<ID3D11RasterizerState2, D3D11RasterizerState>(device, container),
-    m_desc(desc), m_d3d10(this) {
+    m_desc(desc), m_d3d10(this), m_destructionNotifier(this) {
     // Polygon mode. Determines whether the rasterizer fills
     // a polygon or renders lines connecting the vertices.
     switch (desc.FillMode) {
@@ -82,7 +82,12 @@ namespace dxvk {
       *ppvObject = ref(&m_d3d10);
       return S_OK;
     }
-    
+
+    if (riid == __uuidof(ID3DDestructionNotifier)) {
+      *ppvObject = ref(&m_destructionNotifier);
+      return S_OK;
+    }
+
     if (logQueryInterfaceError(__uuidof(ID3D11RasterizerState), riid)) {
       Logger::warn("D3D11RasterizerState::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));

--- a/src/d3d11/d3d11_rasterizer.h
+++ b/src/d3d11/d3d11_rasterizer.h
@@ -66,7 +66,9 @@ namespace dxvk {
     DxvkRasterizerState    m_state      = { };
     DxvkDepthBias          m_depthBias  = { };
     D3D10RasterizerState   m_d3d10;
-    
+
+    D3DDestructionNotifier m_destructionNotifier;
+
   };
   
 }

--- a/src/d3d11/d3d11_sampler.cpp
+++ b/src/d3d11/d3d11_sampler.cpp
@@ -9,7 +9,7 @@ namespace dxvk {
     const D3D11_SAMPLER_DESC& desc,
           Container*          container)
   : D3D11StateObject<ID3D11SamplerState, D3D11SamplerState>(device, container),
-    m_desc(desc), m_d3d10(this) {
+    m_desc(desc), m_d3d10(this), m_destructionNotifier(this) {
     DxvkSamplerKey info = { };
 
     // While D3D11_FILTER is technically an enum, its value bits
@@ -85,7 +85,12 @@ namespace dxvk {
       *ppvObject = ref(&m_d3d10);
       return S_OK;
     }
-    
+
+    if (riid == __uuidof(ID3DDestructionNotifier)) {
+      *ppvObject = ref(&m_destructionNotifier);
+      return S_OK;
+    }
+
     if (logQueryInterfaceError(__uuidof(ID3D11SamplerState), riid)) {
       Logger::warn("D3D11SamplerState::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));

--- a/src/d3d11/d3d11_sampler.h
+++ b/src/d3d11/d3d11_sampler.h
@@ -52,6 +52,8 @@ namespace dxvk {
 
     std::atomic<uint32_t> m_refCount = { 0u };
 
+    D3DDestructionNotifier m_destructionNotifier;
+
     static bool ValidateAddressMode(
             D3D11_TEXTURE_ADDRESS_MODE  Mode);
 

--- a/src/d3d11/d3d11_shader.h
+++ b/src/d3d11/d3d11_shader.h
@@ -114,7 +114,8 @@ namespace dxvk {
     
     D3D11Shader(D3D11Device* device, const D3D11CommonShader& shader)
     : D3D11DeviceChild<D3D11Interface>(device),
-      m_shader(shader), m_d3d10(this), m_shaderExt(this, &m_shader) { }
+      m_shader(shader), m_d3d10(this), m_shaderExt(this, &m_shader),
+      m_destructionNotifier(this) { }
     
     ~D3D11Shader() { }
     
@@ -140,6 +141,11 @@ namespace dxvk {
         return S_OK;
       }
 
+      if (riid == __uuidof(ID3DDestructionNotifier)) {
+        *ppvObject = ref(&m_destructionNotifier);
+        return S_OK;
+      }
+
       if (logQueryInterfaceError(__uuidof(D3D11Interface), riid)) {
         Logger::warn("D3D11Shader::QueryInterface: Unknown interface query");
         Logger::warn(str::format(riid));
@@ -161,6 +167,8 @@ namespace dxvk {
     D3D11CommonShader m_shader;
     D3D10ShaderClass  m_d3d10;
     D3D11ExtShader    m_shaderExt;
+
+    D3DDestructionNotifier m_destructionNotifier;
     
   };
   

--- a/src/d3d11/d3d11_state_object.cpp
+++ b/src/d3d11/d3d11_state_object.cpp
@@ -4,7 +4,8 @@ namespace dxvk {
 
   D3D11DeviceContextState::D3D11DeviceContextState(
           D3D11Device*         pDevice)
-  : D3D11DeviceChild<ID3DDeviceContextState>(pDevice) {
+  : D3D11DeviceChild<ID3DDeviceContextState>(pDevice),
+    m_destructionNotifier(this) {
 
   }
 
@@ -26,6 +27,11 @@ namespace dxvk {
      || riid == __uuidof(ID3D11DeviceChild)
      || riid == __uuidof(ID3DDeviceContextState)) {
       *ppvObject = ref(this);
+      return S_OK;
+    }
+
+    if (riid == __uuidof(ID3DDestructionNotifier)) {
+      *ppvObject = ref(&m_destructionNotifier);
       return S_OK;
     }
 

--- a/src/d3d11/d3d11_state_object.h
+++ b/src/d3d11/d3d11_state_object.h
@@ -39,6 +39,8 @@ namespace dxvk {
 
     D3D11ContextState m_state;
 
+    D3DDestructionNotifier m_destructionNotifier;
+
   };
 
 }

--- a/src/d3d11/d3d11_texture.cpp
+++ b/src/d3d11/d3d11_texture.cpp
@@ -1211,8 +1211,9 @@ namespace dxvk {
     m_interop (this, &m_texture),
     m_surface (this),
     m_resource(this, pDevice),
-    m_d3d10   (this) {
-    
+    m_d3d10   (this),
+    m_destructionNotifier(this) {
+
   }
   
   
@@ -1265,7 +1266,12 @@ namespace dxvk {
       *ppvObject = ref(&m_interop);
       return S_OK;
     }
-    
+
+    if (riid == __uuidof(ID3DDestructionNotifier)) {
+      *ppvObject = ref(&m_destructionNotifier);
+      return S_OK;
+    }
+
     if (logQueryInterfaceError(__uuidof(ID3D10Texture1D), riid)) {
       Logger::warn("D3D11Texture1D::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));
@@ -1323,7 +1329,8 @@ namespace dxvk {
     m_surface   (this),
     m_resource  (this, pDevice),
     m_d3d10     (this),
-    m_swapChain (nullptr) {
+    m_swapChain (nullptr),
+    m_destructionNotifier(this) {
   }
 
 
@@ -1338,8 +1345,9 @@ namespace dxvk {
     m_surface   (this),
     m_resource  (this, pDevice),
     m_d3d10     (this),
-    m_swapChain (nullptr) {
-    
+    m_swapChain (nullptr),
+    m_destructionNotifier(this) {
+
   }
 
 
@@ -1354,8 +1362,9 @@ namespace dxvk {
     m_surface   (this),
     m_resource  (this, pDevice),
     m_d3d10     (this),
-    m_swapChain (pSwapChain) {
-    
+    m_swapChain (pSwapChain),
+    m_destructionNotifier(this) {
+
   }
   
   
@@ -1434,7 +1443,12 @@ namespace dxvk {
       *ppvObject = ref(&m_interop);
       return S_OK;
     }
-    
+
+    if (riid == __uuidof(ID3DDestructionNotifier)) {
+      *ppvObject = ref(&m_destructionNotifier);
+      return S_OK;
+    }
+
     if (logQueryInterfaceError(__uuidof(ID3D10Texture2D), riid)) {
       Logger::warn("D3D11Texture2D::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));
@@ -1506,8 +1520,9 @@ namespace dxvk {
     m_texture (this, pDevice, pDesc, p11on12Info, D3D11_RESOURCE_DIMENSION_TEXTURE3D, 0, VK_NULL_HANDLE, nullptr),
     m_interop (this, &m_texture),
     m_resource(this, pDevice),
-    m_d3d10   (this) {
-    
+    m_d3d10   (this),
+    m_destructionNotifier(this) {
+
   }
   
   
@@ -1553,7 +1568,12 @@ namespace dxvk {
       *ppvObject = ref(&m_interop);
       return S_OK;
     }
-    
+
+    if (riid == __uuidof(ID3DDestructionNotifier)) {
+      *ppvObject = ref(&m_destructionNotifier);
+      return S_OK;
+    }
+
     if (logQueryInterfaceError(__uuidof(ID3D10Texture3D), riid)) {
       Logger::warn("D3D11Texture3D::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));

--- a/src/d3d11/d3d11_texture.h
+++ b/src/d3d11/d3d11_texture.h
@@ -791,7 +791,9 @@ namespace dxvk {
     D3D11DXGISurface      m_surface;
     D3D11DXGIResource     m_resource;
     D3D10Texture1D        m_d3d10;
-    
+
+    D3DDestructionNotifier m_destructionNotifier;
+
   };
   
   
@@ -859,8 +861,10 @@ namespace dxvk {
     D3D11DXGISurface      m_surface;
     D3D11DXGIResource     m_resource;
     D3D10Texture2D        m_d3d10;
-    IUnknown*             m_swapChain;
-    
+    IUnknown*             m_swapChain = nullptr;
+
+    D3DDestructionNotifier m_destructionNotifier;
+
   };
   
   
@@ -910,7 +914,9 @@ namespace dxvk {
     D3D11VkInteropSurface m_interop;
     D3D11DXGIResource     m_resource;
     D3D10Texture3D        m_d3d10;
-    
+
+    D3DDestructionNotifier m_destructionNotifier;
+
   };
   
   

--- a/src/d3d11/d3d11_video.cpp
+++ b/src/d3d11/d3d11_video.cpp
@@ -188,45 +188,68 @@ namespace dxvk {
 
 
 
-  D3D11VideoProcessorInputView::D3D11VideoProcessorInputView(
+  D3D11VideoProcessorView::D3D11VideoProcessorView(
           D3D11Device*            pDevice,
           ID3D11Resource*         pResource,
-    const D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC& Desc)
-  : D3D11DeviceChild<ID3D11VideoProcessorInputView>(pDevice),
-    m_resource(pResource), m_desc(Desc),
-    m_destructionNotifier(this) {
+          DxvkImageViewKey        viewInfo)
+  : m_resource(pResource), m_image(GetCommonTexture(pResource)->GetImage()) {
     D3D11_COMMON_RESOURCE_DESC resourceDesc = { };
     GetCommonResourceDesc(pResource, &resourceDesc);
-
-    Rc<DxvkImage> dxvkImage = GetCommonTexture(pResource)->GetImage();
 
     DXGI_VK_FORMAT_INFO formatInfo = pDevice->LookupFormat(resourceDesc.Format, DXGI_VK_FORMAT_MODE_COLOR);
     DXGI_VK_FORMAT_FAMILY formatFamily = pDevice->LookupFamily(resourceDesc.Format, DXGI_VK_FORMAT_MODE_COLOR);
 
     VkImageAspectFlags aspectMask = lookupFormatInfo(formatInfo.Format)->aspectMask;
 
-    DxvkImageViewKey viewInfo;
     viewInfo.format = formatInfo.Format;
-    viewInfo.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
     viewInfo.packedSwizzle = DxvkImageViewKey::packSwizzle(formatInfo.Swizzle);
+    viewInfo.aspects = aspectMask;
 
-    switch (m_desc.ViewDimension) {
-      case D3D11_VPIV_DIMENSION_TEXTURE2D:
-        viewInfo.viewType   = VK_IMAGE_VIEW_TYPE_2D;
-        viewInfo.mipIndex   = m_desc.Texture2D.MipSlice;
-        viewInfo.mipCount   = 1;
-        viewInfo.layerIndex = m_desc.Texture2D.ArraySlice;
-        viewInfo.layerCount = 1;
-        break;
+    m_layers.aspectMask = aspectMask;
+    m_layers.baseArrayLayer = viewInfo.layerIndex;
+    m_layers.layerCount = viewInfo.layerCount;
+    m_layers.mipLevel = viewInfo.mipIndex;
 
-      case D3D11_VPIV_DIMENSION_UNKNOWN:
-        throw DxvkError("Invalid view dimension");
+    // Create shadow image if we know that the base image is incompatible
+    // with the required usage flags and cannot be relocated.
+    if (m_image->info().shared && (m_image->info().usage & viewInfo.usage) != viewInfo.usage) {
+      DxvkImageCreateInfo imageInfo = { };
+      imageInfo.type = m_image->info().type;
+      imageInfo.format = viewInfo.format;
+      imageInfo.sampleCount = m_image->info().sampleCount;
+      imageInfo.extent = m_image->mipLevelExtent(viewInfo.mipIndex);
+      imageInfo.numLayers = viewInfo.layerCount;
+      imageInfo.mipLevels = viewInfo.mipCount;
+      imageInfo.usage = viewInfo.usage | VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+      imageInfo.stages = VK_PIPELINE_STAGE_TRANSFER_BIT;
+      imageInfo.access = VK_ACCESS_TRANSFER_READ_BIT | VK_ACCESS_TRANSFER_WRITE_BIT;
+      imageInfo.layout = VK_IMAGE_LAYOUT_GENERAL;
+      imageInfo.debugName = "Video shadow image";
+
+      if (viewInfo.usage & VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT) {
+        imageInfo.stages |= VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+        imageInfo.access |= VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT | VK_ACCESS_COLOR_ATTACHMENT_READ_BIT;
+        imageInfo.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+      }
+
+      if (viewInfo.usage & VK_IMAGE_USAGE_SAMPLED_BIT) {
+        imageInfo.stages |= VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+        imageInfo.access |= VK_ACCESS_SHADER_READ_BIT;
+
+        if (imageInfo.layout != VK_IMAGE_LAYOUT_GENERAL)
+          imageInfo.layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+      }
+
+      if (viewInfo.aspects != VK_IMAGE_ASPECT_COLOR_BIT) {
+        imageInfo.flags |= VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT
+                        |  VK_IMAGE_CREATE_EXTENDED_USAGE_BIT;
+      }
+
+      m_shadow = pDevice->GetDXVKDevice()->createImage(imageInfo, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+
+      viewInfo.layerIndex = 0u;
+      viewInfo.mipIndex = 0u;
     }
-
-    m_subresources.aspectMask = aspectMask;
-    m_subresources.baseArrayLayer = viewInfo.layerIndex;
-    m_subresources.layerCount = viewInfo.layerCount;
-    m_subresources.mipLevel = viewInfo.mipIndex;
 
     for (uint32_t i = 0; aspectMask && i < m_views.size(); i++) {
       viewInfo.aspects = vk::getNextAspect(aspectMask);
@@ -234,19 +257,19 @@ namespace dxvk {
       if (viewInfo.aspects != VK_IMAGE_ASPECT_COLOR_BIT)
         viewInfo.format = formatFamily.Formats[i];
 
-      m_views[i] = dxvkImage->createView(viewInfo);
+      m_views[i] = (m_shadow ? m_shadow : m_image)->createView(viewInfo);
     }
 
     m_isYCbCr = IsYCbCrFormat(resourceDesc.Format);
   }
 
 
-  D3D11VideoProcessorInputView::~D3D11VideoProcessorInputView() {
+  D3D11VideoProcessorView::~D3D11VideoProcessorView() {
 
   }
 
 
-  bool D3D11VideoProcessorInputView::IsYCbCrFormat(DXGI_FORMAT Format) {
+  bool D3D11VideoProcessorView::IsYCbCrFormat(DXGI_FORMAT Format) {
     static const std::array<DXGI_FORMAT, 3> s_formats = {{
       DXGI_FORMAT_NV12,
       DXGI_FORMAT_YUY2,
@@ -254,6 +277,24 @@ namespace dxvk {
     }};
 
     return std::find(s_formats.begin(), s_formats.end(), Format) != s_formats.end();
+  }
+
+
+
+
+  D3D11VideoProcessorInputView::D3D11VideoProcessorInputView(
+          D3D11Device*            pDevice,
+          ID3D11Resource*         pResource,
+    const D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC& Desc)
+  : D3D11DeviceChild<ID3D11VideoProcessorInputView>(pDevice),
+    m_common(pDevice, pResource, CreateViewInfo(Desc)),
+    m_desc(Desc), m_destructionNotifier(this) {
+
+  }
+
+
+  D3D11VideoProcessorInputView::~D3D11VideoProcessorInputView() {
+
   }
 
 
@@ -284,7 +325,7 @@ namespace dxvk {
 
   void STDMETHODCALLTYPE D3D11VideoProcessorInputView::GetResource(
           ID3D11Resource**        ppResource) {
-    *ppResource = m_resource.ref();
+    *ppResource = m_common.GetResource();
   }
 
 
@@ -294,47 +335,36 @@ namespace dxvk {
   }
 
 
+  DxvkImageViewKey D3D11VideoProcessorInputView::CreateViewInfo(
+    const D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC& Desc) {
+    DxvkImageViewKey viewInfo = { };
+    viewInfo.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
+
+    switch (Desc.ViewDimension) {
+      case D3D11_VPIV_DIMENSION_TEXTURE2D:
+        viewInfo.viewType   = VK_IMAGE_VIEW_TYPE_2D;
+        viewInfo.mipIndex   = Desc.Texture2D.MipSlice;
+        viewInfo.mipCount   = 1;
+        viewInfo.layerIndex = Desc.Texture2D.ArraySlice;
+        viewInfo.layerCount = 1;
+        break;
+
+      case D3D11_VPIV_DIMENSION_UNKNOWN:
+        throw DxvkError("Invalid view dimension");
+    }
+
+    return viewInfo;
+  }
+
 
   D3D11VideoProcessorOutputView::D3D11VideoProcessorOutputView(
           D3D11Device*            pDevice,
           ID3D11Resource*         pResource,
     const D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC& Desc)
   : D3D11DeviceChild<ID3D11VideoProcessorOutputView>(pDevice),
-    m_resource(pResource), m_desc(Desc), m_destructionNotifier(this) {
-    D3D11_COMMON_RESOURCE_DESC resourceDesc = { };
-    GetCommonResourceDesc(pResource, &resourceDesc);
+    m_common(pDevice, pResource, CreateViewInfo(Desc)),
+    m_desc(Desc), m_destructionNotifier(this) {
 
-    DXGI_VK_FORMAT_INFO formatInfo = pDevice->LookupFormat(
-      resourceDesc.Format, DXGI_VK_FORMAT_MODE_COLOR);
-
-    DxvkImageViewKey viewInfo;
-    viewInfo.format = formatInfo.Format;
-    viewInfo.aspects = lookupFormatInfo(viewInfo.format)->aspectMask;
-    viewInfo.packedSwizzle = DxvkImageViewKey::packSwizzle(formatInfo.Swizzle);
-    viewInfo.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
-
-    switch (m_desc.ViewDimension) {
-      case D3D11_VPOV_DIMENSION_TEXTURE2D:
-        viewInfo.viewType   = VK_IMAGE_VIEW_TYPE_2D;
-        viewInfo.mipIndex   = m_desc.Texture2D.MipSlice;
-        viewInfo.mipCount   = 1;
-        viewInfo.layerIndex = 0;
-        viewInfo.layerCount = 1;
-        break;
-
-      case D3D11_VPOV_DIMENSION_TEXTURE2DARRAY:
-        viewInfo.viewType   = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
-        viewInfo.mipIndex   = m_desc.Texture2DArray.MipSlice;
-        viewInfo.mipCount   = 1;
-        viewInfo.layerIndex = m_desc.Texture2DArray.FirstArraySlice;
-        viewInfo.layerCount = m_desc.Texture2DArray.ArraySize;
-        break;
-
-      case D3D11_VPOV_DIMENSION_UNKNOWN:
-        throw DxvkError("Invalid view dimension");
-    }
-
-    m_view = GetCommonTexture(pResource)->GetImage()->createView(viewInfo);
   }
 
 
@@ -370,7 +400,7 @@ namespace dxvk {
 
   void STDMETHODCALLTYPE D3D11VideoProcessorOutputView::GetResource(
           ID3D11Resource**        ppResource) {
-    *ppResource = m_resource.ref();
+    *ppResource = m_common.GetResource();
   }
 
 
@@ -378,6 +408,37 @@ namespace dxvk {
           D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC* pDesc) {
     *pDesc = m_desc;
   }
+
+
+  DxvkImageViewKey D3D11VideoProcessorOutputView::CreateViewInfo(
+    const D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC& Desc) {
+    DxvkImageViewKey viewInfo = { };
+    viewInfo.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+
+    switch (Desc.ViewDimension) {
+      case D3D11_VPOV_DIMENSION_TEXTURE2D:
+        viewInfo.viewType   = VK_IMAGE_VIEW_TYPE_2D;
+        viewInfo.mipIndex   = Desc.Texture2D.MipSlice;
+        viewInfo.mipCount   = 1;
+        viewInfo.layerIndex = 0;
+        viewInfo.layerCount = 1;
+        break;
+
+      case D3D11_VPOV_DIMENSION_TEXTURE2DARRAY:
+        viewInfo.viewType   = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
+        viewInfo.mipIndex   = Desc.Texture2DArray.MipSlice;
+        viewInfo.mipCount   = 1;
+        viewInfo.layerIndex = Desc.Texture2DArray.FirstArraySlice;
+        viewInfo.layerCount = Desc.Texture2DArray.ArraySize;
+        break;
+
+      case D3D11_VPOV_DIMENSION_UNKNOWN:
+        throw DxvkError("Invalid view dimension");
+    }
+
+    return viewInfo;
+  }
+
 
 
 
@@ -1145,28 +1206,56 @@ namespace dxvk {
     });
 
     auto videoProcessor = static_cast<D3D11VideoProcessor*>(pVideoProcessor);
+
+    auto& outputView = static_cast<D3D11VideoProcessorOutputView*>(pOutputView)->GetCommon();
+    auto views = outputView.GetViews();
+
     bool hasStreamsEnabled = false;
 
-    // Resetting and restoring all context state incurs
-    // a lot of overhead, so only do it as necessary
-    for (uint32_t i = 0; i < StreamCount; i++) {
-      auto streamState = videoProcessor->GetStreamState(i);
+    m_dstIsYCbCr = outputView.IsYCbCr();
 
-      if (!pStreams[i].Enable || !streamState)
+    for (uint32_t vi = 0; vi < views.size(); vi++) {
+      if (!views[vi])
         continue;
 
-      if (!hasStreamsEnabled) {
-        m_ctx->ResetDirtyTracking();
-        m_ctx->ResetCommandListState();
+      bool outputBound = false;
 
-        BindOutputView(pOutputView);
-        hasStreamsEnabled = true;
+      // Resetting and restoring all context state incurs
+      // a lot of overhead, so only do it as necessary
+      for (uint32_t i = 0; i < StreamCount; i++) {
+        auto streamState = videoProcessor->GetStreamState(i);
+
+        if (!pStreams[i].Enable || !streamState)
+          continue;
+
+        if (!hasStreamsEnabled) {
+          m_ctx->ResetDirtyTracking();
+          m_ctx->ResetCommandListState();
+
+          CopyBaseImageToShadow(outputView);
+
+          hasStreamsEnabled = true;
+        }
+
+        if (!outputBound) {
+          BindOutputView(views[vi], views[0]);
+          outputBound = true;
+        }
+
+        if (!views[1])
+          m_exportMode = ExportRGBA;
+        else if (!vi)
+          m_exportMode = ExportY;
+        else
+          m_exportMode = ExportCbCr;
+
+        BlitStream(streamState, &pStreams[i]);
       }
-
-      BlitStream(streamState, &pStreams[i]);
     }
 
     if (hasStreamsEnabled) {
+      CopyShadowToBaseImage(outputView);
+
       UnbindResources();
 
       m_ctx->RestoreCommandListState();
@@ -1306,10 +1395,18 @@ namespace dxvk {
 
 
   void D3D11VideoContext::BindOutputView(
-          ID3D11VideoProcessorOutputView* pOutputView) {
-    auto dxvkView = static_cast<D3D11VideoProcessorOutputView*>(pOutputView)->GetView();
+          Rc<DxvkImageView>               View,
+          Rc<DxvkImageView>               FirstView) {
+    VkExtent3D viewExtent = View->mipLevelExtent(0);
+    m_dstExtent = { viewExtent.width, viewExtent.height };
 
-    m_ctx->EmitCs([this, cView = dxvkView] (DxvkContext* ctx) {
+    VkExtent3D firstExtent = FirstView->mipLevelExtent(0);
+    m_dstSizeFact[0] = (float) viewExtent.width  / (float) firstExtent.width;
+    m_dstSizeFact[1] = (float) viewExtent.height / (float) firstExtent.height;
+
+    m_ctx->EmitCs([
+      cView   = std::move(View)
+    ] (DxvkContext* ctx) {
       DxvkImageUsageInfo usage = { };
       usage.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
       usage.stages = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
@@ -1319,16 +1416,13 @@ namespace dxvk {
 
       DxvkRenderTargets rt;
       rt.color[0].view = cView;
-      rt.color[0].layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+      rt.color[0].layout = cView->pickLayout(VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
 
       ctx->bindRenderTargets(std::move(rt), 0u);
 
       DxvkInputAssemblyState iaState(VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST, false);
       ctx->setInputAssemblyState(iaState);
     });
-
-    VkExtent3D viewExtent = dxvkView->mipLevelExtent(0);
-    m_dstExtent = { viewExtent.width, viewExtent.height };
   }
 
 
@@ -1346,14 +1440,20 @@ namespace dxvk {
     if (pStream->InputFrameOrField)
       Logger::err("D3D11VideoContext: Ignoring non-zero InputFrameOrField");
 
-    auto view = static_cast<D3D11VideoProcessorInputView*>(pStream->pInputSurface);
+    auto& view = static_cast<D3D11VideoProcessorInputView*>(pStream->pInputSurface)->GetCommon();
+
+    CopyBaseImageToShadow(view);
 
     m_ctx->EmitCs([this,
       cStreamState  = *pStreamState,
-      cImage        = view->GetImage(),
-      cViews        = view->GetViews(),
-      cIsYCbCr      = view->IsYCbCr(),
-      cDstExtent    = m_dstExtent
+      cImage        = view.GetImage(),
+      cViews        = view.GetViews(),
+      cSrcIsYCbCr   = view.IsYCbCr(),
+      cDstIsYCbCr   = m_dstIsYCbCr,
+      cDstExtent    = m_dstExtent,
+      cDstSizeFactX = m_dstSizeFact[0],
+      cDstSizeFactY = m_dstSizeFact[1],
+      cExportMode   = m_exportMode
     ] (DxvkContext* ctx) {
       DxvkImageUsageInfo usage = { };
       usage.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
@@ -1375,10 +1475,10 @@ namespace dxvk {
       scissor.extent = cDstExtent;
 
       if (cStreamState.dstRectEnabled) {
-        viewport.x      = float(cStreamState.dstRect.left);
-        viewport.y      = float(cStreamState.dstRect.top);
-        viewport.width  = float(cStreamState.dstRect.right) - viewport.x;
-        viewport.height = float(cStreamState.dstRect.bottom) - viewport.y;
+        viewport.x      = cDstSizeFactX * float(cStreamState.dstRect.left);
+        viewport.y      = cDstSizeFactY * float(cStreamState.dstRect.top);
+        viewport.width  = cDstSizeFactX * float(cStreamState.dstRect.right) - viewport.x;
+        viewport.height = cDstSizeFactY * float(cStreamState.dstRect.bottom) - viewport.y;
       }
 
       VkExtent3D viewExtent = cViews[0]->mipLevelExtent(0);
@@ -1406,8 +1506,9 @@ namespace dxvk {
       uboData.yMin = 0.0f;
       uboData.yMax = 1.0f;
       uboData.isPlanar = cViews[1] != nullptr;
+      uboData.exportMode = cExportMode;
 
-      if (cIsYCbCr)
+      if (cSrcIsYCbCr && !cDstIsYCbCr)
         ApplyYCbCrMatrix(uboData.colorMatrix, cStreamState.colorSpace.YCbCr_Matrix);
 
       if (cStreamState.colorSpace.Nominal_Range) {
@@ -1440,6 +1541,40 @@ namespace dxvk {
       for (uint32_t i = 0; i < cViews.size(); i++)
         ctx->bindResourceImageView(VK_SHADER_STAGE_FRAGMENT_BIT, 1 + i, nullptr);
     });
+  }
+
+
+  void D3D11VideoContext::CopyBaseImageToShadow(
+    const D3D11VideoProcessorView&        View) {
+    auto shadow = View.GetShadow();
+
+    if (!shadow)
+      return;
+
+    VkImageSubresourceLayers imageLayers = View.GetImageSubresource();
+
+    VkImageSubresourceLayers shadowLayers = { };
+    shadowLayers.aspectMask = imageLayers.aspectMask;
+    shadowLayers.layerCount = imageLayers.layerCount;
+
+    m_ctx->SyncImage(shadow, shadowLayers, View.GetImage(), imageLayers);
+  }
+
+
+  void D3D11VideoContext::CopyShadowToBaseImage(
+    const D3D11VideoProcessorView&        View) {
+    auto shadow = View.GetShadow();
+
+    if (!shadow)
+      return;
+
+    VkImageSubresourceLayers imageLayers = View.GetImageSubresource();
+
+    VkImageSubresourceLayers shadowLayers = { };
+    shadowLayers.aspectMask = imageLayers.aspectMask;
+    shadowLayers.layerCount = imageLayers.layerCount;
+
+    m_ctx->SyncImage(View.GetImage(), imageLayers, shadow, shadowLayers);
   }
 
 

--- a/src/d3d11/d3d11_video.cpp
+++ b/src/d3d11/d3d11_video.cpp
@@ -12,7 +12,7 @@ namespace dxvk {
           D3D11Device*            pDevice,
     const D3D11_VIDEO_PROCESSOR_CONTENT_DESC& Desc)
   : D3D11DeviceChild<ID3D11VideoProcessorEnumerator>(pDevice),
-    m_desc(Desc) {
+    m_desc(Desc), m_destructionNotifier(this) {
 
   }
 
@@ -29,6 +29,11 @@ namespace dxvk {
      || riid == __uuidof(ID3D11DeviceChild)
      || riid == __uuidof(ID3D11VideoProcessorEnumerator)) {
       *ppvObject = ref(this);
+      return S_OK;
+    }
+
+    if (riid == __uuidof(ID3DDestructionNotifier)) {
+      *ppvObject = ref(&m_destructionNotifier);
       return S_OK;
     }
 
@@ -134,7 +139,8 @@ namespace dxvk {
           D3D11VideoProcessorEnumerator*  pEnumerator,
           UINT                            RateConversionIndex)
   : D3D11DeviceChild<ID3D11VideoProcessor>(pDevice),
-    m_enumerator(pEnumerator), m_rateConversionIndex(RateConversionIndex) {
+    m_enumerator(pEnumerator), m_rateConversionIndex(RateConversionIndex),
+    m_destructionNotifier(this) {
 
   }
 
@@ -151,6 +157,11 @@ namespace dxvk {
      || riid == __uuidof(ID3D11DeviceChild)
      || riid == __uuidof(ID3D11VideoProcessor)) {
       *ppvObject = ref(this);
+      return S_OK;
+    }
+
+    if (riid == __uuidof(ID3DDestructionNotifier)) {
+      *ppvObject = ref(&m_destructionNotifier);
       return S_OK;
     }
 
@@ -182,7 +193,8 @@ namespace dxvk {
           ID3D11Resource*         pResource,
     const D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC& Desc)
   : D3D11DeviceChild<ID3D11VideoProcessorInputView>(pDevice),
-    m_resource(pResource), m_desc(Desc) {
+    m_resource(pResource), m_desc(Desc),
+    m_destructionNotifier(this) {
     D3D11_COMMON_RESOURCE_DESC resourceDesc = { };
     GetCommonResourceDesc(pResource, &resourceDesc);
 
@@ -256,6 +268,11 @@ namespace dxvk {
       return S_OK;
     }
 
+    if (riid == __uuidof(ID3DDestructionNotifier)) {
+      *ppvObject = ref(&m_destructionNotifier);
+      return S_OK;
+    }
+
     if (logQueryInterfaceError(__uuidof(ID3D11VideoProcessorInputView), riid)) {
       Logger::warn("D3D11VideoProcessorInputView::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));
@@ -283,7 +300,7 @@ namespace dxvk {
           ID3D11Resource*         pResource,
     const D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC& Desc)
   : D3D11DeviceChild<ID3D11VideoProcessorOutputView>(pDevice),
-    m_resource(pResource), m_desc(Desc) {
+    m_resource(pResource), m_desc(Desc), m_destructionNotifier(this) {
     D3D11_COMMON_RESOURCE_DESC resourceDesc = { };
     GetCommonResourceDesc(pResource, &resourceDesc);
 
@@ -334,6 +351,11 @@ namespace dxvk {
      || riid == __uuidof(ID3D11View)
      || riid == __uuidof(ID3D11VideoProcessorOutputView)) {
       *ppvObject = ref(this);
+      return S_OK;
+    }
+
+    if (riid == __uuidof(ID3DDestructionNotifier)) {
+      *ppvObject = ref(&m_destructionNotifier);
       return S_OK;
     }
 

--- a/src/d3d11/d3d11_video.h
+++ b/src/d3d11/d3d11_video.h
@@ -116,6 +116,90 @@ namespace dxvk {
   };
 
 
+  /**
+   * \brief Common video processor view
+   */
+  class D3D11VideoProcessorView {
+
+  public:
+
+    D3D11VideoProcessorView(
+            D3D11Device*            pDevice,
+            ID3D11Resource*         pResource,
+            DxvkImageViewKey        viewInfo);
+
+    ~D3D11VideoProcessorView();
+
+    bool IsYCbCr() const {
+      return m_isYCbCr;
+    }
+
+    /**
+     * \brief Queries base image
+     *
+     * Returns the base image for whihc
+     */
+    Rc<DxvkImage> GetImage() const {
+      return m_image;
+    }
+
+    /**
+     * \brief Queries shadow image
+     *
+     * In some cases, a dedicated image is required in order to support
+     * the image usage flags. This must be kept in sync with the base
+     * image whenever the view is used for video input or output.
+     * \returns Shadow image
+     */
+    Rc<DxvkImage> GetShadow() const {
+      return m_shadow;
+    }
+
+    /**
+     * \brief Queries base image subresources
+     *
+     * Useful in case a shadow image is requried.
+     * \returns Base image subresource layers
+     */
+    VkImageSubresourceLayers GetImageSubresource() const {
+      return m_layers;
+    }
+
+    /**
+     * \brief Retrieves image views
+     *
+     * For planar formats, this will contain one view per plane.
+     * \returns Array of views
+     */
+    std::array<Rc<DxvkImageView>, 2> GetViews() const {
+      return m_views;
+    }
+
+    /**
+     * \brief Queries underlying D3D11 resource
+     * \returns D3D11 resource pointer
+     */
+    ID3D11Resource* GetResource() {
+      return m_resource.ref();
+    }
+
+  private:
+
+    Com<ID3D11Resource>                   m_resource;
+
+    Rc<DxvkImage>                         m_image;
+    Rc<DxvkImage>                         m_shadow;
+
+    VkImageSubresourceLayers              m_layers = { };
+
+    std::array<Rc<DxvkImageView>, 2>      m_views;
+    bool                                  m_isYCbCr = false;
+
+    static bool IsYCbCrFormat(DXGI_FORMAT Format);
+
+  };
+
+
 
   class D3D11VideoProcessorInputView : public D3D11DeviceChild<ID3D11VideoProcessorInputView> {
 
@@ -138,34 +222,18 @@ namespace dxvk {
     void STDMETHODCALLTYPE GetDesc(
             D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC* pDesc);
 
-    bool IsYCbCr() const {
-      return m_isYCbCr;
-    }
-
-    Rc<DxvkImage> GetImage() const {
-      return GetCommonTexture(m_resource.ptr())->GetImage();
-    }
-
-    VkImageSubresourceLayers GetImageSubresources() const {
-      return m_subresources;
-    }
-
-    std::array<Rc<DxvkImageView>, 2> GetViews() const {
-      return m_views;
+    const D3D11VideoProcessorView& GetCommon() const {
+      return m_common;
     }
 
   private:
 
-    Com<ID3D11Resource>                   m_resource;
+    D3D11VideoProcessorView               m_common;
     D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC m_desc;
-    VkImageSubresourceLayers              m_subresources;
-    std::array<Rc<DxvkImageView>, 2>      m_views;
-    bool                                  m_isYCbCr = false;
 
     D3DDestructionNotifier                m_destructionNotifier;
 
-    static bool IsYCbCrFormat(DXGI_FORMAT Format);
-
+    static DxvkImageViewKey CreateViewInfo(const D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC& Desc);
   };
 
 
@@ -191,18 +259,18 @@ namespace dxvk {
     void STDMETHODCALLTYPE GetDesc(
             D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC* pDesc);
 
-    Rc<DxvkImageView> GetView() const {
-      return m_view;
+    const D3D11VideoProcessorView& GetCommon() const {
+      return m_common;
     }
 
   private:
 
-    Com<ID3D11Resource>                     m_resource;
+    D3D11VideoProcessorView                 m_common;
     D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC  m_desc;
-    Rc<DxvkImageView>                       m_view;
 
     D3DDestructionNotifier                  m_destructionNotifier;
 
+    static DxvkImageViewKey CreateViewInfo(const D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC& Desc);
   };
 
 
@@ -580,12 +648,19 @@ namespace dxvk {
 
   private:
 
+    enum ExportMode : uint32_t {
+      ExportRGBA = 0,
+      ExportY    = 1,
+      ExportCbCr = 2,
+    };
+
     struct alignas(16) UboData {
       float colorMatrix[3][4];
       float coordMatrix[3][2];
       VkRect2D srcRect;
       float yMin, yMax;
       VkBool32 isPlanar;
+      ExportMode exportMode;
     };
 
     D3D11ImmediateContext*  m_ctx;
@@ -595,7 +670,10 @@ namespace dxvk {
     Rc<DxvkShader>          m_fs;
     Rc<DxvkBuffer>          m_ubo;
 
-    VkExtent2D m_dstExtent = { 0u, 0u };
+    VkExtent2D m_dstExtent      = { 0u, 0u };
+    float      m_dstSizeFact[2] = { 1.0f, 1.0f };
+    bool       m_dstIsYCbCr     = false;
+    ExportMode m_exportMode     = ExportRGBA;
 
     bool m_resourcesCreated = false;
 
@@ -604,11 +682,18 @@ namespace dxvk {
     void ApplyYCbCrMatrix(float pColorMatrix[3][4], bool UseBt709);
 
     void BindOutputView(
-            ID3D11VideoProcessorOutputView* pOutputView);
+            Rc<DxvkImageView>               View,
+            Rc<DxvkImageView>               FirstView);
 
     void BlitStream(
       const D3D11VideoProcessorStreamState* pStreamState,
       const D3D11_VIDEO_PROCESSOR_STREAM*   pStream);
+
+    void CopyBaseImageToShadow(
+      const D3D11VideoProcessorView&        View);
+
+    void CopyShadowToBaseImage(
+      const D3D11VideoProcessorView&        View);
 
     void CreateUniformBuffer();
 

--- a/src/d3d11/d3d11_video.h
+++ b/src/d3d11/d3d11_video.h
@@ -47,6 +47,8 @@ namespace dxvk {
 
     D3D11_VIDEO_PROCESSOR_CONTENT_DESC  m_desc;
 
+    D3DDestructionNotifier              m_destructionNotifier;
+
   };
 
 
@@ -109,6 +111,8 @@ namespace dxvk {
     D3D11VideoProcessorState       m_state;
     D3D11VideoProcessorStreamState m_streams[D3D11_VK_VIDEO_STREAM_COUNT];
 
+    D3DDestructionNotifier         m_destructionNotifier;
+
   };
 
 
@@ -158,6 +162,8 @@ namespace dxvk {
     std::array<Rc<DxvkImageView>, 2>      m_views;
     bool                                  m_isYCbCr = false;
 
+    D3DDestructionNotifier                m_destructionNotifier;
+
     static bool IsYCbCrFormat(DXGI_FORMAT Format);
 
   };
@@ -194,6 +200,8 @@ namespace dxvk {
     Com<ID3D11Resource>                     m_resource;
     D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC  m_desc;
     Rc<DxvkImageView>                       m_view;
+
+    D3DDestructionNotifier                  m_destructionNotifier;
 
   };
 

--- a/src/d3d11/d3d11_view_dsv.h
+++ b/src/d3d11/d3d11_view_dsv.h
@@ -96,7 +96,9 @@ namespace dxvk {
     D3D11_VK_VIEW_INFO                m_info;
     Rc<DxvkImageView>                 m_view;
     D3D10DepthStencilView             m_d3d10;
-    
+
+    D3DDestructionNotifier            m_destructionNotifier;
+
   };
   
 }

--- a/src/d3d11/d3d11_view_rtv.cpp
+++ b/src/d3d11/d3d11_view_rtv.cpp
@@ -11,7 +11,8 @@ namespace dxvk {
           ID3D11Resource*                   pResource,
     const D3D11_RENDER_TARGET_VIEW_DESC1*   pDesc)
   : D3D11DeviceChild<ID3D11RenderTargetView1>(pDevice),
-    m_resource(pResource), m_desc(*pDesc), m_d3d10(this) {
+    m_resource(pResource), m_desc(*pDesc), m_d3d10(this),
+    m_destructionNotifier(this) {
     ResourceAddRefPrivate(m_resource);
 
     auto texture = GetCommonTexture(pResource);
@@ -117,6 +118,8 @@ namespace dxvk {
   
   
   D3D11RenderTargetView::~D3D11RenderTargetView() {
+    m_destructionNotifier.Notify();
+
     ResourceReleasePrivate(m_resource);
     m_resource = nullptr;
 
@@ -145,7 +148,12 @@ namespace dxvk {
       *ppvObject = ref(&m_d3d10);
       return S_OK;
     }
-    
+
+    if (riid == __uuidof(ID3DDestructionNotifier)) {
+      *ppvObject = ref(&m_destructionNotifier);
+      return S_OK;
+    }
+
     if (logQueryInterfaceError(__uuidof(ID3D11RenderTargetView), riid)) {
       Logger::warn("D3D11RenderTargetView::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));

--- a/src/d3d11/d3d11_view_rtv.h
+++ b/src/d3d11/d3d11_view_rtv.h
@@ -85,7 +85,9 @@ namespace dxvk {
     D3D11_VK_VIEW_INFO                m_info;
     Rc<DxvkImageView>                 m_view;
     D3D10RenderTargetView             m_d3d10;
-    
+
+    D3DDestructionNotifier            m_destructionNotifier;
+
   };
   
 }

--- a/src/d3d11/d3d11_view_srv.cpp
+++ b/src/d3d11/d3d11_view_srv.cpp
@@ -11,7 +11,8 @@ namespace dxvk {
           ID3D11Resource*                   pResource,
     const D3D11_SHADER_RESOURCE_VIEW_DESC1* pDesc)
   : D3D11DeviceChild<ID3D11ShaderResourceView1>(pDevice),
-    m_resource(pResource), m_desc(*pDesc), m_d3d10(this) {
+    m_resource(pResource), m_desc(*pDesc), m_d3d10(this),
+    m_destructionNotifier(this) {
     ResourceAddRefPrivate(m_resource);
 
     D3D11_COMMON_RESOURCE_DESC resourceDesc;
@@ -182,6 +183,8 @@ namespace dxvk {
   
   
   D3D11ShaderResourceView::~D3D11ShaderResourceView() {
+    m_destructionNotifier.Notify();
+
     ResourceReleasePrivate(m_resource);
     m_resource = nullptr;
 
@@ -212,7 +215,12 @@ namespace dxvk {
       *ppvObject = ref(&m_d3d10);
       return S_OK;
     }
-    
+
+    if (riid == __uuidof(ID3DDestructionNotifier)) {
+      *ppvObject = ref(&m_destructionNotifier);
+      return S_OK;
+    }
+
     if (logQueryInterfaceError(__uuidof(ID3D11ShaderResourceView), riid)) {
       Logger::warn("D3D11ShaderResourceView::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));

--- a/src/d3d11/d3d11_view_srv.h
+++ b/src/d3d11/d3d11_view_srv.h
@@ -89,6 +89,8 @@ namespace dxvk {
     Rc<DxvkImageView>                 m_imageView;
     D3D10ShaderResourceView           m_d3d10;
 
+    D3DDestructionNotifier            m_destructionNotifier;
+
   };
   
 }

--- a/src/d3d11/d3d11_view_uav.cpp
+++ b/src/d3d11/d3d11_view_uav.cpp
@@ -11,7 +11,8 @@ namespace dxvk {
           ID3D11Resource*                    pResource,
     const D3D11_UNORDERED_ACCESS_VIEW_DESC1* pDesc)
   : D3D11DeviceChild<ID3D11UnorderedAccessView1>(pDevice),
-    m_resource(pResource), m_desc(*pDesc) {
+    m_resource(pResource), m_desc(*pDesc),
+    m_destructionNotifier(this) {
     ResourceAddRefPrivate(m_resource);
 
     D3D11_COMMON_RESOURCE_DESC resourceDesc;
@@ -127,6 +128,8 @@ namespace dxvk {
   
   
   D3D11UnorderedAccessView::~D3D11UnorderedAccessView() {
+    m_destructionNotifier.Notify();
+
     ResourceReleasePrivate(m_resource);
     m_resource = nullptr;
 
@@ -150,7 +153,12 @@ namespace dxvk {
       *ppvObject = ref(this);
       return S_OK;
     }
-    
+
+    if (riid == __uuidof(ID3DDestructionNotifier)) {
+      *ppvObject = ref(&m_destructionNotifier);
+      return S_OK;
+    }
+
     if (logQueryInterfaceError(__uuidof(ID3D11UnorderedAccessView), riid)) {
       Logger::warn("D3D11UnorderedAccessView::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));

--- a/src/d3d11/d3d11_view_uav.h
+++ b/src/d3d11/d3d11_view_uav.h
@@ -89,6 +89,8 @@ namespace dxvk {
     Rc<DxvkImageView>                 m_imageView;
     Rc<DxvkBufferView>                m_counterView;
 
+    D3DDestructionNotifier            m_destructionNotifier;
+
     Rc<DxvkBufferView> CreateCounterBufferView();
     
   };

--- a/src/d3d11/shaders/d3d11_video_blit_frag.frag
+++ b/src/d3d11/shaders/d3d11_video_blit_frag.frag
@@ -2,6 +2,10 @@
 
 #extension GL_EXT_samplerless_texture_functions : require
 
+#define EXPORT_RGBA (0u)
+#define EXPORT_Y (1u)
+#define EXPORT_CbCr (2u)
+
 // Can't use matrix types here since even a two-row
 // matrix will be padded to 16 bytes per column for
 // absolutely no reason
@@ -18,6 +22,7 @@ uniform ubo_t {
   float y_min;
   float y_max;
   bool is_planar;
+  uint export_mode;
 };
 
 layout(location = 0) in vec2 i_texcoord;
@@ -90,5 +95,10 @@ void main() {
     accum += factor.x * factor.y * color;
   }
 
-  o_color = accum;
+  if (export_mode == EXPORT_RGBA)
+    o_color = accum;
+  else if (export_mode == EXPORT_Y)
+    o_color = vec4(accum.g, 0.0, 0.0, 1.0);
+  else if (export_mode == EXPORT_CbCr)
+    o_color = vec4(accum.br, 0.0, 1.0);
 }

--- a/src/dxgi/dxgi_include.h
+++ b/src/dxgi/dxgi_include.h
@@ -7,6 +7,7 @@
   #define DLLEXPORT
 #endif
 
+#include "../util/com/com_destruction_notifier.h"
 #include "../util/com/com_guid.h"
 #include "../util/com/com_object.h"
 #include "../util/com/com_pointer.h"

--- a/src/dxgi/dxgi_swapchain.cpp
+++ b/src/dxgi/dxgi_swapchain.cpp
@@ -22,7 +22,8 @@ namespace dxvk {
     m_presentId (0u),
     m_presenter (pPresenter),
     m_monitor   (wsi::getWindowMonitor(m_window)),
-    m_is_d3d12(SUCCEEDED(pDevice->QueryInterface(__uuidof(ID3D12CommandQueue), reinterpret_cast<void**>(&Com<ID3D12CommandQueue>())))) {
+    m_is_d3d12(SUCCEEDED(pDevice->QueryInterface(__uuidof(ID3D12CommandQueue), reinterpret_cast<void**>(&Com<ID3D12CommandQueue>())))),
+    m_destructionNotifier(this) {
 
     if (FAILED(m_presenter->GetAdapter(__uuidof(IDXGIAdapter), reinterpret_cast<void**>(&m_adapter))))
       throw DxvkError("DXGI: Failed to get adapter for present device");
@@ -85,6 +86,11 @@ namespace dxvk {
      || riid == __uuidof(IDXGISwapChain3)
      || riid == __uuidof(IDXGISwapChain4)) {
       *ppvObject = ref(this);
+      return S_OK;
+    }
+
+    if (riid == __uuidof(ID3DDestructionNotifier)) {
+      *ppvObject = ref(&m_destructionNotifier);
       return S_OK;
     }
 

--- a/src/dxgi/dxgi_swapchain.h
+++ b/src/dxgi/dxgi_swapchain.h
@@ -206,6 +206,8 @@ namespace dxvk {
 
     uint32_t                        m_globalHDRStateSerial = 0;
     bool                            m_hasLatencyControl = false;
+
+    D3DDestructionNotifier          m_destructionNotifier;
     
     HRESULT EnterFullscreenMode(
             IDXGIOutput1            *pTarget);

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -4324,9 +4324,9 @@ namespace dxvk {
           str::format("Clear view (", dstName ? dstName : "unknown", ")").c_str()));
       }
 
-      clearLayout = (imageView->info().aspects & VK_IMAGE_ASPECT_COLOR_BIT)
-        ? imageView->pickLayout(VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL)
-        : imageView->pickLayout(VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
+      clearLayout = (imageView->info().aspects & (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT))
+        ? imageView->pickLayout(VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL)
+        : imageView->pickLayout(VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
 
       VkExtent3D extent = imageView->mipLevelExtent(0);
 
@@ -4340,14 +4340,7 @@ namespace dxvk {
       renderingInfo.renderArea.extent = { extent.width, extent.height };
       renderingInfo.layerCount = imageView->info().layerCount;
 
-      if (imageView->info().aspects & VK_IMAGE_ASPECT_COLOR_BIT) {
-        clearStages |= VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-        clearAccess |= VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT
-                    |  VK_ACCESS_COLOR_ATTACHMENT_READ_BIT;
-
-        renderingInfo.colorAttachmentCount = 1;
-        renderingInfo.pColorAttachments = &attachmentInfo;
-      } else {
+      if (imageView->info().aspects & (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT)) {
         clearStages |= VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT
                     |  VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
         clearAccess |= VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT
@@ -4358,6 +4351,13 @@ namespace dxvk {
 
         if (imageView->info().aspects & VK_IMAGE_ASPECT_STENCIL_BIT)
           renderingInfo.pStencilAttachment = &attachmentInfo;
+      } else {
+        clearStages |= VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+        clearAccess |= VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT
+                    |  VK_ACCESS_COLOR_ATTACHMENT_READ_BIT;
+
+        renderingInfo.colorAttachmentCount = 1;
+        renderingInfo.pColorAttachments = &attachmentInfo;
       }
 
       addImageLayoutTransition(*imageView->image(), imageView->imageSubresources(),

--- a/src/util/com/com_destruction_notifier.cpp
+++ b/src/util/com/com_destruction_notifier.cpp
@@ -1,0 +1,81 @@
+#include "com_destruction_notifier.h"
+
+namespace dxvk {
+
+  D3DDestructionNotifier::D3DDestructionNotifier(IUnknown* pParent)
+  : m_parent(pParent) {
+
+  }
+
+
+  D3DDestructionNotifier::~D3DDestructionNotifier() {
+    Notify();
+  }
+
+
+  ULONG STDMETHODCALLTYPE D3DDestructionNotifier::AddRef() {
+    return m_parent->AddRef();
+  }
+
+
+  ULONG STDMETHODCALLTYPE D3DDestructionNotifier::Release() {
+    return m_parent->Release();
+  }
+
+
+  HRESULT STDMETHODCALLTYPE D3DDestructionNotifier::QueryInterface(
+          REFIID                    iid,
+          void**                    ppvObject) {
+    return m_parent->QueryInterface(iid, ppvObject);
+  }
+
+
+  HRESULT STDMETHODCALLTYPE D3DDestructionNotifier::RegisterDestructionCallback(
+          PFN_DESTRUCTION_CALLBACK  pCallback,
+          void*                     pData,
+          UINT*                     pCallbackId) {
+    std::lock_guard lock(m_mutex);
+
+    if (!pCallback)
+      return DXGI_ERROR_INVALID_CALL;
+
+    auto& cb = m_callbacks.emplace_back();
+    cb.cb = pCallback;
+    cb.data = pData;
+
+    if (pCallbackId) {
+      cb.id = ++m_nextId;
+      *pCallbackId = cb.id;
+    }
+
+    return S_OK;
+  }
+
+
+  HRESULT STDMETHODCALLTYPE D3DDestructionNotifier::UnregisterDestructionCallback(
+          UINT                      CallbackId) {
+    std::lock_guard lock(m_mutex);
+
+    if (!CallbackId)
+      return DXGI_ERROR_NOT_FOUND;
+
+    for (size_t i = 0; i < m_callbacks.size(); i++) {
+      if (m_callbacks[i].id == CallbackId) {
+        m_callbacks[i] = std::move(m_callbacks.back());
+        m_callbacks.pop_back();
+        return S_OK;
+      }
+    }
+
+    return DXGI_ERROR_NOT_FOUND;
+  }
+
+
+  void D3DDestructionNotifier::Notify() {
+    for (size_t i = 0; i < m_callbacks.size(); i++)
+      m_callbacks[i].cb(m_callbacks[i].data);
+
+    m_callbacks.clear();
+  }
+
+}

--- a/src/util/com/com_destruction_notifier.h
+++ b/src/util/com/com_destruction_notifier.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <d3dcommon.h>
+
+#include "../util/thread.h"
+#include "../util/util_small_vector.h"
+
+namespace dxvk {
+
+  class D3DDestructionNotifier : public ID3DDestructionNotifier {
+
+  public:
+
+    D3DDestructionNotifier(IUnknown* pParent);
+
+    ~D3DDestructionNotifier();
+
+    ULONG STDMETHODCALLTYPE AddRef();
+
+    ULONG STDMETHODCALLTYPE Release();
+
+    HRESULT STDMETHODCALLTYPE QueryInterface(
+            REFIID                    iid,
+            void**                    ppvObject);
+
+    HRESULT STDMETHODCALLTYPE RegisterDestructionCallback(
+            PFN_DESTRUCTION_CALLBACK  pCallback,
+            void*                     pData,
+            UINT*                     pCallbackId);
+
+    HRESULT STDMETHODCALLTYPE UnregisterDestructionCallback(
+            UINT                      CallbackId);
+
+    void Notify();
+
+  private:
+
+    struct Entry {
+      uint32_t id = 0u;
+      PFN_DESTRUCTION_CALLBACK cb = nullptr;
+      void* data = nullptr;
+    };
+
+    IUnknown*   m_parent = nullptr;
+
+    dxvk::mutex m_mutex;
+    uint32_t    m_nextId = 0u;
+
+    small_vector<Entry, 2> m_callbacks;
+
+  };
+
+}

--- a/src/util/meson.build
+++ b/src/util/meson.build
@@ -11,6 +11,7 @@ util_src = files([
 
   'thread.cpp',
 
+  'com/com_destruction_notifier.cpp',
   'com/com_guid.cpp',
   'com/com_private_data.cpp',
 

--- a/src/util/util_flush.cpp
+++ b/src/util/util_flush.cpp
@@ -45,7 +45,6 @@ namespace dxvk {
         return chunkCount >= m_minChunkCount;
       }
 
-      case GpuFlushType::ImplicitMediumHint:
       case GpuFlushType::ImplicitWeakHint: {
         // Aim for a higher number of chunks per submission with
         // a weak hint in order to avoid submitting too often.
@@ -69,6 +68,9 @@ namespace dxvk {
         uint32_t threshold = std::min(m_maxChunkCount.load(), pendingSubmissions * m_minChunkCount.load());
         return chunkCount >= threshold;
       }
+
+      case GpuFlushType::None:
+        return false;
     }
 
     // Should be unreachable
@@ -79,7 +81,7 @@ namespace dxvk {
   void GpuFlushTracker::notifyFlush(
           uint64_t              chunkId,
           uint64_t              submissionId) {
-    m_lastMissedType = GpuFlushType::ImplicitWeakHint;
+    m_lastMissedType = GpuFlushType::None;
 
     m_lastFlushChunkId = chunkId;
     m_lastFlushSubmissionId = submissionId;

--- a/src/util/util_flush.h
+++ b/src/util/util_flush.h
@@ -19,12 +19,12 @@ namespace dxvk {
     /** GPU command that applications are likely to synchronize
      *  with soon has been recorded into the command list */
     ImplicitStrongHint      = 2,
-    /** A render pass boundary is likely to occur and a flush
-     *  should be recorded if the command list is large enough. */
-    ImplicitMediumHint      = 3,
     /** GPU commands have been recorded and a flush should be
      *  performed if the current command list is large enough. */
-    ImplicitWeakHint        = 4,
+    ImplicitWeakHint        = 3,
+
+    /** No flush. Must be the highest enum value. */
+    None                    = ~0u
   };
 
 
@@ -39,6 +39,19 @@ namespace dxvk {
   public:
 
     GpuFlushTracker(GpuFlushType maxAllowed);
+
+    /**
+     * \brief Queries type of last missed submission request
+     *
+     * If \c considerFlush has returned \c false, the strongest request type
+     * will be tracked so that a submission can be performed as soon as the
+     * corresponding heuristic allows it.
+     * \returns Missed submission request type, or \c GpuFlushType::None if
+     *    no submission request has been missed.
+     */
+    GpuFlushType getPendingType() const {
+      return m_lastMissedType;
+    }
 
     /**
      * \brief Checks whether a context flush should be performed
@@ -72,7 +85,7 @@ namespace dxvk {
   private:
 
     GpuFlushType  m_maxType               = GpuFlushType::ImplicitWeakHint;
-    GpuFlushType  m_lastMissedType        = GpuFlushType::ImplicitWeakHint;
+    GpuFlushType  m_lastMissedType        = GpuFlushType::None;
 
     uint64_t      m_lastFlushChunkId      = 0ull;
     uint64_t      m_lastFlushSubmissionId = 0ull;


### PR DESCRIPTION
And later commits.

[0f4bf3b](https://github.com/doitsujin/dxvk/commit/0f4bf3bf77e665370bd78377d1cc97c72e13a5f9) - [util] Add functionality to query rejected submission request type - [Rework tiler submission heuristic (again)](https://github.com/doitsujin/dxvk/pull/4841)

[a169933](https://github.com/doitsujin/dxvk/commit/a1699333a634aa2eaeb357a98bfee920ba7fd958) - [d3d11] Rework render pass boundary submission heuristic for tilers - [Rework tiler submission heuristic (again)](https://github.com/doitsujin/dxvk/pull/4841)

[5d09231](https://github.com/doitsujin/dxvk/commit/5d0923195cb63f80c7ce8fd19421b5e268145102) - [util] Remove medium hint for submission heuristic - [Rework tiler submission heuristic (again)](https://github.com/doitsujin/dxvk/pull/4841)

[4751079](https://github.com/doitsujin/dxvk/commit/4751079ed2a7de60d9d8b87bc7a199db87ba751f) - [util] Add D3DDestructionNotifier implementation - [Clean up device and instance creation](https://github.com/doitsujin/dxvk/pull/4846)

[6647394](https://github.com/doitsujin/dxvk/commit/6647394990d34596838f5cc267454eeb2688ac79) - [d3d11] Add D3DDestructionNotifier to all relevant interfaces - [Clean up device and instance creation](https://github.com/doitsujin/dxvk/pull/4846)

[2e0d0fe](https://github.com/doitsujin/dxvk/commit/2e0d0fe335212152cfbed81139dbe1e83480bd28) - [dxgi] Add D3DDestructionNotifier to swap chain - [Clean up device and instance creation](https://github.com/doitsujin/dxvk/pull/4846)

[e73b324](https://github.com/doitsujin/dxvk/commit/e73b3241d6894109b5f874cfeea51daeb6c57481) - [d3d11] Remove unused image subresources from D3D11VideoProcessorInputView - [[d3d11] Support planar outputs in video processor](https://github.com/doitsujin/dxvk/pull/4872)

[218360b](https://github.com/doitsujin/dxvk/commit/218360b033c98b1d2adf144fc0e0a1ce56e0eb5d) - [d3d11] Add VideoProcessorView class - [[d3d11] Support planar outputs in video processor](https://github.com/doitsujin/dxvk/pull/4872)

[d677a4c](https://github.com/doitsujin/dxvk/commit/d677a4cbbf08a250108623fa809ed78654492bdd) - [d3d11] Use VideoProcessorView in D3D11VideoProcessorInputView - [[d3d11] Support planar outputs in video processor](https://github.com/doitsujin/dxvk/pull/4872)

[c39233a](https://github.com/doitsujin/dxvk/commit/c39233a7d6b7487198bfe63149c50174d8d76b15) - [d3d11] Use VideoProcessorView in D3D11VideoProcessorOutputView - [[d3d11] Support planar outputs in video processor](https://github.com/doitsujin/dxvk/pull/4872)

[c78dc47](https://github.com/doitsujin/dxvk/commit/c78dc47ad0d306915dfeed214255954166b3dcac) - [d3d11] Allow video blit shader to handle planar and YCbCr outputs - [[d3d11] Support planar outputs in video processor](https://github.com/doitsujin/dxvk/pull/4872)

[7d9faaa](https://github.com/doitsujin/dxvk/commit/7d9faaa0ab7b554a091e585ee9c26491ec48a4b2) - [d3d11] Use multiple passes to render planar video output - [[d3d11] Support planar outputs in video processor](https://github.com/doitsujin/dxvk/pull/4872)

[9c69d21](https://github.com/doitsujin/dxvk/commit/9c69d2166f5980fb0aea090bf07544d424f9748b) - [d3d11] Refactor ClearView method - [Rework ClearView](https://github.com/doitsujin/dxvk/pull/4878)

[4a988d3](https://github.com/doitsujin/dxvk/commit/4a988d361d8d3d803ee6ff45e3a77e37a6cf15ed) - [d3d11] Support clearing planar video output views - [Rework ClearView](https://github.com/doitsujin/dxvk/pull/4878)

[d44370e](https://github.com/doitsujin/dxvk/commit/d44370e7c1be899acc586de1fe63fb6a85dc2ec4) - [dxvk] Fix broken aspect check in clearImageView - [Rework ClearView](https://github.com/doitsujin/dxvk/pull/4878)

[3494386](https://github.com/doitsujin/dxvk/commit/34943867185ddb1f02bf60b37e4915bc7f260eda) - [d3d11] Remove unused GetView method from D3D11VideoProcessorOutputView - [Rework ClearView](https://github.com/doitsujin/dxvk/pull/4878)

[cbd8253](https://github.com/doitsujin/dxvk/commit/cbd82536b37615444b34f8f9bfc414adc85da67e) - [d3d11] Store image directly in video output view

[2e2d6e7](https://github.com/doitsujin/dxvk/commit/2e2d6e766d4deefd1b1913ad61ce9313a491e5f9) - [d3d11] Reintroduce shadow image path for video processor views

[e93c4fc](https://github.com/doitsujin/dxvk/commit/e93c4fcab03931e1fb866c4dac708a3eec7e250f) - [d3d11] Fix planar video output when dst rect is enabled