### PR TITLE
Backport upstream DXVK PR#4993, part of PR#4923, changes GPLAsync patch to 2.7.1 

### DIFF
--- a/src/d3d11/d3d11_context.cpp
+++ b/src/d3d11/d3d11_context.cpp
@@ -3654,17 +3654,13 @@ namespace dxvk {
     // target bindings are updated. Set up the attachments.
     for (UINT i = 0; i < m_state.om.rtvs.size(); i++) {
       if (m_state.om.rtvs[i] != nullptr) {
-        attachments.color[i] = {
-          m_state.om.rtvs[i]->GetImageView(),
-          m_state.om.rtvs[i]->GetRenderLayout() };
+        attachments.color[i].view = m_state.om.rtvs[i]->GetImageView();
         sampleCount = m_state.om.rtvs[i]->GetSampleCount();
       }
     }
 
     if (m_state.om.dsv != nullptr) {
-      attachments.depth = {
-        m_state.om.dsv->GetImageView(),
-        m_state.om.dsv->GetRenderLayout() };
+      attachments.depth.view = m_state.om.dsv->GetImageView();
       sampleCount = m_state.om.dsv->GetSampleCount();
 
       if (m_device->features().extDepthBiasControl.leastRepresentableValueForceUnormRepresentation)
@@ -5779,7 +5775,8 @@ namespace dxvk {
       }
 
       // Otherwise we can't really do anything fancy, so just do a GPU copy
-      context->UpdateBuffer(bufferResource, offset, length, pSrcData);
+      if (likely(length))
+        context->UpdateBuffer(bufferResource, offset, length, pSrcData);
     } else {
       D3D11CommonTexture* textureResource = GetCommonTexture(pDstResource);
 

--- a/src/d3d11/d3d11_device.cpp
+++ b/src/d3d11/d3d11_device.cpp
@@ -792,14 +792,9 @@ namespace dxvk {
     moduleInfo.tess    = nullptr;
     moduleInfo.xfb     = nullptr;
 
-    Sha1Hash hash = Sha1Hash::compute(
-      pShaderBytecode, BytecodeLength);
-    
-    HRESULT hr = CreateShaderModule(&module,
-      DxvkShaderKey(VK_SHADER_STAGE_VERTEX_BIT, hash),
-      pShaderBytecode, BytecodeLength, pClassLinkage,
-      &moduleInfo);
-    
+    HRESULT hr = CreateShaderModule(&module, VK_SHADER_STAGE_VERTEX_BIT,
+      pShaderBytecode, BytecodeLength, pClassLinkage, &moduleInfo);
+
     if (FAILED(hr))
       return hr;
     
@@ -824,13 +819,8 @@ namespace dxvk {
     moduleInfo.tess    = nullptr;
     moduleInfo.xfb     = nullptr;
 
-    Sha1Hash hash = Sha1Hash::compute(
-      pShaderBytecode, BytecodeLength);
-    
-    HRESULT hr = CreateShaderModule(&module,
-      DxvkShaderKey(VK_SHADER_STAGE_GEOMETRY_BIT, hash),
-      pShaderBytecode, BytecodeLength, pClassLinkage,
-      &moduleInfo);
+    HRESULT hr = CreateShaderModule(&module, VK_SHADER_STAGE_GEOMETRY_BIT,
+      pShaderBytecode, BytecodeLength, pClassLinkage, &moduleInfo);
 
     if (FAILED(hr))
       return hr;
@@ -898,37 +888,15 @@ namespace dxvk {
     
     if (RasterizedStream != D3D11_SO_NO_RASTERIZED_STREAM)
       Logger::err("D3D11: CreateGeometryShaderWithStreamOutput: Rasterized stream not supported");
-    
-    // Compute hash from both the xfb info and the source
-    // code, because both influence the generated code
-    DxbcXfbInfo hashXfb = xfb;
 
-    std::vector<Sha1Data> chunks = {{
-      { pShaderBytecode, BytecodeLength  },
-      { &hashXfb,        sizeof(hashXfb) },
-    }};
-
-    for (uint32_t i = 0; i < hashXfb.entryCount; i++) {
-      const char* semantic = hashXfb.entries[i].semanticName;
-
-      if (semantic) {
-        chunks.push_back({ semantic, std::strlen(semantic) });
-        hashXfb.entries[i].semanticName = nullptr;
-      }
-    }
-
-    Sha1Hash hash = Sha1Hash::compute(chunks.size(), chunks.data());
-    
     // Create the actual shader module
     DxbcModuleInfo moduleInfo;
     moduleInfo.options = m_dxbcOptions;
     moduleInfo.tess    = nullptr;
     moduleInfo.xfb     = &xfb;
-    
-    HRESULT hr = CreateShaderModule(&module,
-      DxvkShaderKey(VK_SHADER_STAGE_GEOMETRY_BIT, hash),
-      pShaderBytecode, BytecodeLength, pClassLinkage,
-      &moduleInfo);
+
+    HRESULT hr = CreateShaderModule(&module, VK_SHADER_STAGE_GEOMETRY_BIT,
+      pShaderBytecode, BytecodeLength, pClassLinkage, &moduleInfo);
 
     if (FAILED(hr))
       return E_INVALIDARG;
@@ -954,14 +922,8 @@ namespace dxvk {
     moduleInfo.tess    = nullptr;
     moduleInfo.xfb     = nullptr;
 
-    Sha1Hash hash = Sha1Hash::compute(
-      pShaderBytecode, BytecodeLength);
-    
-
-    HRESULT hr = CreateShaderModule(&module,
-      DxvkShaderKey(VK_SHADER_STAGE_FRAGMENT_BIT, hash),
-      pShaderBytecode, BytecodeLength, pClassLinkage,
-      &moduleInfo);
+    HRESULT hr = CreateShaderModule(&module, VK_SHADER_STAGE_FRAGMENT_BIT,
+      pShaderBytecode, BytecodeLength, pClassLinkage, &moduleInfo);
 
     if (FAILED(hr))
       return hr;
@@ -993,11 +955,7 @@ namespace dxvk {
     if (tessInfo.maxTessFactor >= 8.0f)
       moduleInfo.tess = &tessInfo;
 
-    Sha1Hash hash = Sha1Hash::compute(
-      pShaderBytecode, BytecodeLength);
-    
-    HRESULT hr = CreateShaderModule(&module,
-      DxvkShaderKey(VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT, hash),
+    HRESULT hr = CreateShaderModule(&module, VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT,
       pShaderBytecode, BytecodeLength, pClassLinkage, &moduleInfo);
 
     if (FAILED(hr))
@@ -1024,11 +982,7 @@ namespace dxvk {
     moduleInfo.tess    = nullptr;
     moduleInfo.xfb     = nullptr;
 
-    Sha1Hash hash = Sha1Hash::compute(
-      pShaderBytecode, BytecodeLength);
-    
-    HRESULT hr = CreateShaderModule(&module,
-      DxvkShaderKey(VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT, hash),
+    HRESULT hr = CreateShaderModule(&module, VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT,
       pShaderBytecode, BytecodeLength, pClassLinkage, &moduleInfo);
 
     if (FAILED(hr))
@@ -1055,13 +1009,8 @@ namespace dxvk {
     moduleInfo.tess    = nullptr;
     moduleInfo.xfb     = nullptr;
 
-    Sha1Hash hash = Sha1Hash::compute(
-      pShaderBytecode, BytecodeLength);
-    
-    HRESULT hr = CreateShaderModule(&module,
-      DxvkShaderKey(VK_SHADER_STAGE_COMPUTE_BIT, hash),
-      pShaderBytecode, BytecodeLength, pClassLinkage,
-      &moduleInfo);
+    HRESULT hr = CreateShaderModule(&module, VK_SHADER_STAGE_COMPUTE_BIT,
+      pShaderBytecode, BytecodeLength, pClassLinkage, &moduleInfo);
 
     if (FAILED(hr))
       return hr;
@@ -2010,11 +1959,67 @@ namespace dxvk {
 
     return enabled;
   }
-  
-  
+
+
+  DxvkShaderKey D3D11Device::ComputeShaderKey(
+          VkShaderStageFlagBits   ShaderStage,
+    const void*                   pShaderBytecode,
+          size_t                  BytecodeLength,
+    const DxbcModuleInfo*         pModuleInfo) {
+    constexpr static uint32_t Md5Size = 16;
+
+    // DXBC shaders store an MD5 hash within their header, so just
+    // use that instead of running SHA-1 over the entire binary.
+    Sha1Digest digest = { };
+
+    if (BytecodeLength >= Md5Size + 4u)
+      std::memcpy(&digest[0], reinterpret_cast<const char*>(pShaderBytecode) + 4, Md5Size);
+
+    uint32_t metadata = uint32_t(ShaderStage) | (uint32_t(BytecodeLength) << 8u);
+    std::memcpy(&digest[Md5Size], &metadata, sizeof(metadata));
+
+    // If transform feedback is enabled, hash that state too since it
+    // affects the generated shader code, and factor it into the key.
+    if (pModuleInfo && pModuleInfo->xfb) {
+      std::vector<unsigned char> serialized;
+
+      serialized.push_back(pModuleInfo->xfb->entryCount);
+
+      for (uint32_t i = 0; i < pModuleInfo->xfb->entryCount; i++) {
+        if (pModuleInfo->xfb->entries[i].semanticName) {
+          for (uint32_t j = 0; pModuleInfo->xfb->entries[i].semanticName[j]; j++)
+            serialized.push_back(pModuleInfo->xfb->entries[i].semanticName[j]);
+        }
+
+        serialized.push_back(pModuleInfo->xfb->entries[i].semanticIndex);
+        serialized.push_back(pModuleInfo->xfb->entries[i].componentIndex);
+        serialized.push_back(pModuleInfo->xfb->entries[i].componentCount);
+        serialized.push_back(pModuleInfo->xfb->entries[i].streamId);
+        serialized.push_back(pModuleInfo->xfb->entries[i].bufferId);
+        serialized.push_back(pModuleInfo->xfb->entries[i].offset);
+        serialized.push_back(pModuleInfo->xfb->entries[i].offset >> 8u);
+      }
+
+      for (uint32_t i = 0; i < 4u; i++) {
+        serialized.push_back(pModuleInfo->xfb->strides[i]);
+        serialized.push_back(pModuleInfo->xfb->strides[i] >> 8u);
+      }
+
+      serialized.push_back(pModuleInfo->xfb->rasterizedStream);
+
+      Sha1Digest xfbDigest = Sha1Hash::compute(serialized.data(), serialized.size()).digest();
+
+      for (size_t i = 0; i < xfbDigest.size(); i++)
+        digest[i] ^= xfbDigest[i];
+    }
+
+    return DxvkShaderKey(ShaderStage, Sha1Hash(digest));
+  }
+
+
   HRESULT D3D11Device::CreateShaderModule(
           D3D11CommonShader*      pShaderModule,
-          DxvkShaderKey           ShaderKey,
+          VkShaderStageFlagBits   ShaderStage,
     const void*                   pShaderBytecode,
           size_t                  BytecodeLength,
           ID3D11ClassLinkage*     pClassLinkage,
@@ -2025,10 +2030,12 @@ namespace dxvk {
     if (pClassLinkage != nullptr)
       Logger::warn("D3D11Device::CreateShaderModule: Class linkage not supported");
 
+    DxvkShaderKey shaderKey = ComputeShaderKey(ShaderStage, pShaderBytecode, BytecodeLength, pModuleInfo);
+
     D3D11CommonShader commonShader;
 
     HRESULT hr = m_shaderModules.GetShaderModule(this,
-      &ShaderKey, pModuleInfo, pShaderBytecode, BytecodeLength,
+      &shaderKey, pModuleInfo, pShaderBytecode, BytecodeLength,
       &commonShader);
 
     if (FAILED(hr))

--- a/src/d3d11/d3d11_device.h
+++ b/src/d3d11/d3d11_device.h
@@ -524,9 +524,15 @@ namespace dxvk {
 
     Com<D3D11ImmediateContext, false> m_context;
 
+    DxvkShaderKey ComputeShaderKey(
+            VkShaderStageFlagBits   ShaderStage,
+      const void*                   pShaderBytecode,
+            size_t                  BytecodeLength,
+      const DxbcModuleInfo*         pModuleInfo);
+
     HRESULT CreateShaderModule(
             D3D11CommonShader*      pShaderModule,
-            DxvkShaderKey           ShaderKey,
+            VkShaderStageFlagBits   ShaderStage,
       const void*                   pShaderBytecode,
             size_t                  BytecodeLength,
             ID3D11ClassLinkage*     pClassLinkage,

--- a/src/d3d11/d3d11_video.cpp
+++ b/src/d3d11/d3d11_video.cpp
@@ -251,6 +251,9 @@ namespace dxvk {
       viewInfo.mipIndex = 0u;
     }
 
+    if (viewInfo.usage == VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT)
+      viewInfo.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
     for (uint32_t i = 0; aspectMask && i < m_views.size(); i++) {
       viewInfo.aspects = vk::getNextAspect(aspectMask);
 
@@ -1416,7 +1419,6 @@ namespace dxvk {
 
       DxvkRenderTargets rt;
       rt.color[0].view = cView;
-      rt.color[0].layout = cView->pickLayout(VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
 
       ctx->bindRenderTargets(std::move(rt), 0u);
 

--- a/src/d3d11/d3d11_view_dsv.cpp
+++ b/src/d3d11/d3d11_view_dsv.cpp
@@ -20,6 +20,7 @@ namespace dxvk {
 
     DxvkImageViewKey viewInfo;
     viewInfo.format = pDevice->LookupFormat(pDesc->Format, DXGI_VK_FORMAT_MODE_DEPTH).Format;
+    viewInfo.layout = GetViewLayout();
     viewInfo.aspects = lookupFormatInfo(viewInfo.format)->aspectMask;
     viewInfo.usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
     
@@ -292,4 +293,17 @@ namespace dxvk {
     return S_OK;
   }
   
+
+  VkImageLayout D3D11DepthStencilView::GetViewLayout() const {
+    switch (m_desc.Flags & (D3D11_DSV_READ_ONLY_DEPTH | D3D11_DSV_READ_ONLY_STENCIL)) {
+      default:  // case 0
+        return VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+      case D3D11_DSV_READ_ONLY_DEPTH:
+        return VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL_KHR;
+      case D3D11_DSV_READ_ONLY_STENCIL:
+        return VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL_KHR;
+      case D3D11_DSV_READ_ONLY_DEPTH | D3D11_DSV_READ_ONLY_STENCIL:
+        return VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL;
+    }
+  }
 }

--- a/src/d3d11/d3d11_view_dsv.h
+++ b/src/d3d11/d3d11_view_dsv.h
@@ -49,19 +49,6 @@ namespace dxvk {
       return m_view;
     }
     
-    VkImageLayout GetRenderLayout() const {
-      switch (m_desc.Flags & (D3D11_DSV_READ_ONLY_DEPTH | D3D11_DSV_READ_ONLY_STENCIL)) {
-        default:  // case 0
-          return VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-        case D3D11_DSV_READ_ONLY_DEPTH:
-          return VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL_KHR;
-        case D3D11_DSV_READ_ONLY_STENCIL:
-          return VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL_KHR;
-        case D3D11_DSV_READ_ONLY_DEPTH | D3D11_DSV_READ_ONLY_STENCIL:
-          return VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL;
-      }
-    }
-
     UINT GetSampleCount() const {
       return UINT(m_view->image()->info().sampleCount);
     }
@@ -98,6 +85,8 @@ namespace dxvk {
     D3D10DepthStencilView             m_d3d10;
 
     D3DDestructionNotifier            m_destructionNotifier;
+
+    VkImageLayout GetViewLayout() const;
 
   };
   

--- a/src/d3d11/d3d11_view_rtv.cpp
+++ b/src/d3d11/d3d11_view_rtv.cpp
@@ -25,6 +25,7 @@ namespace dxvk {
 
     DxvkImageViewKey viewInfo;
     viewInfo.format = formatInfo.Format;
+    viewInfo.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     viewInfo.aspects = lookupFormatInfo(viewInfo.format)->aspectMask;
     viewInfo.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
     viewInfo.packedSwizzle = DxvkImageViewKey::packSwizzle(formatInfo.Swizzle);

--- a/src/d3d11/d3d11_view_rtv.h
+++ b/src/d3d11/d3d11_view_rtv.h
@@ -51,10 +51,6 @@ namespace dxvk {
       return m_view;
     }
     
-    VkImageLayout GetRenderLayout() const {
-      return VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-    }
-
     UINT GetSampleCount() const {
       return UINT(m_view->image()->info().sampleCount);
     }

--- a/src/d3d11/d3d11_view_uav.cpp
+++ b/src/d3d11/d3d11_view_uav.cpp
@@ -59,6 +59,7 @@ namespace dxvk {
       
       DxvkImageViewKey viewInfo;
       viewInfo.format = formatInfo.Format;
+      viewInfo.layout = VK_IMAGE_LAYOUT_GENERAL;
       viewInfo.aspects = formatInfo.Aspect;
       viewInfo.usage = VK_IMAGE_USAGE_STORAGE_BIT;
 

--- a/src/d3d9/d3d9_common_texture.cpp
+++ b/src/d3d9/d3d9_common_texture.cpp
@@ -652,12 +652,14 @@ namespace dxvk {
   Rc<DxvkImageView> D3D9CommonTexture::CreateView(
           UINT                   Layer,
           UINT                   Lod,
-          VkImageUsageFlags      UsageFlags,
-          bool                   Srgb) {    
+          VkImageUsageFlagBits   UsageFlags,
+          VkImageLayout          Layout,
+          bool                   Srgb) {
     DxvkImageViewKey viewInfo;
     viewInfo.format    = m_mapping.ConversionFormatInfo.FormatColor != VK_FORMAT_UNDEFINED
                        ? PickSRGB(m_mapping.ConversionFormatInfo.FormatColor, m_mapping.ConversionFormatInfo.FormatSrgb, Srgb)
                        : PickSRGB(m_mapping.FormatColor, m_mapping.FormatSrgb, Srgb);
+    viewInfo.layout    = Layout;
     viewInfo.aspects   = lookupFormatInfo(viewInfo.format)->aspectMask;
     viewInfo.usage     = UsageFlags;
     viewInfo.viewType  = GetImageViewTypeFromResourceType(m_type, Layer);
@@ -716,10 +718,13 @@ namespace dxvk {
     if (unlikely(m_mapMode == D3D9_COMMON_TEXTURE_MAP_MODE_SYSTEMMEM))
       return;
 
-    m_sampleView.Color = CreateView(AllLayers, Lod, VK_IMAGE_USAGE_SAMPLED_BIT, false);
+    m_sampleView.Color = CreateView(AllLayers, Lod,
+      VK_IMAGE_USAGE_SAMPLED_BIT, VK_IMAGE_LAYOUT_UNDEFINED, false);
 
-    if (IsSrgbCompatible())
-      m_sampleView.Srgb = CreateView(AllLayers, Lod, VK_IMAGE_USAGE_SAMPLED_BIT, true);
+    if (IsSrgbCompatible()) {
+      m_sampleView.Srgb = CreateView(AllLayers, Lod,
+        VK_IMAGE_USAGE_SAMPLED_BIT, VK_IMAGE_LAYOUT_UNDEFINED, true);
+    }
   }
 
 

--- a/src/d3d9/d3d9_common_texture.h
+++ b/src/d3d9/d3d9_common_texture.h
@@ -363,23 +363,11 @@ namespace dxvk {
         : VK_IMAGE_LAYOUT_GENERAL;
     }
 
-    VkImageLayout DetermineDepthStencilLayout(bool write, bool hazardous, VkImageLayout hazardLayout) const {
-      if (unlikely(m_transitionedToHazardLayout))
-        return hazardLayout;
-
-      if (unlikely(m_image->info().tiling != VK_IMAGE_TILING_OPTIMAL))
-        return VK_IMAGE_LAYOUT_GENERAL;
-
-      if (unlikely(hazardous && !write))
-        return VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL;
-
-      return VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-    }
-
     Rc<DxvkImageView> CreateView(
             UINT                   Layer,
             UINT                   Lod,
-            VkImageUsageFlags      UsageFlags,
+            VkImageUsageFlagBits   UsageFlags,
+            VkImageLayout          Layout,
             bool                   Srgb);
     D3D9SubresourceBitset& GetUploadBitmask() { return m_needsUpload; }
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -1995,7 +1995,7 @@ namespace dxvk {
       VkExtent3D         extent) {
       // Clear depth if we need to.
       if (depthAspectMask != 0)
-        ClearImageView(alignment, offset, extent, m_state.depthStencil->GetDepthStencilView(), depthAspectMask, clearValueDepth);
+        ClearImageView(alignment, offset, extent, m_state.depthStencil->GetDepthStencilView(true), depthAspectMask, clearValueDepth);
 
       // Clear render targets if we need to.
       if (Flags & D3DCLEAR_TARGET) {
@@ -6973,25 +6973,19 @@ namespace dxvk {
     // despite not having color writes enabled,
     // otherwise we might end up with unnecessary render pass spills
     boundMask &= (anyColorWriteMask | ~limitsRenderAreaMask);
-    for (uint32_t i : bit::BitMask(boundMask)) {
-      attachments.color[i] = {
-        m_state.renderTargets[i]->GetRenderTargetView(srgb),
-        m_state.renderTargets[i]->GetRenderTargetLayout(m_hazardLayout) };
-    }
+    for (uint32_t i : bit::BitMask(boundMask))
+      attachments.color[i].view = m_state.renderTargets[i]->GetRenderTargetView(srgb);
 
-    if (dsvBound) {
-      const bool depthWrite = m_state.renderStates[D3DRS_ZWRITEENABLE];
+    const bool depthWrite = m_state.renderStates[D3DRS_ZWRITEENABLE];
 
-      attachments.depth = {
-        m_state.depthStencil->GetDepthStencilView(),
-        m_state.depthStencil->GetDepthStencilLayout(depthWrite, m_textureSlotTracking.hazardDS != 0, m_hazardLayout) };
-    }
+    if (dsvBound)
+      attachments.depth.view = m_state.depthStencil->GetDepthStencilView(depthWrite);
 
     VkImageAspectFlags feedbackLoopAspects = 0u;
     if (m_hazardLayout == VK_IMAGE_LAYOUT_ATTACHMENT_FEEDBACK_LOOP_OPTIMAL_EXT) {
       if (m_textureSlotTracking.hazardRT != 0)
         feedbackLoopAspects |= VK_IMAGE_ASPECT_COLOR_BIT;
-      if (m_textureSlotTracking.hazardDS != 0 && attachments.depth.layout != VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL)
+      if (m_textureSlotTracking.hazardDS != 0 && depthWrite)
         feedbackLoopAspects |= VK_IMAGE_ASPECT_DEPTH_BIT;
     }
 

--- a/src/dxvk/dxvk_buffer.h
+++ b/src/dxvk/dxvk_buffer.h
@@ -277,8 +277,8 @@ namespace dxvk {
      * \param [in] length Buffer slice length
      * \returns Buffer slice descriptor
      */
-    DxvkDescriptorInfo getDescriptor(VkDeviceSize offset, VkDeviceSize length) const {
-      DxvkDescriptorInfo result = { };
+    DxvkLegacyDescriptor getDescriptor(VkDeviceSize offset, VkDeviceSize length) const {
+      DxvkLegacyDescriptor result = { };
       result.buffer.buffer = m_bufferInfo.buffer;
       result.buffer.offset = m_bufferInfo.offset + offset;
       result.buffer.range = length;
@@ -608,7 +608,7 @@ namespace dxvk {
      * \brief Retrieves descriptor info
      * \returns Buffer slice descriptor
      */
-    DxvkDescriptorInfo getDescriptor() const {
+    DxvkLegacyDescriptor getDescriptor() const {
       return m_buffer->getDescriptor(m_offset, m_length);
     }
     

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -419,7 +419,7 @@ namespace dxvk {
       // Suspend works here because we'll end up with one of these scenarios:
       // 1) The render pass gets ended for good, in which case we emit barriers
       // 2) The clear gets folded into render pass ops, so the layout is correct
-      // 3) The clear gets executed separately, in which case updateFramebuffer
+      // 3) The clear gets executed separately, in which case updateRenderTargets
       //    will indirectly emit barriers for the given render target.
       // If there is overlap, we need to explicitly transition affected attachments.
       this->spillRenderPass(true);
@@ -1571,7 +1571,7 @@ namespace dxvk {
         found = m_state.om.framebufferInfo.getAttachment(i).view->image() == image;
 
       if (found) {
-        m_flags.set(DxvkContextFlag::GpDirtyFramebuffer);
+        m_flags.set(DxvkContextFlag::GpDirtyRenderTargets);
 
         spillRenderPass(true);
 
@@ -4293,7 +4293,7 @@ namespace dxvk {
           VkExtent3D            extent,
           VkImageAspectFlags    aspect,
           VkClearValue          value) {
-    this->updateFramebuffer(true);
+    this->updateRenderTargets(true);
 
     VkPipelineStageFlags clearStages = 0;
     VkAccessFlags clearAccess = 0;
@@ -6831,28 +6831,47 @@ namespace dxvk {
 
 
   void DxvkContext::updateFramebuffer(bool isDraw) {
-    if (m_flags.test(DxvkContextFlag::GpDirtyFramebuffer)) {
-      m_flags.clr(DxvkContextFlag::GpDirtyFramebuffer);
+    if (m_flags.test(DxvkContextFlag::GpDirtyRenderTargets)) {
+      m_flags.clr(DxvkContextFlag::GpDirtyRenderTargets);
+
+      if (m_flags.test(DxvkContextFlag::GpRenderPassBound) && !m_flags.test(DxvkContextFlag::GpRenderPassNeedsFlush)) {
+        // Only interrupt an active render pass if the render targets have actually
+        // changed since the last update. There are cases where client APIs cannot
+        // know in advance that consecutive draws use the same set of render targets.
+        if (m_state.om.renderTargets == m_state.om.framebufferInfo.attachments())
+          return;
+      }
+
+      // End active render pass and reset load/store ops for the new render targets.
+      DxvkFramebufferInfo fbInfo = makeFramebufferInfo(m_state.om.renderTargets);
+      this->updateRenderTargetLayouts(fbInfo, m_state.om.framebufferInfo);
+
 
       this->spillRenderPass(true);
 
-      DxvkFramebufferInfo fbInfo = makeFramebufferInfo(m_state.om.renderTargets);
-      this->updateRenderTargetLayouts(fbInfo, m_state.om.framebufferInfo);
+      this->resetRenderPassOps(
+        m_state.om.renderTargets,
+        m_state.om.renderPassOps);
+
+      this->updateRenderTargetLayouts(fbInfo,
+        m_state.om.framebufferInfo);
 
       // Update relevant graphics pipeline state
       m_state.gp.state.ms.setSampleCount(fbInfo.getSampleCount());
       m_state.gp.state.rt = fbInfo.getRtInfo();
-      m_state.om.framebufferInfo = fbInfo;
 
       for (uint32_t i = 0; i < MaxNumRenderTargets; i++) {
-        const Rc<DxvkImageView>& attachment = fbInfo.getColorTarget(i).view;
+        const auto& attachment = fbInfo.getColorTarget(i).view;
 
-        VkComponentMapping mapping = attachment != nullptr
-          ? util::invertComponentMapping(attachment->info().unpackSwizzle())
-          : VkComponentMapping();
+        VkComponentMapping mapping = VkComponentMapping();
+
+        if (attachment)
+          mapping = util::invertComponentMapping(attachment->info().unpackSwizzle());
 
         m_state.gp.state.omSwizzle[i] = DxvkOmAttachmentSwizzle(mapping);
       }
+
+       m_state.om.framebufferInfo = std::move(fbInfo);
 
       if (isDraw) {
         for (uint32_t i = 0; i < fbInfo.numAttachments(); i++)
@@ -7540,9 +7559,9 @@ namespace dxvk {
     }
 
     // End render pass if there are pending resolves
-    if (m_flags.any(DxvkContextFlag::GpDirtyFramebuffer,
+    if (m_flags.any(DxvkContextFlag::GpDirtyRenderTargets,
                     DxvkContextFlag::GpRenderPassNeedsFlush))
-      this->updateFramebuffer(true);
+      this->updateRenderTargets(true);
 
     if (m_flags.test(DxvkContextFlag::GpXfbActive)) {
       // If transform feedback is active and there is a chance that we might
@@ -8451,7 +8470,7 @@ namespace dxvk {
       DxvkContextFlag::GpIndependentSets);
 
     m_flags.set(
-      DxvkContextFlag::GpDirtyFramebuffer,
+      DxvkContextFlag::GpDirtyRenderTargets,
       DxvkContextFlag::GpDirtyPipeline,
       DxvkContextFlag::GpDirtyPipelineState,
       DxvkContextFlag::GpDirtyVertexBuffers,

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -6830,7 +6830,7 @@ namespace dxvk {
   }
 
 
-  void DxvkContext::updateFramebuffer(bool isDraw) {
+    void DxvkContext::updateRenderTargets(bool isDraw) {
     if (m_flags.test(DxvkContextFlag::GpDirtyRenderTargets)) {
       m_flags.clr(DxvkContextFlag::GpDirtyRenderTargets);
 

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -1346,9 +1346,9 @@ namespace dxvk {
 
     // Create image views, etc.
     DxvkMetaMipGenViews mipGenerator(imageView);
-    
-    VkImageLayout dstLayout = imageView->pickLayout(VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
-    VkImageLayout srcLayout = imageView->pickLayout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+
+    VkImageLayout dstLayout = mipGenerator.getDstView(0u)->getLayout();
+    VkImageLayout srcLayout = mipGenerator.getSrcView(0u)->getLayout();
 
     // If necessary, transition first mip level to the read-only layout
     addImageLayoutTransition(*imageView->image(),
@@ -1399,7 +1399,7 @@ namespace dxvk {
       VkExtent3D passExtent = mipGenerator.computePassExtent(i);
       
       // Create descriptor set with the current source view
-      descriptorImage.imageView = mipGenerator.getSrcViewHandle(i);
+      descriptorImage.imageView = mipGenerator.getSrcView(i)->handle();
       descriptorWrite.dstSet = m_descriptorPool->alloc(pipeInfo.layout->getDescriptorSetLayout(0));
       m_cmd->updateDescriptorSets(1, &descriptorWrite);
       
@@ -1417,7 +1417,7 @@ namespace dxvk {
       scissor.extent    = { passExtent.width, passExtent.height };
       
       // Set up rendering info
-      attachmentInfo.imageView = mipGenerator.getDstViewHandle(i);
+      attachmentInfo.imageView = mipGenerator.getDstView(i)->handle();
       renderingInfo.renderArea = scissor;
       renderingInfo.layerCount = passExtent.depth;
       
@@ -2139,7 +2139,7 @@ namespace dxvk {
       // isn't writable. We can only hit this particular path when starting a render pass,
       // so we can safely manipulate load layouts here.
       int32_t colorIndex = m_state.om.framebufferInfo.getColorAttachmentIndex(attachmentIndex);
-      VkImageLayout renderLayout = m_state.om.framebufferInfo.getAttachment(attachmentIndex).layout;
+      VkImageLayout renderLayout = m_state.om.framebufferInfo.getAttachment(attachmentIndex).view->getLayout();
 
       if (colorIndex < 0) {
         depthOp.loadLayout = m_state.om.renderPassOps.depthOps.loadLayout;
@@ -2179,9 +2179,7 @@ namespace dxvk {
       }
 
       // Set up a temporary render pass to execute the clear
-      VkImageLayout imageLayout = ((clearAspects | discardAspects) & VK_IMAGE_ASPECT_COLOR_BIT)
-        ? imageView->pickLayout(VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL)
-        : imageView->pickLayout(VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
+      VkImageLayout imageLayout = imageView->getLayout();
 
       VkRenderingAttachmentInfo attachmentInfo = { VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO };
       attachmentInfo.imageView = imageView->handle();
@@ -3611,8 +3609,8 @@ namespace dxvk {
     flushPendingAccesses(*srcView, DxvkAccess::Read);
 
     // Prepare the two images for transfer ops if necessary
-    auto dstLayout = dstView->pickLayout(VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
-    auto srcLayout = srcView->pickLayout(VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL);
+    auto dstLayout = dstView->image()->pickLayout(VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
+    auto srcLayout = srcView->image()->pickLayout(VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL);
 
     addImageLayoutTransition(*dstView->image(), dstView->imageSubresources(),
       dstLayout, VK_PIPELINE_STAGE_2_TRANSFER_BIT, VK_ACCESS_2_TRANSFER_WRITE_BIT, false);
@@ -4324,9 +4322,7 @@ namespace dxvk {
           str::format("Clear view (", dstName ? dstName : "unknown", ")").c_str()));
       }
 
-      clearLayout = (imageView->info().aspects & (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT))
-        ? imageView->pickLayout(VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL)
-        : imageView->pickLayout(VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
+      clearLayout = imageView->getLayout();
 
       VkExtent3D extent = imageView->mipLevelExtent(0);
 
@@ -5422,10 +5418,12 @@ namespace dxvk {
     // that can be used for rendering.
     bool isDepthStencil = region.dstSubresource.aspectMask & (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
 
-    DxvkImageUsageInfo usage = { };
-    usage.usage = isDepthStencil
+    VkImageUsageFlagBits usageBit = isDepthStencil
       ? VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT
       : VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+
+    DxvkImageUsageInfo usage = { };
+    usage.usage = usageBit;
     usage.viewFormatCount = 1;
     usage.viewFormats = &format;
 
@@ -5439,7 +5437,7 @@ namespace dxvk {
     // Create an image view that we can use to perform the clear
     DxvkImageViewKey key = { };
     key.viewType = VK_IMAGE_VIEW_TYPE_2D;
-    key.usage = usage.usage;
+    key.usage = usageBit;
     key.format = format;
     key.aspects = region.dstSubresource.aspectMask;
     key.layerIndex = region.dstSubresource.baseArrayLayer;
@@ -5513,7 +5511,7 @@ namespace dxvk {
     uint32_t relativeLayer = 0u;
 
     DxvkImageViewKey dstKey = { };
-    dstKey.usage = usage;
+    dstKey.usage = VkImageUsageFlagBits(usage);
     dstKey.aspects = region.dstSubresource.aspectMask;
     dstKey.mipIndex = region.dstSubresource.mipLevel;
     dstKey.mipCount = 1u;
@@ -5801,56 +5799,61 @@ namespace dxvk {
     // Transition all images to the render layout as necessary
     const auto& depthAttachment = framebufferInfo.getDepthTarget();
 
-    if (depthAttachment.layout != ops.depthOps.loadLayout
-     && depthAttachment.view != nullptr) {
-      VkImageAspectFlags depthAspects = depthAttachment.view->info().aspects;
+    if (depthAttachment.view) {
+      VkImageLayout layout = depthAttachment.view->getLayout();
 
-      VkPipelineStageFlags2 depthStages =
-        VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT |
-        VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT;
-      VkAccessFlags2 depthAccess = VK_ACCESS_2_NONE;
+      if (layout != ops.depthOps.loadLayout) {
+        VkImageAspectFlags depthAspects = depthAttachment.view->info().aspects;
 
-      if (((depthAspects & VK_IMAGE_ASPECT_DEPTH_BIT) && ops.depthOps.loadOpD == VK_ATTACHMENT_LOAD_OP_LOAD)
-       || ((depthAspects & VK_IMAGE_ASPECT_STENCIL_BIT) && ops.depthOps.loadOpS == VK_ATTACHMENT_LOAD_OP_LOAD))
-        depthAccess |= VK_ACCESS_2_DEPTH_STENCIL_ATTACHMENT_READ_BIT;
+        VkPipelineStageFlags2 depthStages =
+          VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT |
+          VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT;
+        VkAccessFlags2 depthAccess = VK_ACCESS_2_NONE;
 
-      if (((depthAspects & VK_IMAGE_ASPECT_DEPTH_BIT) && ops.depthOps.loadOpD != VK_ATTACHMENT_LOAD_OP_LOAD)
-       || ((depthAspects & VK_IMAGE_ASPECT_STENCIL_BIT) && ops.depthOps.loadOpS != VK_ATTACHMENT_LOAD_OP_LOAD)
-       || (depthAttachment.layout != VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL))
-        depthAccess |= VK_ACCESS_2_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+        if (((depthAspects & VK_IMAGE_ASPECT_DEPTH_BIT) && ops.depthOps.loadOpD == VK_ATTACHMENT_LOAD_OP_LOAD)
+         || ((depthAspects & VK_IMAGE_ASPECT_STENCIL_BIT) && ops.depthOps.loadOpS == VK_ATTACHMENT_LOAD_OP_LOAD))
+          depthAccess |= VK_ACCESS_2_DEPTH_STENCIL_ATTACHMENT_READ_BIT;
 
-      if (depthAttachment.layout != VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL) {
-        depthStages |= m_device->getShaderPipelineStages();
-        depthAccess |= VK_ACCESS_2_SHADER_READ_BIT;
+
+        if (((depthAspects & VK_IMAGE_ASPECT_DEPTH_BIT) && ops.depthOps.loadOpD != VK_ATTACHMENT_LOAD_OP_LOAD)
+         || ((depthAspects & VK_IMAGE_ASPECT_STENCIL_BIT) && ops.depthOps.loadOpS != VK_ATTACHMENT_LOAD_OP_LOAD)
+         || (layout != VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL))
+          depthAccess |= VK_ACCESS_2_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+
+        if (layout != VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL) {
+          depthStages |= m_device->getShaderPipelineStages();
+          depthAccess |= VK_ACCESS_2_SHADER_READ_BIT;
+        }
+
+        accessImage(DxvkCmdBuffer::ExecBuffer,
+          *depthAttachment.view->image(),
+          depthAttachment.view->imageSubresources(),
+          ops.depthOps.loadLayout,
+          depthStages, 0, layout,
+          depthStages, depthAccess, DxvkAccessOp::None);
       }
-
-      accessImage(DxvkCmdBuffer::ExecBuffer,
-        *depthAttachment.view->image(),
-        depthAttachment.view->imageSubresources(),
-        ops.depthOps.loadLayout,
-        depthStages, 0,
-        depthAttachment.layout,
-        depthStages, depthAccess, DxvkAccessOp::None);
     }
 
     for (uint32_t i = 0; i < MaxNumRenderTargets; i++) {
       const auto& colorAttachment = framebufferInfo.getColorTarget(i);
 
-      if (colorAttachment.layout != ops.colorOps[i].loadLayout
-       && colorAttachment.view != nullptr) {
-        VkAccessFlags2 colorAccess = VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT;
+      if (colorAttachment.view) {
+        VkImageLayout layout = colorAttachment.view->getLayout();
 
-        if (ops.colorOps[i].loadOp == VK_ATTACHMENT_LOAD_OP_LOAD)
-          colorAccess |= VK_ACCESS_2_COLOR_ATTACHMENT_READ_BIT;
+        if (layout != ops.colorOps[i].loadLayout) {
+          VkAccessFlags2 colorAccess = VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT;
 
-        accessImage(DxvkCmdBuffer::ExecBuffer,
-          *colorAttachment.view->image(),
-          colorAttachment.view->imageSubresources(),
-          ops.colorOps[i].loadLayout,
-          VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT, 0,
-          colorAttachment.layout,
-          VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT,
-          colorAccess, DxvkAccessOp::None);
+          if (ops.colorOps[i].loadOp == VK_ATTACHMENT_LOAD_OP_LOAD)
+            colorAccess |= VK_ACCESS_2_COLOR_ATTACHMENT_READ_BIT;
+
+          accessImage(DxvkCmdBuffer::ExecBuffer,
+            *colorAttachment.view->image(),
+            colorAttachment.view->imageSubresources(),
+            ops.colorOps[i].loadLayout,
+            VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT, 0, layout,
+            VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT,
+            colorAccess, DxvkAccessOp::None);
+        }
       }
     }
 
@@ -5866,16 +5869,16 @@ namespace dxvk {
     const DxvkRenderPassOps&    ops) {
     const auto& depthAttachment = framebufferInfo.getDepthTarget();
 
-    if (depthAttachment.view != nullptr) {
+    if (depthAttachment.view) {
+      VkImageLayout srcLayout = depthAttachment.view->getLayout();
       VkAccessFlags2 srcAccess = VK_ACCESS_2_DEPTH_STENCIL_ATTACHMENT_READ_BIT;
 
-      if (depthAttachment.layout != VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL)
+      if (srcLayout != VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL)
         srcAccess |= VK_ACCESS_2_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
 
       accessImage(DxvkCmdBuffer::ExecBuffer,
         *depthAttachment.view->image(),
-        depthAttachment.view->imageSubresources(),
-        depthAttachment.layout,
+        depthAttachment.view->imageSubresources(), srcLayout,
         VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT |
         VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT,
         srcAccess, ops.depthOps.storeLayout,
@@ -5887,11 +5890,11 @@ namespace dxvk {
     for (uint32_t i = 0; i < MaxNumRenderTargets; i++) {
       const auto& colorAttachment = framebufferInfo.getColorTarget(i);
 
-      if (colorAttachment.view != nullptr) {
+      if (colorAttachment.view) {
         accessImage(DxvkCmdBuffer::ExecBuffer,
           *colorAttachment.view->image(),
           colorAttachment.view->imageSubresources(),
-          colorAttachment.layout,
+          colorAttachment.view->getLayout(),
           VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT,
           VK_ACCESS_2_COLOR_ATTACHMENT_READ_BIT |
           VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT,
@@ -5938,7 +5941,7 @@ namespace dxvk {
         colorFormats[i] = colorTarget.view->info().format;
 
         colorInfo.imageView = colorTarget.view->handle();
-        colorInfo.imageLayout = colorTarget.layout;
+        colorInfo.imageLayout = colorTarget.view->getLayout();
         colorInfo.loadOp = ops.colorOps[i].loadOp;
         colorInfo.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
 
@@ -5976,13 +5979,13 @@ namespace dxvk {
     if (depthTarget.view) {
       depthStencilFormat = depthTarget.view->info().format;
       depthStencilAspects = depthTarget.view->info().aspects;
-      depthStencilWritable = vk::getWritableAspectsForLayout(depthTarget.layout);
+      depthStencilWritable = vk::getWritableAspectsForLayout(depthTarget.view->info().layout);
 
       if (!m_device->properties().khrMaintenance7.separateDepthStencilAttachmentAccess && depthStencilWritable)
         depthStencilWritable = depthStencilAspects;
 
       depthInfo.imageView = depthTarget.view->handle();
-      depthInfo.imageLayout = depthTarget.layout;
+      depthInfo.imageLayout = depthTarget.view->getLayout();
       depthInfo.loadOp = ops.depthOps.loadOpD;
       depthInfo.storeOp = (depthStencilWritable & VK_IMAGE_ASPECT_DEPTH_BIT)
         ? VK_ATTACHMENT_STORE_OP_STORE : VK_ATTACHMENT_STORE_OP_NONE;
@@ -6083,7 +6086,7 @@ namespace dxvk {
         VkImageSubresourceRange subresources = attachment.view->imageSubresources();
 
         if (subresources.aspectMask & (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT))
-          subresources.aspectMask = vk::getWritableAspectsForLayout(attachment.layout);
+          subresources.aspectMask = vk::getWritableAspectsForLayout(attachment.view->info().layout);
 
         m_implicitResolves.invalidate(*attachment.view->image(), subresources);
       }
@@ -6126,20 +6129,20 @@ namespace dxvk {
   void DxvkContext::resetRenderPassOps(
     const DxvkRenderTargets&    renderTargets,
           DxvkRenderPassOps&    renderPassOps) {
-    if (renderTargets.depth.view != nullptr) {
+    if (renderTargets.depth.view) {
+      VkImageLayout layout = renderTargets.depth.view->getLayout();
+
       renderPassOps.depthOps = DxvkDepthAttachmentOps {
-        VK_ATTACHMENT_LOAD_OP_LOAD, VK_ATTACHMENT_LOAD_OP_LOAD,
-        renderTargets.depth.layout, renderTargets.depth.layout };
+        VK_ATTACHMENT_LOAD_OP_LOAD, VK_ATTACHMENT_LOAD_OP_LOAD, layout, layout };
     } else {
       renderPassOps.depthOps = DxvkDepthAttachmentOps { };
     }
     
     for (uint32_t i = 0; i < MaxNumRenderTargets; i++) {
-      if (renderTargets.color[i].view != nullptr) {
+      if (renderTargets.color[i].view) {
+        VkImageLayout layout = renderTargets.color[i].view->getLayout();
         renderPassOps.colorOps[i] = DxvkColorAttachmentOps {
-            VK_ATTACHMENT_LOAD_OP_LOAD,
-            renderTargets.color[i].layout,
-            renderTargets.color[i].layout };
+            VK_ATTACHMENT_LOAD_OP_LOAD, layout, layout };
       } else {
         renderPassOps.colorOps[i] = DxvkColorAttachmentOps { };
       }
@@ -6527,7 +6530,7 @@ namespace dxvk {
     const auto* pipelineLayout = layout->getLayout();
 
     // Ensure that the arrays we write descriptor info to are big enough
-    if (unlikely(layout->getDescriptorCount() > m_descriptors.size()))
+    if (unlikely(layout->getDescriptorCount() > m_descriptorInfos.size()))
       this->resizeDescriptorArrays(layout->getDescriptorCount());
 
     // On 32-bit wine, vkUpdateDescriptorSets has significant overhead due
@@ -6562,7 +6565,7 @@ namespace dxvk {
           descriptorWrite.descriptorType = binding.getDescriptorType();
         }
 
-        auto& descriptorInfo = m_descriptors[descriptorCount++];
+        auto& descriptorInfo = m_descriptorInfos[descriptorCount++];
 
         if (binding.isUniformBuffer()) {
           const auto& slice = m_uniformBuffers[binding.getResourceIndex()];
@@ -6601,17 +6604,14 @@ namespace dxvk {
 
             case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE: {
               const auto& res = m_resources[binding.getResourceIndex()];
+              const DxvkDescriptor* descriptor = nullptr;
 
-              VkImageView viewHandle = VK_NULL_HANDLE;
+              if (res.imageView)
+                descriptor = res.imageView->getDescriptor(binding.getViewType());
 
-              if (res.imageView != nullptr)
-                viewHandle = res.imageView->handle(binding.getViewType());
-
-              if (viewHandle) {
+              if (descriptor) {
                 if (likely(!res.imageView->isMultisampled() || binding.isMultisampled())) {
-                  descriptorInfo.image.sampler = VK_NULL_HANDLE;
-                  descriptorInfo.image.imageView = viewHandle;
-                  descriptorInfo.image.imageLayout = res.imageView->defaultLayout();
+                  descriptorInfo = descriptor->legacy;
 
                   if (BindPoint == VK_PIPELINE_BIND_POINT_COMPUTE || unlikely(res.imageView->hasGfxStores())) {
                     accessImage(DxvkCmdBuffer::ExecBuffer, *res.imageView,
@@ -6622,9 +6622,7 @@ namespace dxvk {
                 } else {
                   auto view = m_implicitResolves.getResolveView(*res.imageView, m_trackingId);
 
-                  descriptorInfo.image.sampler = VK_NULL_HANDLE;
-                  descriptorInfo.image.imageView = view->handle(binding.getViewType());
-                  descriptorInfo.image.imageLayout = view->defaultLayout();
+                  descriptorInfo = view->getDescriptor(binding.getViewType())->legacy;
 
                   m_cmd->track(view->image(), DxvkAccess::Read);
                 }
@@ -6637,16 +6635,13 @@ namespace dxvk {
 
             case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE: {
               const auto& res = m_resources[binding.getResourceIndex()];
+              const DxvkDescriptor* descriptor = nullptr;
 
-              VkImageView viewHandle = VK_NULL_HANDLE;
+              if (res.imageView)
+                descriptor = res.imageView->getDescriptor(binding.getViewType());
 
-              if (res.imageView != nullptr)
-                viewHandle = res.imageView->handle(binding.getViewType());
-
-              if (viewHandle) {
-                descriptorInfo.image.sampler = VK_NULL_HANDLE;
-                descriptorInfo.image.imageView = viewHandle;
-                descriptorInfo.image.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+              if (descriptor) {
+                descriptorInfo = descriptor->legacy;
 
                 if (BindPoint == VK_PIPELINE_BIND_POINT_COMPUTE || res.imageView->hasGfxStores()) {
                   accessImage(DxvkCmdBuffer::ExecBuffer, *res.imageView,
@@ -6666,16 +6661,17 @@ namespace dxvk {
               const auto& res = m_resources[binding.getResourceIndex()];
               const auto& sampler = m_samplers[binding.getResourceIndex()];
 
-              VkImageView viewHandle = VK_NULL_HANDLE;
+              const DxvkDescriptor* descriptor = nullptr;
 
               if (res.imageView && sampler)
-                viewHandle = res.imageView->handle(binding.getViewType());
+                descriptor = res.imageView->getDescriptor(binding.getViewType());
 
-              if (viewHandle) {
+              if (descriptor) {
+                descriptorInfo.image.sampler = sampler->handle();
+
                 if (likely(!res.imageView->isMultisampled() || binding.isMultisampled())) {
-                  descriptorInfo.image.sampler = sampler->handle();
-                  descriptorInfo.image.imageView = viewHandle;
-                  descriptorInfo.image.imageLayout = res.imageView->defaultLayout();
+                  descriptorInfo.image.imageView = descriptor->legacy.image.imageView;
+                  descriptorInfo.image.imageLayout = descriptor->legacy.image.imageLayout;
 
                   if (BindPoint == VK_PIPELINE_BIND_POINT_COMPUTE || unlikely(res.imageView->hasGfxStores())) {
                     accessImage(DxvkCmdBuffer::ExecBuffer, *res.imageView,
@@ -6686,10 +6682,10 @@ namespace dxvk {
                   m_cmd->track(sampler);
                 } else {
                   auto view = m_implicitResolves.getResolveView(*res.imageView, m_trackingId);
+                  descriptor = view->getDescriptor(binding.getViewType());
 
-                  descriptorInfo.image.sampler = sampler->handle();
-                  descriptorInfo.image.imageView = view->handle(binding.getViewType());
-                  descriptorInfo.image.imageLayout = view->defaultLayout();
+                  descriptorInfo.image.imageView = descriptor->legacy.image.imageView;
+                  descriptorInfo.image.imageLayout = descriptor->legacy.image.imageLayout;
 
                   m_cmd->track(view->image(), DxvkAccess::Read);
                   m_cmd->track(sampler);
@@ -6705,7 +6701,7 @@ namespace dxvk {
               const auto& res = m_resources[binding.getResourceIndex()];
 
               if (res.bufferView != nullptr) {
-                descriptorInfo.texelBuffer = res.bufferView->handle();
+                descriptorInfo.bufferView = res.bufferView->handle();
 
                 if (BindPoint == VK_PIPELINE_BIND_POINT_COMPUTE || unlikely(res.bufferView->buffer()->hasGfxStores())) {
                   accessBuffer(DxvkCmdBuffer::ExecBuffer, *res.bufferView,
@@ -6715,7 +6711,7 @@ namespace dxvk {
                 m_cmd->track(res.bufferView->buffer(), DxvkAccess::Read);
 
               } else {
-                descriptorInfo.texelBuffer = VK_NULL_HANDLE;
+                descriptorInfo.bufferView = VK_NULL_HANDLE;
               }
             } break;
 
@@ -6723,7 +6719,7 @@ namespace dxvk {
               const auto& res = m_resources[binding.getResourceIndex()];
 
               if (res.bufferView != nullptr) {
-                descriptorInfo.texelBuffer = res.bufferView->handle();
+                descriptorInfo.bufferView = res.bufferView->handle();
 
                 if (BindPoint == VK_PIPELINE_BIND_POINT_COMPUTE || res.bufferView->buffer()->hasGfxStores()) {
                   accessBuffer(DxvkCmdBuffer::ExecBuffer, *res.bufferView,
@@ -6733,7 +6729,7 @@ namespace dxvk {
                 m_cmd->track(res.bufferView->buffer(), (binding.getAccess() & vk::AccessWriteMask)
                   ? DxvkAccess::Write : DxvkAccess::Read);
               } else {
-                descriptorInfo.texelBuffer = VK_NULL_HANDLE;
+                descriptorInfo.bufferView = VK_NULL_HANDLE;
               }
             } break;
 
@@ -6785,7 +6781,7 @@ namespace dxvk {
       if (useDescriptorTemplates) {
         m_cmd->updateDescriptorSetWithTemplate(sets[setIndex],
           pipelineLayout->getDescriptorSetLayout(setIndex)->getSetUpdateTemplate(),
-          &m_descriptors[0]);
+          &m_descriptorInfos[0]);
         descriptorCount = 0;
       }
 
@@ -8401,16 +8397,16 @@ namespace dxvk {
 
   void DxvkContext::resizeDescriptorArrays(
           uint32_t                  bindingCount) {
-    m_descriptors.resize(bindingCount);
+    m_descriptorInfos.resize(bindingCount);
     m_descriptorWrites.resize(bindingCount);
 
     for (uint32_t i = 0; i < bindingCount; i++) {
       m_descriptorWrites[i] = { VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET };
       m_descriptorWrites[i].descriptorCount = 1;
       m_descriptorWrites[i].descriptorType = VK_DESCRIPTOR_TYPE_MAX_ENUM;
-      m_descriptorWrites[i].pImageInfo = &m_descriptors[i].image;
-      m_descriptorWrites[i].pBufferInfo = &m_descriptors[i].buffer;
-      m_descriptorWrites[i].pTexelBufferView = &m_descriptors[i].texelBuffer;
+      m_descriptorWrites[i].pImageInfo = &m_descriptorInfos[i].image;
+      m_descriptorWrites[i].pBufferInfo = &m_descriptorInfos[i].buffer;
+      m_descriptorWrites[i].pTexelBufferView = &m_descriptorInfos[i].bufferView;
     }
   }
 

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -153,25 +153,15 @@ namespace dxvk {
             DxvkRenderTargets&&   targets,
             VkImageAspectFlags    feedbackLoop) {
 
-      m_state.om.renderTargets = std::move(targets);
+      if (likely(m_state.om.renderTargets != targets)) {
+        m_state.om.renderTargets = std::move(targets);
 
-      if (unlikely(m_state.gp.state.om.feedbackLoop() != feedbackLoop)) {
-        m_state.gp.state.om.setFeedbackLoop(feedbackLoop);
-        m_flags.set(DxvkContextFlag::GpDirtyPipelineState);
-      }
+        if (unlikely(m_state.gp.state.om.feedbackLoop() != feedbackLoop)) {
+          m_state.gp.state.om.setFeedbackLoop(feedbackLoop);
+          m_flags.set(DxvkContextFlag::GpDirtyPipelineState);
+        }
 
-      this->resetRenderPassOps(
-        m_state.om.renderTargets,
-        m_state.om.renderPassOps);
-
-      if (!m_state.om.framebufferInfo.hasTargets(m_state.om.renderTargets)) {
-        // Create a new framebuffer object next
-        // time we start rendering something
-        m_flags.set(DxvkContextFlag::GpDirtyFramebuffer);
-      } else {
-        // Don't redundantly spill the render pass if
-        // the same render targets are bound again
-        m_flags.clr(DxvkContextFlag::GpDirtyFramebuffer);
+        m_flags.set(DxvkContextFlag::GpDirtyRenderTargets);
       }
     }
 
@@ -1722,8 +1712,8 @@ namespace dxvk {
     DxvkFramebufferInfo makeFramebufferInfo(
       const DxvkRenderTargets&      renderTargets);
 
-    void updateFramebuffer(bool isDraw = false);
-    
+    void updateRenderTargets(bool isDraw = false);
+
     void applyRenderTargetLoadLayouts();
 
     void applyRenderTargetStoreLayouts();

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -152,15 +152,8 @@ namespace dxvk {
     void bindRenderTargets(
             DxvkRenderTargets&&   targets,
             VkImageAspectFlags    feedbackLoop) {
-      // Set up default render pass ops and normalize layouts
+
       m_state.om.renderTargets = std::move(targets);
-
-      for (uint32_t i = 0; i < MaxNumRenderTargets; i++) {
-        auto& rt = m_state.om.renderTargets.color[i];
-
-        if (rt.view)
-          rt.layout = rt.view->pickLayout(rt.layout);
-      }
 
       if (unlikely(m_state.gp.state.om.feedbackLoop() != feedbackLoop)) {
         m_state.gp.state.om.setFeedbackLoop(feedbackLoop);
@@ -1413,7 +1406,7 @@ namespace dxvk {
     std::array<DxvkDeferredResolve, MaxNumRenderTargets + 1u> m_deferredResolves = { };
 
     std::vector<VkWriteDescriptorSet> m_descriptorWrites;
-    std::vector<DxvkDescriptorInfo>   m_descriptors;
+    std::vector<DxvkLegacyDescriptor> m_descriptorInfos;
 
     std::array<Rc<DxvkSampler>, MaxNumSamplerSlots> m_samplers;
     std::array<DxvkBufferSlice, MaxNumUniformBufferSlots> m_uniformBuffers;

--- a/src/dxvk/dxvk_context_state.h
+++ b/src/dxvk/dxvk_context_state.h
@@ -27,7 +27,7 @@ namespace dxvk {
     GpRenderPassSideEffects,    ///< Render pass has side effects
     GpRenderPassNeedsFlush,     ///< Render pass has pending resolves or discards
     GpXfbActive,                ///< Transform feedback is enabled
-    GpDirtyFramebuffer,         ///< Framebuffer binding is out of date
+    GpDirtyRenderTargets,       ///< Bound render targets are out of date
     GpDirtyPipeline,            ///< Graphics pipeline binding is out of date
     GpDirtyPipelineState,       ///< Graphics pipeline needs to be recompiled
     GpDirtyVertexBuffers,       ///< Vertex buffer bindings are out of date

--- a/src/dxvk/dxvk_descriptor.h
+++ b/src/dxvk/dxvk_descriptor.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "dxvk_include.h"
+#include "dxvk_limits.h"
+
+namespace dxvk {
+
+  /**
+   * \brief Legacy Vulkan descriptor info
+   *
+   * This structure can be used directly with
+   * descriptor update templates.
+   */
+  union DxvkLegacyDescriptor {
+    VkDescriptorBufferInfo buffer;
+    VkDescriptorImageInfo image;
+    VkBufferView bufferView;
+  };
+
+
+  /**
+   * \brief Descriptor info
+   *
+   * Stores a resource or view descriptor.
+   */
+  union DxvkDescriptor {
+    DxvkLegacyDescriptor legacy;
+  };
+
+}

--- a/src/dxvk/dxvk_descriptor_pool.h
+++ b/src/dxvk/dxvk_descriptor_pool.h
@@ -2,7 +2,7 @@
 
 #include <vector>
 
-#include "dxvk_include.h"
+#include "dxvk_descriptor.h"
 #include "dxvk_pipelayout.h"
 #include "dxvk_recycler.h"
 #include "dxvk_stats.h"
@@ -11,19 +11,6 @@ namespace dxvk {
 
   class DxvkDevice;
   class DxvkDescriptorPoolSet;
-  
-  /**
-   * \brief Descriptor info
-   * 
-   * Stores information that is required to
-   * update a single resource descriptor.
-   */
-  union DxvkDescriptorInfo {
-    VkDescriptorImageInfo  image;
-    VkDescriptorBufferInfo buffer;
-    VkBufferView           texelBuffer;
-  };
-  
   
   /**
    * \brief Descriptor set list

--- a/src/dxvk/dxvk_framebuffer.cpp
+++ b/src/dxvk/dxvk_framebuffer.cpp
@@ -43,13 +43,10 @@ namespace dxvk {
 
 
   bool DxvkFramebufferInfo::hasTargets(const DxvkRenderTargets& renderTargets) {
-    bool eq = m_renderTargets.depth.view   == renderTargets.depth.view
-           && m_renderTargets.depth.layout == renderTargets.depth.layout;
+    bool eq = m_renderTargets.depth.view   == renderTargets.depth.view;
 
-    for (uint32_t i = 0; i < MaxNumRenderTargets && eq; i++) {
-      eq &= m_renderTargets.color[i].view   == renderTargets.color[i].view
-         && m_renderTargets.color[i].layout == renderTargets.color[i].layout;
-    }
+    for (uint32_t i = 0; i < MaxNumRenderTargets && eq; i++)
+      eq &= m_renderTargets.color[i].view   == renderTargets.color[i].view;
 
     return eq;
   }
@@ -63,7 +60,15 @@ namespace dxvk {
 
 
   bool DxvkFramebufferInfo::isWritable(uint32_t attachmentIndex, VkImageAspectFlags aspects) const {
-    VkImageAspectFlags writableAspects = vk::getWritableAspectsForLayout(getAttachment(attachmentIndex).layout);
+    const auto& attachment = getAttachment(attachmentIndex);
+
+    if (!attachment.view)
+      return false;
+
+    /* Check the layout that the view was created for, not the view that we
+     * actually selected for rendering since that may lose information about
+     * the writable aspects. */
+    VkImageAspectFlags writableAspects = vk::getWritableAspectsForLayout(attachment.view->info().layout);
     return (writableAspects & aspects) == aspects;
   }
 
@@ -72,10 +77,10 @@ namespace dxvk {
     VkFormat depthStencilFormat = VK_FORMAT_UNDEFINED;
     VkImageAspectFlags depthStencilReadOnlyAspects = 0;
 
-    if (m_renderTargets.depth.view != nullptr) {
+    if (m_renderTargets.depth.view) {
       depthStencilFormat = m_renderTargets.depth.view->info().format;
       depthStencilReadOnlyAspects = m_renderTargets.depth.view->formatInfo()->aspectMask
-        & ~vk::getWritableAspectsForLayout(m_renderTargets.depth.layout);
+        & ~vk::getWritableAspectsForLayout(m_renderTargets.depth.view->info().layout);
     }
 
     std::array<VkFormat, MaxNumRenderTargets> colorFormats = { };

--- a/src/dxvk/dxvk_framebuffer.cpp
+++ b/src/dxvk/dxvk_framebuffer.cpp
@@ -42,16 +42,6 @@ namespace dxvk {
   }
 
 
-  bool DxvkFramebufferInfo::hasTargets(const DxvkRenderTargets& renderTargets) {
-    bool eq = m_renderTargets.depth.view   == renderTargets.depth.view;
-
-    for (uint32_t i = 0; i < MaxNumRenderTargets && eq; i++)
-      eq &= m_renderTargets.color[i].view   == renderTargets.color[i].view;
-
-    return eq;
-  }
-
-
   bool DxvkFramebufferInfo::isFullSize(const Rc<DxvkImageView>& view) const {
     return m_renderSize.width  == view->mipLevelExtent(0).width
         && m_renderSize.height == view->mipLevelExtent(0).height

--- a/src/dxvk/dxvk_framebuffer.h
+++ b/src/dxvk/dxvk_framebuffer.h
@@ -24,12 +24,9 @@ namespace dxvk {
   /**
    * \brief Framebuffer attachment
    * 
-   * Stores an attachment, as well as the image layout
-   * that will be used for rendering to the attachment.
    */
   struct DxvkAttachment {
     Rc<DxvkImageView> view    = nullptr;
-    VkImageLayout     layout  = VK_IMAGE_LAYOUT_UNDEFINED;
   };
   
   

--- a/src/dxvk/dxvk_framebuffer.h
+++ b/src/dxvk/dxvk_framebuffer.h
@@ -26,7 +26,10 @@ namespace dxvk {
    * 
    */
   struct DxvkAttachment {
-    Rc<DxvkImageView> view    = nullptr;
+    Rc<DxvkImageView> view = nullptr;
+
+    bool operator == (const DxvkAttachment& other) const { return view == other.view; }
+    bool operator != (const DxvkAttachment& other) const { return view != other.view; }
   };
   
   
@@ -39,6 +42,19 @@ namespace dxvk {
   struct DxvkRenderTargets {
     DxvkAttachment depth;
     DxvkAttachment color[MaxNumRenderTargets];
+
+    bool operator == (const DxvkRenderTargets& other) const {
+      bool eq = depth == other.depth;
+
+      for (uint32_t i = 0; i < MaxNumRenderTargets && eq; i++)
+        eq = color[i] == other.color[i];
+
+      return eq;
+    }
+
+    bool operator != (const DxvkRenderTargets& other) const {
+      return !(this->operator == (other));
+    }
   };
 
 
@@ -161,15 +177,6 @@ namespace dxvk {
      * \returns Attachment index
      */
     int32_t findAttachment(const Rc<DxvkImageView>& view) const;
-
-    /**
-     * \brief Checks whether the framebuffer's targets match
-     *
-     * \param [in] renderTargets Render targets to check
-     * \returns \c true if the render targets are the same
-     *          as the ones used for this framebuffer object.
-     */
-    bool hasTargets(const DxvkRenderTargets& renderTargets);
 
     /**
      * \brief Checks whether view and framebuffer sizes match

--- a/src/dxvk/dxvk_image.cpp
+++ b/src/dxvk/dxvk_image.cpp
@@ -447,6 +447,34 @@ namespace dxvk {
     const DxvkImageViewKey&         key)
   : m_image   (image),
     m_key     (key) {
+    // If the view does not define a layout, figure out a suitable
+    // layout based on image view usage and image prperties. This
+    // will be good enough in most situations.
+    if (!m_key.layout) {
+      switch (m_key.usage) {
+        case VK_IMAGE_USAGE_SAMPLED_BIT:
+          m_key.layout = (m_image->formatInfo()->aspectMask & (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT))
+            ? VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL
+            : VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+          break;
+
+        case VK_IMAGE_USAGE_STORAGE_BIT:
+          m_key.layout = VK_IMAGE_LAYOUT_GENERAL;
+          break;
+
+        case VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT:
+          m_key.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+          break;
+
+        case VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT:
+          m_key.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+          break;
+
+        default:
+          break;
+      }
+    }
+
     updateProperties();
   }
 
@@ -456,7 +484,7 @@ namespace dxvk {
   }
 
 
-  VkImageView DxvkImageView::createView(VkImageViewType type) const {
+  const DxvkDescriptor* DxvkImageView::createView(VkImageViewType type) const {
     constexpr VkImageUsageFlags ViewUsage =
       VK_IMAGE_USAGE_SAMPLED_BIT |
       VK_IMAGE_USAGE_STORAGE_BIT |
@@ -467,10 +495,10 @@ namespace dxvk {
     // objects so that some internal APIs can be more consistent.
     DxvkImageViewKey key = m_key;
     key.viewType = type;
-    key.usage &= ViewUsage;
+    key.layout = getLayout();
 
-    if (!key.usage)
-      return VK_NULL_HANDLE;
+    if (!(key.usage & ViewUsage))
+      return nullptr;
 
     // Only use one layer for non-arrayed view types
     if (type == VK_IMAGE_VIEW_TYPE_1D || type == VK_IMAGE_VIEW_TYPE_2D)
@@ -480,20 +508,20 @@ namespace dxvk {
       case VK_IMAGE_TYPE_1D: {
         // Trivial, just validate that view types are compatible
         if (type != VK_IMAGE_VIEW_TYPE_1D && type != VK_IMAGE_VIEW_TYPE_1D_ARRAY)
-          return VK_NULL_HANDLE;
+          return nullptr;
       } break;
 
       case VK_IMAGE_TYPE_2D: {
         if (type == VK_IMAGE_VIEW_TYPE_CUBE || type == VK_IMAGE_VIEW_TYPE_CUBE_ARRAY) {
           // Ensure that the image is compatible with cube maps
           if (key.layerCount < 6 || !(m_image->info().flags & VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT))
-            return VK_NULL_HANDLE;
+            return nullptr;
 
           // Adjust layer count to make sure it's a multiple of 6
           key.layerCount = type == VK_IMAGE_VIEW_TYPE_CUBE_ARRAY
             ? key.layerCount - key.layerCount % 6u : 6u;
         } else if (type != VK_IMAGE_VIEW_TYPE_2D && type != VK_IMAGE_VIEW_TYPE_2D_ARRAY) {
-          return VK_NULL_HANDLE;
+          return nullptr;
         }
       } break;
 
@@ -501,25 +529,25 @@ namespace dxvk {
         if (type == VK_IMAGE_VIEW_TYPE_2D || type == VK_IMAGE_VIEW_TYPE_2D_ARRAY) {
           // Ensure that the image is actually compatible with 2D views
           if (!(m_image->info().flags & VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT))
-            return VK_NULL_HANDLE;
+            return nullptr;
 
           // In case the view's native type is 3D, we can only create 2D compat
           // views if there is only one mip and with the full set of array layers.
           if (m_key.viewType == VK_IMAGE_VIEW_TYPE_3D) {
             if (m_key.mipCount != 1u)
-              return VK_NULL_HANDLE;
+              return nullptr;
 
             key.layerIndex = 0u;
             key.layerCount = type == VK_IMAGE_VIEW_TYPE_2D_ARRAY
               ? m_image->mipLevelExtent(key.mipIndex).depth : 1u;
           }
         } else if (type != VK_IMAGE_VIEW_TYPE_3D) {
-          return VK_NULL_HANDLE;
+          return nullptr;
         }
       } break;
 
       default:
-        return VK_NULL_HANDLE;
+        return nullptr;
     }
 
     // We need to expose RT and UAV swizzles to the backend,

--- a/src/dxvk/dxvk_image.h
+++ b/src/dxvk/dxvk_image.h
@@ -139,6 +139,28 @@ namespace dxvk {
     void decRef();
 
     /**
+     * \brief Image view descriptor for the default type
+     *
+     * The default view type is guaranteed to be
+     * supported by the image view, and should be
+     * preferred over picking a different type.
+     * \returns Image view handle
+     */
+    const DxvkDescriptor* getDescriptor() {
+      return getDescriptor(m_key.viewType);
+    }
+
+    /**
+     * \brief Image view handle for a given view type
+     *
+     * If the view does not support the requested image
+     * view type, \c VK_NULL_HANDLE will be returned.
+     * \param [in] viewType The requested view type
+     * \returns The image view handle
+     */
+    const DxvkDescriptor* getDescriptor(VkImageViewType viewType);
+
+    /**
      * \brief Image view handle for the default type
      *
      * The default view type is guaranteed to be
@@ -158,7 +180,10 @@ namespace dxvk {
      * \param [in] viewType The requested view type
      * \returns The image view handle
      */
-    VkImageView handle(VkImageViewType viewType);
+    VkImageView handle(VkImageViewType viewType) {
+      auto descriptor = getDescriptor(viewType);
+      return likely(descriptor) ? descriptor->legacy.image.imageView : VK_NULL_HANDLE;
+    }
 
     /**
      * \brief Image view type
@@ -234,27 +259,6 @@ namespace dxvk {
     VkImageSubresourceRange imageSubresources() const;
 
     /**
-     * \brief Picks an image layout
-     * \see DxvkImage::pickLayout
-     */
-    VkImageLayout pickLayout(VkImageLayout layout) const;
-
-    /**
-     * \brief Retrieves descriptor info
-     * 
-     * \param [in] type Exact view type
-     * \param [in] layout Image layout
-     * \returns Image descriptor
-     */
-    DxvkDescriptorInfo getDescriptor(VkImageViewType type, VkImageLayout layout) {
-      DxvkDescriptorInfo result;
-      result.image.sampler = VK_NULL_HANDLE;
-      result.image.imageView = handle(type);
-      result.image.imageLayout = layout;
-      return result;
-    }
-
-    /**
      * \brief Checks whether this view matches another
      *
      * \param [in] view The other view to check
@@ -319,6 +323,15 @@ namespace dxvk {
     }
 
     /**
+     * \brief Queries the view layout
+     *
+     * If no layout was explicitly specified for the view, this
+     * will return a suitable layout for the given usage.
+     * \returns Image view layout
+     */
+    VkImageLayout getLayout() const;
+
+    /**
      * \brief Queries the default image layout
      *
      * Used when binding the view as a descriptor.
@@ -353,12 +366,12 @@ namespace dxvk {
 
     DxvkImageViewImageProperties m_properties = { };
 
-    std::array<VkImageView, ViewCount> m_views = { };
+    std::array<const DxvkDescriptor*, ViewCount> m_views = { };
 
     uint32_t m_rtBindingFrameId    = 0;
     uint32_t m_rtBindingFrameCount = 0;
 
-    VkImageView createView(VkImageViewType type) const;
+    const DxvkDescriptor* createView(VkImageViewType type) const;
 
     void updateViews();
 
@@ -821,12 +834,7 @@ namespace dxvk {
   }
 
 
-  inline VkImageLayout DxvkImageView::pickLayout(VkImageLayout layout) const {
-    return m_image->pickLayout(layout);
-  }
-
-
-  inline VkImageView DxvkImageView::handle(VkImageViewType viewType) {
+  inline const DxvkDescriptor* DxvkImageView::getDescriptor(VkImageViewType viewType) {
     viewType = viewType != VK_IMAGE_VIEW_TYPE_MAX_ENUM ? viewType : m_key.viewType;
 
     if (unlikely(m_version < m_image->m_version))
@@ -836,6 +844,11 @@ namespace dxvk {
       m_views[viewType] = createView(viewType);
 
     return m_views[viewType];
+  }
+
+
+  inline VkImageLayout DxvkImageView::getLayout() const {
+    return m_image->pickLayout(m_key.layout);
   }
 
 

--- a/src/dxvk/dxvk_memory.cpp
+++ b/src/dxvk/dxvk_memory.cpp
@@ -103,18 +103,18 @@ namespace dxvk {
 
   DxvkResourceImageViewMap::~DxvkResourceImageViewMap() {
     for (const auto& view : m_views)
-      m_vkd->vkDestroyImageView(m_vkd->device(), view.second, nullptr);
+      m_vkd->vkDestroyImageView(m_vkd->device(), view.second.legacy.image.imageView, nullptr);
   }
 
 
-  VkImageView DxvkResourceImageViewMap::createImageView(
+  const DxvkDescriptor* DxvkResourceImageViewMap::createImageView(
     const DxvkImageViewKey&           key) {
     std::lock_guard lock(m_mutex);
 
     auto entry = m_views.find(key);
 
     if (entry != m_views.end())
-      return entry->second;
+      return &entry->second;
 
     VkImageViewUsageCreateInfo usage = { VK_STRUCTURE_TYPE_IMAGE_VIEW_USAGE_CREATE_INFO };
     usage.usage = key.usage;
@@ -130,16 +130,17 @@ namespace dxvk {
     info.subresourceRange.baseArrayLayer = key.layerIndex;
     info.subresourceRange.layerCount = key.layerCount;
 
-    VkImageView view = VK_NULL_HANDLE;
+    DxvkDescriptor descriptor = { };
+    descriptor.legacy.image.imageLayout = key.layout;
 
     VkResult vr = m_vkd->vkCreateImageView(
-      m_vkd->device(), &info, nullptr, &view);
+      m_vkd->device(), &info, nullptr, &descriptor.legacy.image.imageView);
 
     if (vr != VK_SUCCESS)
       throw DxvkError(str::format("Failed to create Vulkan image view: ", vr));
 
-    m_views.insert({ key, view });
-    return view;
+    entry = m_views.insert({ key, descriptor }).first;
+    return &entry->second;
   }
 
 
@@ -185,7 +186,7 @@ namespace dxvk {
   }
 
 
-  VkImageView DxvkResourceAllocation::createImageView(
+  const DxvkDescriptor* DxvkResourceAllocation::createImageView(
     const DxvkImageViewKey&           key) {
     if (unlikely(!m_imageViews))
       m_imageViews = new DxvkResourceImageViewMap(m_allocator, m_image);

--- a/src/dxvk/dxvk_memory.h
+++ b/src/dxvk/dxvk_memory.h
@@ -6,6 +6,7 @@
 #include "dxvk_access.h"
 #include "dxvk_adapter.h"
 #include "dxvk_allocator.h"
+#include "dxvk_descriptor.h"
 #include "dxvk_hash.h"
 
 #include "../util/util_time.h"
@@ -331,9 +332,11 @@ namespace dxvk {
     /// View type
     VkImageViewType viewType = VK_IMAGE_VIEW_TYPE_MAX_ENUM;
     /// View usage flags
-    VkImageUsageFlags usage = 0u;
+    VkImageUsageFlagBits usage = VkImageUsageFlagBits(0u);
     /// View format
     VkFormat format = VK_FORMAT_UNDEFINED;
+    /// Image layout that the view will be used as
+    VkImageLayout layout = VK_IMAGE_LAYOUT_UNDEFINED;
     /// Aspect flags to include in this view
     VkImageAspectFlags aspects = 0u;
     /// First mip
@@ -352,6 +355,7 @@ namespace dxvk {
       hash.add(uint32_t(viewType));
       hash.add(uint32_t(usage));
       hash.add(uint32_t(format));
+      hash.add(uint32_t(layout));
       hash.add(uint32_t(aspects));
       hash.add(uint32_t(mipIndex) | (uint32_t(mipCount) << 16));
       hash.add(uint32_t(layerIndex) | (uint32_t(layerCount) << 16));
@@ -363,6 +367,7 @@ namespace dxvk {
       return viewType == other.viewType
           && usage == other.usage
           && format == other.format
+          && layout == other.layout
           && aspects == other.aspects
           && mipIndex == other.mipIndex
           && mipCount == other.mipCount
@@ -405,9 +410,9 @@ namespace dxvk {
      * \brief Creates an image view
      *
      * \param [in] key View properties
-     * \returns Image view handle
+     * \returns Pointer to descriptor info
      */
-    VkImageView createImageView(
+    const DxvkDescriptor* createImageView(
       const DxvkImageViewKey&           key);
 
   private:
@@ -417,7 +422,7 @@ namespace dxvk {
 
     dxvk::mutex       m_mutex;
     std::unordered_map<DxvkImageViewKey,
-      VkImageView, DxvkHash, DxvkEq> m_views;
+      DxvkDescriptor, DxvkHash, DxvkEq> m_views;
 
   };
 
@@ -615,7 +620,7 @@ namespace dxvk {
      * \param [in] key View properties
      * \returns Image view handle
      */
-    VkImageView createImageView(
+    const DxvkDescriptor* createImageView(
       const DxvkImageViewKey&           key);
 
   private:

--- a/src/dxvk/dxvk_meta_mipgen.h
+++ b/src/dxvk/dxvk_meta_mipgen.h
@@ -51,8 +51,8 @@ namespace dxvk {
      * \param [in] pass Render pass index
      * \returns Source image view handle for the given pass
      */
-    VkImageView getSrcViewHandle(uint32_t passId) const {
-      return m_passes[passId].src->handle();
+    Rc<DxvkImageView> getSrcView(uint32_t passId) const {
+      return m_passes[passId].src;
     }
 
     /**
@@ -61,8 +61,8 @@ namespace dxvk {
      * \param [in] pass Render pass index
      * \returns Destination image view handle for the given pass
      */
-    VkImageView getDstViewHandle(uint32_t passId) const {
-      return m_passes[passId].dst->handle();
+    Rc<DxvkImageView> getDstView(uint32_t passId) const {
+      return m_passes[passId].dst;
     }
 
     /**

--- a/src/dxvk/dxvk_pipelayout.cpp
+++ b/src/dxvk/dxvk_pipelayout.cpp
@@ -74,8 +74,8 @@ namespace dxvk {
         templateInfo.dstArrayElement = 0;
         templateInfo.descriptorCount = entry.getDescriptorCount();
         templateInfo.descriptorType = entry.getDescriptorType();
-        templateInfo.offset = sizeof(DxvkDescriptorInfo) * descriptorCount;
-        templateInfo.stride = sizeof(DxvkDescriptorInfo);
+        templateInfo.offset = sizeof(DxvkLegacyDescriptor) * descriptorCount;
+        templateInfo.stride = sizeof(DxvkLegacyDescriptor);
         templateInfos.push_back(templateInfo);
 
         descriptorCount += entry.getDescriptorCount();

--- a/src/dxvk/dxvk_swapchain_blitter.h
+++ b/src/dxvk/dxvk_swapchain_blitter.h
@@ -226,7 +226,8 @@ namespace dxvk {
     Rc<DxvkSampler>     m_samplerCursorNearest;
 
     Rc<DxvkImage>       m_hudImage;
-    Rc<DxvkImageView>   m_hudView;
+    Rc<DxvkImageView>   m_hudRtv;
+    Rc<DxvkImageView>   m_hudSrv;
 
     const DxvkPipelineLayout* m_blitLayout = nullptr;
     const DxvkPipelineLayout* m_cursorLayout = nullptr;

--- a/src/util/sha1/sha1_util.h
+++ b/src/util/sha1/sha1_util.h
@@ -29,6 +29,10 @@ namespace dxvk {
            | uint32_t(m_digest[4 * id + 2]) << 16
            | uint32_t(m_digest[4 * id + 3]) << 24;
     }
+
+    Sha1Digest digest() const {
+      return m_digest;
+    }
     
     bool operator == (const Sha1Hash& other) const {
       return !std::memcmp(


### PR DESCRIPTION
And later commits.

[7e55c2d](https://github.com/doitsujin/dxvk/commit/7e55c2d169e682280341b033480a80af69459a6c) - [d3d11] Use existing MD5 hash to look up shader objects

[0b4a79d](https://github.com/doitsujin/dxvk/commit/0b4a79dd649830e11ca3335d09c13ba6a95b15c4) - [dxvk] Rename some more descriptor structures - [Descriptor management rework](https://github.com/doitsujin/dxvk/pull/4923)

[a532b6d](https://github.com/doitsujin/dxvk/commit/a532b6d8d61d25ab2525b71e79aa5850db835fe6) - [dxvk] Only allow one image usage bit per view - [Descriptor management rework](https://github.com/doitsujin/dxvk/pull/4923)

[7ffa281](https://github.com/doitsujin/dxvk/commit/7ffa281d3b6c248ae9e4ff5ea939ebcff5aad5d6) - [dxvk] Add image layout property to image view key - [Descriptor management rework](https://github.com/doitsujin/dxvk/pull/4923)

[51dfd04](https://github.com/doitsujin/dxvk/commit/51dfd04e4de30dd8ec7ff4a67d1d4708c50bc537) - [d3d11] Set explicit view layout for RTVs, DSVs and UAVs - [Descriptor management rework](https://github.com/doitsujin/dxvk/pull/4923)

[57abc54](https://github.com/doitsujin/dxvk/commit/57abc542568519dbc30d61ce1d62ce654b58f8ab) - [d3d9] Set explicit view layout for RTVs and DSV - [Descriptor management rework](https://github.com/doitsujin/dxvk/pull/4923)

[6d97353](https://github.com/doitsujin/dxvk/commit/6d973535061f593f4b9c06768ff0e45a0a392287) - [dxvk] Remove render target layout from attachment info - [Descriptor management rework](https://github.com/doitsujin/dxvk/pull/4923)

[677f670](https://github.com/doitsujin/dxvk/commit/677f670301214d1ea1d8a7de50feff3ce334af6f) - [d3d11] Validate buffer size for UpdateSubresource - [Descriptor management rework](https://github.com/doitsujin/dxvk/pull/4923)

[53c495e](https://github.com/doitsujin/dxvk/commit/53c495e88e844c72a0f0644de07d325646248281) - [dxvk] Use plain image view descriptor info for resource updates - [Descriptor management rework](https://github.com/doitsujin/dxvk/pull/4923)

[a7dce4f](https://github.com/doitsujin/dxvk/commit/a7dce4f932a7cfb840fd4017bf081be26d707aca) - [dxvk] Implement equality checks for render target classes - [Render target binding fix](https://github.com/doitsujin/dxvk/pull/4993)

[35d7974](https://github.com/doitsujin/dxvk/commit/35d7974a78e6adc023721294c08c556818cb6205) - [dxvk] Clean up and fix render target updates - [Render target binding fix](https://github.com/doitsujin/dxvk/pull/4993)

[f620939](https://github.com/doitsujin/dxvk/commit/f6209398a83752509b277a460a708c2345273a2c) - [dxvk] Properly end render pass if there are pending resolves