### PR TITLE
Backport upstream DXVK PR#5058 and part of PR#5111

### DIFF
--- a/src/d3d11/d3d11_swapchain.cpp
+++ b/src/d3d11/d3d11_swapchain.cpp
@@ -724,7 +724,9 @@ namespace dxvk {
     uint32_t flHi = (featureLevel >> 12);
     uint32_t flLo = (featureLevel >> 8) & 0x7;
 
-    return str::format("D3D", apiVersion, " FL", flHi, "_", flLo);
+    bool is11On12 = m_parent->Is11on12Device();
+
+    return str::format("D3D", apiVersion, (is11On12 ? "On12" : ""), " FL", flHi, "_", flLo);
   }
 
 }

--- a/src/d3d9/d3d9_adapter.cpp
+++ b/src/d3d9/d3d9_adapter.cpp
@@ -35,6 +35,7 @@ namespace dxvk {
 
   D3D9Adapter::D3D9Adapter(
           D3D9InterfaceEx* pParent,
+    const D3D9ON12_ARGS*   p9On12Args,
           Rc<DxvkAdapter>  Adapter,
           UINT             Ordinal,
           UINT             DisplayIndex)
@@ -48,6 +49,9 @@ namespace dxvk {
     // D3D9VkFormatTable needs to be constructed after we've cached the
     // identifier info and determined the proper vendorID to be used.
     m_d3d9Formats = std::make_unique<D3D9VkFormatTable>(this, Adapter, m_parent->GetOptions());
+
+    if (p9On12Args)
+      m_9On12Args = *p9On12Args;
   }
 
 

--- a/src/d3d9/d3d9_adapter.h
+++ b/src/d3d9/d3d9_adapter.h
@@ -19,6 +19,7 @@ namespace dxvk {
 
     D3D9Adapter(
             D3D9InterfaceEx* pParent,
+      const D3D9ON12_ARGS*   p9On12Args,
             Rc<DxvkAdapter>  Adapter,
             UINT             Ordinal,
             UINT             DisplayIndex);
@@ -93,6 +94,10 @@ namespace dxvk {
       return m_d3d9Formats->GetUnsupportedFormatInfo(Format);
     }
 
+    D3D9ON12_ARGS Get9On12Args() const {
+      return m_9On12Args;
+    }
+
     bool IsExtended() const;
 
     bool IsD3D8Compatible() const;
@@ -143,6 +148,7 @@ namespace dxvk {
     uint32_t                      m_deviceId;
     std::string                   m_deviceDesc;
     std::string                   m_deviceDriver;
+    D3D9ON12_ARGS                 m_9On12Args = { };
 
     std::vector<D3DDISPLAYMODEEX>            m_modes;
     D3D9Format                               m_modeCacheFormat;

--- a/src/d3d9/d3d9_common_texture.cpp
+++ b/src/d3d9/d3d9_common_texture.cpp
@@ -183,6 +183,7 @@ namespace dxvk {
         return D3DERR_INVALIDCALL;
     }
 
+    // Sample counts need to be valid
     VkSampleCountFlagBits sampleCount;
     if (FAILED(DecodeMultiSampleType(pDevice->GetDXVKDevice(), pDesc->MultiSample, pDesc->MultisampleQuality, &sampleCount)))
       return D3DERR_INVALIDCALL;
@@ -240,6 +241,10 @@ namespace dxvk {
     if (pDesc->Format == D3D9Format::ATI2
      && (pDesc->Usage & D3DUSAGE_RENDERTARGET ||
         (pDevice->IsExtended() && isPlainSurface && pDesc->Pool != D3DPOOL_SCRATCH)))
+      return D3DERR_INVALIDCALL;
+
+    // Auto-Mipgen is only valid on textures (for obvious reasons)
+    if ((pDesc->Usage & D3DUSAGE_AUTOGENMIPMAP) && ResourceType == D3DRTYPE_SURFACE)
       return D3DERR_INVALIDCALL;
 
     // Auto-Mipgen is only valid on textures (for obvious reasons)

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -60,6 +60,7 @@ namespace dxvk {
     , m_submissionFence    ( new sync::Fence() )
     , m_flushTracker       ( GetMaxFlushType() )
     , m_d3d9Interop        ( this )
+    , m_d3d9On12Args       ( pAdapter->Get9On12Args() )
     , m_d3d9On12           ( this )
     , m_d3d8Bridge         ( this ) {
 
@@ -240,8 +241,13 @@ namespace dxvk {
     }
 
     if (riid == __uuidof(IDirect3DDevice9On12)) {
-      *ppvObject = ref(&m_d3d9On12);
-      return S_OK;
+      if (m_d3d9On12Args.Enable9On12) {
+        *ppvObject = ref(&m_d3d9On12);
+        return S_OK;
+      } else if (logQueryInterfaceError(__uuidof(IDirect3DDevice9), riid)) {
+        Logger::warn("D3D9DeviceEx::QueryInterface: IDirect3DDevice9On12 queried, but 9On12 not enabled for device");
+        return E_NOINTERFACE;
+      }
     }
 
     // We want to ignore this if the extended device is queried and we weren't made extended.

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -1270,6 +1270,10 @@ namespace dxvk {
       return DxvkCsChunkRef(chunk, &m_csChunkPool);
     }
 
+    bool Is9On12Device() const {
+      return m_d3d9On12Args.Enable9On12;
+    }
+
   private:
 
     template<bool AllowFlush = true, typename Cmd>
@@ -1699,6 +1703,7 @@ namespace dxvk {
     Direct3DState9                  m_state;
 
     D3D9VkInteropDevice             m_d3d9Interop;
+    D3D9ON12_ARGS                   m_d3d9On12Args = { };
     D3D9On12                        m_d3d9On12;
     DxvkD3D8Bridge                  m_d3d8Bridge;
 

--- a/src/d3d9/d3d9_interface.cpp
+++ b/src/d3d9/d3d9_interface.cpp
@@ -14,7 +14,7 @@ namespace dxvk {
 
   Singleton<DxvkInstance> g_dxvkInstance;
 
-  D3D9InterfaceEx::D3D9InterfaceEx(bool bExtended)
+  D3D9InterfaceEx::D3D9InterfaceEx(bool bExtended, const D3D9ON12_ARGS* pOverrideList, uint32_t OverrideCount)
     : m_instance    ( g_dxvkInstance.acquire(DxvkInstanceFlag::ClientApiIsD3D9) )
     , m_d3d8Bridge  ( this )
     , m_extended    ( bExtended ) 
@@ -49,8 +49,10 @@ namespace dxvk {
           ? m_instance->enumAdapters(0)
           : m_instance->enumAdapters(adapterOrdinal);
 
-        if (adapter != nullptr)
-          m_adapters.emplace_back(this, adapter, adapterOrdinal++, i - 1);
+        if (adapter != nullptr) {
+          const auto* d3d9On12Args = Find9On12Args(adapter, pOverrideList, OverrideCount);
+          m_adapters.emplace_back(this, d3d9On12Args, adapter, adapterOrdinal++, i - 1);
+        }
       }
     }
     else
@@ -59,8 +61,10 @@ namespace dxvk {
       const uint32_t adapterCount = m_instance->adapterCount();
       m_adapters.reserve(adapterCount);
 
-      for (uint32_t i = 0; i < adapterCount; i++)
-        m_adapters.emplace_back(this, m_instance->enumAdapters(i), i, 0);
+      for (uint32_t i = 0; i < adapterCount; i++) {
+        const auto* d3d9On12Args = Find9On12Args(m_instance->enumAdapters(i), pOverrideList, OverrideCount);
+        m_adapters.emplace_back(this, d3d9On12Args, m_instance->enumAdapters(i), i, 0);
+      }
     }
 
 #ifdef _WIN32
@@ -519,6 +523,37 @@ namespace dxvk {
       return D3DERR_INVALIDCALL;
 
     return D3D_OK;
+  }
+
+
+  const D3D9ON12_ARGS* D3D9InterfaceEx::Find9On12Args(
+    const Rc<DxvkAdapter>& Adapter,
+    const D3D9ON12_ARGS*   pOverrides,
+          uint32_t         OverrideCount) {
+    const D3D9ON12_ARGS* arg = nullptr;
+
+#ifdef _WIN32
+    for (uint32_t i = 0u; i < OverrideCount; i++) {
+      if (pOverrides[i].pD3D12Device) {
+        const auto& vk11 = Adapter->devicePropertiesExt().vk11;
+
+        if (vk11.deviceLUIDValid) {
+          Com<ID3D12Device> device = nullptr;
+
+          if (SUCCEEDED(pOverrides[i].pD3D12Device->QueryInterface(__uuidof(ID3D12Device), reinterpret_cast<void**>(&device)))) {
+            LUID luid = device->GetAdapterLuid();
+
+            if (!std::memcmp(&luid, vk11.deviceLUID, sizeof(vk11.deviceLUID)))
+              arg = &pOverrides[i];
+          }
+        }
+      } else if (!arg) {
+        arg = &pOverrides[i];
+      }
+    }
+#endif
+
+    return arg;
   }
 
 }

--- a/src/d3d9/d3d9_interface.h
+++ b/src/d3d9/d3d9_interface.h
@@ -19,7 +19,10 @@ namespace dxvk {
 
   public:
 
-    D3D9InterfaceEx(bool bExtended);
+    D3D9InterfaceEx(
+              bool           bExtended,
+        const D3D9ON12_ARGS* pOverrideList,
+              uint32_t       OverrideCount);
 
     ~D3D9InterfaceEx();
 
@@ -170,6 +173,11 @@ namespace dxvk {
     std::vector<D3D9Adapter>      m_adapters;
 
     D3D9VkInteropInterface        m_d3d9Interop;
+
+    static const D3D9ON12_ARGS* Find9On12Args(
+      const Rc<DxvkAdapter>& Adapter,
+      const D3D9ON12_ARGS*   pOverrides,
+            uint32_t         OverrideCount);
 
     bool m_unlockAdditionalFormats = false;
 

--- a/src/d3d9/d3d9_main.cpp
+++ b/src/d3d9/d3d9_main.cpp
@@ -14,11 +14,13 @@ namespace dxvk {
 
   HRESULT CreateD3D9(
           bool           Extended,
-          IDirect3D9Ex** ppDirect3D9Ex) {
+          IDirect3D9Ex** ppDirect3D9Ex,
+    const D3D9ON12_ARGS* pOverrideList,
+          uint32_t       OverrideCount) {
     if (!ppDirect3D9Ex)
       return D3DERR_INVALIDCALL;
 
-    *ppDirect3D9Ex = ref(new D3D9InterfaceEx( Extended ));
+    *ppDirect3D9Ex = ref(new D3D9InterfaceEx(Extended, pOverrideList, OverrideCount));
     return D3D_OK;
   }
 }
@@ -28,13 +30,13 @@ extern "C" {
 
   DLLEXPORT IDirect3D9* __stdcall Direct3DCreate9(UINT nSDKVersion) {
     IDirect3D9Ex* pDirect3D = nullptr;
-    dxvk::CreateD3D9(false, &pDirect3D);
+    dxvk::CreateD3D9(false, &pDirect3D, nullptr, 0);
 
     return pDirect3D;
   }
 
   DLLEXPORT HRESULT __stdcall Direct3DCreate9Ex(UINT nSDKVersion, IDirect3D9Ex** ppDirect3D9Ex) {
-    return dxvk::CreateD3D9(true, ppDirect3D9Ex);
+    return dxvk::CreateD3D9(true, ppDirect3D9Ex, nullptr, 0);
   }
 
   DLLEXPORT int __stdcall D3DPERF_BeginEvent(D3DCOLOR col, LPCWSTR wszName) {
@@ -103,12 +105,16 @@ extern "C" {
 
   DLLEXPORT IDirect3D9* __stdcall Direct3DCreate9On12(UINT sdk_version, D3D9ON12_ARGS* override_list, UINT override_entry_count) {
     dxvk::Logger::warn("Direct3DCreate9On12: 9On12 functionality is unimplemented.");
-    return Direct3DCreate9(sdk_version);
+
+    IDirect3D9Ex* pDirect3D = nullptr;
+    dxvk::CreateD3D9(false, &pDirect3D, override_list, override_entry_count);
+
+    return pDirect3D;
   }
 
   DLLEXPORT HRESULT __stdcall Direct3DCreate9On12Ex(UINT sdk_version, D3D9ON12_ARGS* override_list, UINT override_entry_count, IDirect3D9Ex** output) {
     dxvk::Logger::warn("Direct3DCreate9On12Ex: 9On12 functionality is unimplemented.");
-    return Direct3DCreate9Ex(sdk_version, output);
+    return dxvk::CreateD3D9(true, output, override_list, override_entry_count);
   }
 
 }

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -1397,6 +1397,9 @@ namespace dxvk {
 
 
   std::string D3D9SwapChainEx::GetApiName() {
+    if (this->GetParent()->Is9On12Device())
+      return this->GetParent()->IsExtended() ? "D3D9On12Ex" : "D3D9On12";
+
     return this->GetParent()->IsD3D8Compatible() ? "D3D8" :
            this->GetParent()->IsExtended() ? "D3D9Ex" : "D3D9";
   }


### PR DESCRIPTION
Changed deviceExtensions() to deviceExtensionsExt() in d3d9_interface.cpp, due to no PR#4969.

[96b223e](https://github.com/doitsujin/dxvk/commit/96b223e2f91e09288fcd23a448e59475a6af263b) - [d3d9] Forward 9On12 args to device - [Display whether device is 11on12 or 9on12 device in HUD](https://github.com/doitsujin/dxvk/pull/5058)

[425e3c9](https://github.com/doitsujin/dxvk/commit/425e3c99b1124b2dc4ccc1864e7748dd653dd00d) - [d3d9] Display whether device is a 9On12 device - [Display whether device is 11on12 or 9on12 device in HUD](https://github.com/doitsujin/dxvk/pull/5058)

[86d4b25](https://github.com/doitsujin/dxvk/commit/86d4b258ce313dc6d1f9a032edcf95d178198bd2) - [d3d11] Display whether device is an 11on12 device - [Display whether device is 11on12 or 9on12 device in HUD](https://github.com/doitsujin/dxvk/pull/5058)

[edd935e](https://github.com/doitsujin/dxvk/commit/edd935e8557f24a252525ff0d99fe8c30d61c66a) - [d3d9] Add some missing texture validation - [[d3d9] Texture creation cleanup + missing D3D9Ex texture creation validations](https://github.com/doitsujin/dxvk/pull/5111)