### PR TITLE
Backport upstream DXVK D3D9 PRs - Part 2 - PR#5154, PR#5704, PR#5293 and parts of PR#4948 and PR#5203

### DIFF
--- a/src/d3d9/d3d9_common_texture.cpp
+++ b/src/d3d9/d3d9_common_texture.cpp
@@ -660,7 +660,7 @@ namespace dxvk {
   Rc<DxvkImageView> D3D9CommonTexture::CreateView(
           UINT                   Layer,
           UINT                   Lod,
-          VkImageUsageFlagBits   UsageFlags,
+          VkImageUsageFlags      UsageFlags,
           VkImageLayout          Layout,
           bool                   Srgb) {
     DxvkImageViewKey viewInfo;
@@ -678,16 +678,16 @@ namespace dxvk {
     viewInfo.packedSwizzle = DxvkImageViewKey::packSwizzle(m_mapping.Swizzle);
 
     // Remove the stencil aspect if we are trying to create a regular image
-    // view of a depth stencil format 
-    if (UsageFlags != VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT)
+    // view of a depth stencil format
+    if (!(UsageFlags & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT))
       viewInfo.aspects &= ~VK_IMAGE_ASPECT_STENCIL_BIT;
 
-    if (UsageFlags == VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT ||
-        UsageFlags == VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT)
+    if (UsageFlags & (VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT |
+        VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT))
       viewInfo.mipCount = 1;
 
     // Remove swizzle on depth views.
-    if (UsageFlags == VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT)
+    if (UsageFlags & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT)
       viewInfo.packedSwizzle = 0u;
 
     // Create the underlying image view object

--- a/src/d3d9/d3d9_common_texture.cpp
+++ b/src/d3d9/d3d9_common_texture.cpp
@@ -730,12 +730,20 @@ namespace dxvk {
     // that have GENERAL (or FEEDBACK_LOOP) as their layout.
     // This will always be the case for images that can be sampled.
     // So just pick UNDEFINED here.
+
+    VkImageLayout layout = VK_IMAGE_LAYOUT_UNDEFINED;
+
+    // We default to DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL for DS images that can be sampled.
+    // The backend defaults to DS_READ_ONLY, so we need to set the layout explicitly.
+    if (IsDepthStencil())
+      layout = VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL;
+
     m_sampleView.Color = CreateView(AllLayers, Lod,
-      VK_IMAGE_USAGE_SAMPLED_BIT, VK_IMAGE_LAYOUT_UNDEFINED, false);
+      VK_IMAGE_USAGE_SAMPLED_BIT, layout, false);
 
     if (IsSrgbCompatible()) {
       m_sampleView.Srgb = CreateView(AllLayers, Lod,
-        VK_IMAGE_USAGE_SAMPLED_BIT, VK_IMAGE_LAYOUT_UNDEFINED, true);
+        VK_IMAGE_USAGE_SAMPLED_BIT, layout, true);
     }
   }
 

--- a/src/d3d9/d3d9_common_texture.h
+++ b/src/d3d9/d3d9_common_texture.h
@@ -360,7 +360,7 @@ namespace dxvk {
     Rc<DxvkImageView> CreateView(
             UINT                   Layer,
             UINT                   Lod,
-            VkImageUsageFlagBits   UsageFlags,
+            VkImageUsageFlags      UsageFlags,
             VkImageLayout          Layout,
             bool                   Srgb);
     D3D9SubresourceBitset& GetUploadBitmask() { return m_needsUpload; }

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -53,7 +53,7 @@ namespace dxvk {
     , m_stagingBufferFence ( new sync::Fence() )
     , m_d3d9Options        ( dxvkDevice, pParent->GetInstance()->config() )
     , m_multithread        ( BehaviorFlags & D3DCREATE_MULTITHREADED )
-    , m_isSWVP             ( (BehaviorFlags & D3DCREATE_SOFTWARE_VERTEXPROCESSING) ? true : false )
+    , m_isSWVP             ( (BehaviorFlags & D3DCREATE_SOFTWARE_VERTEXPROCESSING) != 0 )
     , m_isD3D8Compatible   ( pParent->IsD3D8Compatible() )
     , m_csThread           ( dxvkDevice, dxvkDevice->createContext() )
     , m_csChunk            ( AllocCsChunk() )
@@ -190,6 +190,8 @@ namespace dxvk {
     m_flags.set(D3D9DeviceFlag::DirtyPointScale);
 
     m_flags.set(D3D9DeviceFlag::DirtySpecializationEntries);
+
+    m_specInfo.set<SpecDrefScaling, uint32_t>(m_d3d9Options.drefScaling);
 
     m_unlockAdditionalFormats = m_parent->HasFormatsUnlocked();
   }
@@ -4610,8 +4612,8 @@ namespace dxvk {
         m_flags.set(D3D9DeviceFlag::DirtyFFPixelShader);
     }
 
-    bool oldTextureIsCube = oldTexture != nullptr ? oldTexture->IsCube() : false;
-    bool newTextureIsCube = newTexture != nullptr ? newTexture->IsCube() : false;
+    bool oldTextureIsCube = oldTexture != nullptr && oldTexture->IsCube();
+    bool newTextureIsCube = newTexture != nullptr && newTexture->IsCube();
     if (unlikely(oldTextureIsCube != newTextureIsCube)) {
       m_textureSlotTracking.samplerStateDirty |= 1u << StateSampler;
     }
@@ -8146,9 +8148,9 @@ namespace dxvk {
 
   void D3D9DeviceEx::UpdateFixedFunctionVS() {
     // Shader...
-    bool hasPositionT = m_state.vertexDecl != nullptr ? m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasPositionT) : false;
-    bool hasBlendWeight    = m_state.vertexDecl != nullptr ? m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasBlendWeight)  : false;
-    bool hasBlendIndices   = m_state.vertexDecl != nullptr ? m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasBlendIndices) : false;
+    bool hasPositionT = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasPositionT);
+    bool hasBlendWeight    = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasBlendWeight);
+    bool hasBlendIndices   = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasBlendIndices);
 
     bool indexedVertexBlend = hasBlendIndices && m_state.renderStates[D3DRS_INDEXEDVERTEXBLENDENABLE];
 
@@ -8177,17 +8179,17 @@ namespace dxvk {
       m_flags.clr(D3D9DeviceFlag::DirtyFFVertexShader);
 
       D3D9FFShaderKeyVS key;
-      key.Data.Contents.HasPositionT = hasPositionT;
-      key.Data.Contents.HasColor0    = m_state.vertexDecl != nullptr ? m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasColor0)    : false;
-      key.Data.Contents.HasColor1    = m_state.vertexDecl != nullptr ? m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasColor1)    : false;
-      key.Data.Contents.HasPointSize = m_state.vertexDecl != nullptr ? m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasPointSize) : false;
-      key.Data.Contents.HasFog       = m_state.vertexDecl != nullptr ? m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasFog)       : false;
+      key.Data.Contents.VertexHasPositionT = hasPositionT;
+      key.Data.Contents.VertexHasColor0    = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasColor0);
+      key.Data.Contents.VertexHasColor1    = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasColor1);
+      key.Data.Contents.VertexHasPointSize = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasPointSize);
+      key.Data.Contents.VertexHasFog       = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasFog);
 
-      bool lighting    = m_state.renderStates[D3DRS_LIGHTING] != 0 && !key.Data.Contents.HasPositionT;
+      bool lighting    = m_state.renderStates[D3DRS_LIGHTING] != 0 && !key.Data.Contents.VertexHasPositionT;
       bool colorVertex = m_state.renderStates[D3DRS_COLORVERTEX] != 0;
       uint32_t mask    = (lighting && colorVertex)
-                       ? (key.Data.Contents.HasColor0 ? D3DMCS_COLOR1 : D3DMCS_MATERIAL)
-                       | (key.Data.Contents.HasColor1 ? D3DMCS_COLOR2 : D3DMCS_MATERIAL)
+                       ? (key.Data.Contents.VertexHasColor0 ? D3DMCS_COLOR1 : D3DMCS_MATERIAL)
+                       | (key.Data.Contents.VertexHasColor1 ? D3DMCS_COLOR2 : D3DMCS_MATERIAL)
                        : 0;
 
       key.Data.Contents.UseLighting      = lighting;
@@ -9091,8 +9093,8 @@ namespace dxvk {
 
   void D3D9DeviceEx::UpdatePixelShaderSamplerSpec(uint32_t types, uint32_t projections, uint32_t fetch4) {
     bool dirty  = m_specInfo.set<SpecSamplerType>(types);
-         dirty |= m_specInfo.set<SpecProjectionType>(projections);
-         dirty |= m_specInfo.set<SpecFetch4>(fetch4);
+         dirty |= m_specInfo.set<SpecSamplerProjected>(projections);
+         dirty |= m_specInfo.set<SpecSamplerFetch4>(fetch4);
 
     if (dirty)
       m_flags.set(D3D9DeviceFlag::DirtySpecializationEntries);
@@ -9102,7 +9104,7 @@ namespace dxvk {
   void D3D9DeviceEx::UpdateCommonSamplerSpec(uint32_t nullMask, uint32_t depthMask, uint32_t drefMask) {
     bool dirty  = m_specInfo.set<SpecSamplerDepthMode>(depthMask);
          dirty |= m_specInfo.set<SpecSamplerNull>(nullMask);
-         dirty |= m_specInfo.set<SpecDrefClamp>(drefMask);
+         dirty |= m_specInfo.set<SpecSamplerDrefClamp>(drefMask);
 
     if (dirty)
       m_flags.set(D3D9DeviceFlag::DirtySpecializationEntries);

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -6446,12 +6446,12 @@ namespace dxvk {
 
       // In fixed function shaders and SM < 2 we put the type mask
       // into a spec constant to select the used sampler type.
-      uint32_t oldTextureTypes = m_textureSlotTracking.textureType;
+      const uint32_t oldTextureTypes = m_textureSlotTracking.textureType;
+      m_textureSlotTracking.textureType &= ~textureBitMask;
+      m_textureSlotTracking.textureType |=  textureBits;
       if (oldTextureTypes != m_textureSlotTracking.textureType) {
         m_flags.set(D3D9DeviceFlag::DirtyFFPixelShader);
       }
-      m_textureSlotTracking.textureType &= ~textureBitMask;
-      m_textureSlotTracking.textureType |=  textureBits;
     }
 
     if (likely(tex != nullptr)) {

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -184,7 +184,7 @@ namespace dxvk {
     m_dirty.set(D3D9DeviceDirtyFlag::FFPixelShader);
     m_dirty.set(D3D9DeviceDirtyFlag::FFViewport);
     m_dirty.set(D3D9DeviceDirtyFlag::FFPixelData);
-    m_flags.set(D3D9DeviceFlag::DirtyProgVertexShader);
+    m_dirty.set(D3D9DeviceDirtyFlag::ProgVertexShader);
     m_dirty.set(D3D9DeviceDirtyFlag::SharedPixelShaderData);
     m_dirty.set(D3D9DeviceDirtyFlag::DepthBounds);
     m_dirty.set(D3D9DeviceDirtyFlag::PointScale);
@@ -3555,7 +3555,7 @@ namespace dxvk {
     m_state.vertexShader = shader;
 
     if (shader != nullptr) {
-      m_flags.clr(D3D9DeviceFlag::DirtyProgVertexShader);
+      m_dirty.clr(D3D9DeviceDirtyFlag::ProgVertexShader);
       m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
 
       BindShader<DxsoProgramTypes::VertexShader>(GetCommonShader(shader));
@@ -5871,7 +5871,7 @@ namespace dxvk {
         ](DxvkContext* ctx) mutable {
           ctx->bindVertexBuffer(cStream, std::move(cBufferSlice), cStride);
         });
-        m_flags.set(D3D9DeviceFlag::DirtyVertexBuffers);
+        m_dirty.set(D3D9DeviceDirtyFlag::VertexBuffers);
       }
 
       // Change the draw call parameters to reflect the changed vertex buffers
@@ -5887,7 +5887,7 @@ namespace dxvk {
         EmitCs([](DxvkContext* ctx) {
           ctx->bindIndexBuffer(DxvkBufferSlice(), VK_INDEX_TYPE_UINT32);
         });
-        m_flags.set(D3D9DeviceFlag::DirtyIndexBuffer);
+        m_dirty.set(D3D9DeviceDirtyFlag::IndexBuffer);
       } else {
         auto* ibo = GetCommonBuffer(m_state.indices);
         uint32_t indexStride = ibo->Desc()->Format == D3D9Format::INDEX16 ? 2 : 4;
@@ -5904,7 +5904,7 @@ namespace dxvk {
         ](DxvkContext* ctx) mutable {
           ctx->bindIndexBuffer(std::move(cBufferSlice), cIndexType);
         });
-        m_flags.set(D3D9DeviceFlag::DirtyIndexBuffer);
+        m_dirty.set(D3D9DeviceDirtyFlag::IndexBuffer);
       }
 
       // Change the draw call parameters to reflect the changed index buffer
@@ -6222,7 +6222,7 @@ namespace dxvk {
 
 
   void D3D9DeviceEx::UpdateClipPlanes() {
-    m_flags.clr(D3D9DeviceFlag::DirtyClipPlanes);
+    m_dirty.clr(D3D9DeviceDirtyFlag::ClipPlanes);
 
     auto mapPtr = m_vsClipPlanes.AllocSlice();
     auto dst = reinterpret_cast<D3D9ClipPlane*>(mapPtr);
@@ -6850,7 +6850,7 @@ namespace dxvk {
 
     uint32_t mode = scaleBit | spriteBit;
 
-    if (rs[D3DRS_POINTSCALEENABLE] && m_flags.test(D3D9DeviceFlag::DirtyPointScale)) {
+    if (rs[D3DRS_POINTSCALEENABLE] && m_dirty.test(D3D9DeviceDirtyFlag::PointScale)) {
       m_dirty.clr(D3D9DeviceDirtyFlag::PointScale);
 
       UpdatePushConstant<D3D9RenderStateItem::PointScaleA>();
@@ -6871,24 +6871,24 @@ namespace dxvk {
     bool vertexFog  = rs[D3DRS_FOGVERTEXMODE] != D3DFOG_NONE && fogEnabled && !pixelFog;
 
     auto UpdateFogConstants = [&](D3DFOGMODE FogMode) {
-      if (m_flags.test(D3D9DeviceFlag::DirtyFogColor)) {
+      if (m_dirty.test(D3D9DeviceDirtyFlag::FogColor)) {
         m_dirty.clr(D3D9DeviceDirtyFlag::FogColor);
         UpdatePushConstant<D3D9RenderStateItem::FogColor>();
       }
 
       if (FogMode == D3DFOG_LINEAR) {
-        if (m_flags.test(D3D9DeviceFlag::DirtyFogScale)) {
+        if (m_dirty.test(D3D9DeviceDirtyFlag::FogScale)) {
           m_dirty.clr(D3D9DeviceDirtyFlag::FogScale);
           UpdatePushConstant<D3D9RenderStateItem::FogScale>();
         }
 
-        if (m_flags.test(D3D9DeviceFlag::DirtyFogEnd)) {
+        if (m_dirty.test(D3D9DeviceDirtyFlag::FogEnd)) {
           m_dirty.clr(D3D9DeviceDirtyFlag::FogEnd);
           UpdatePushConstant<D3D9RenderStateItem::FogEnd>();
         }
       }
       else if (FogMode == D3DFOG_EXP || FogMode == D3DFOG_EXP2) {
-        if (m_flags.test(D3D9DeviceFlag::DirtyFogDensity)) {
+        if (m_dirty.test(D3D9DeviceDirtyFlag::FogDensity)) {
           m_dirty.clr(D3D9DeviceDirtyFlag::FogDensity);
           UpdatePushConstant<D3D9RenderStateItem::FogDensity>();
         }
@@ -6900,7 +6900,7 @@ namespace dxvk {
 
       UpdateFogConstants(mode);
 
-      if (m_flags.test(D3D9DeviceFlag::DirtyFogState)) {
+      if (m_dirty.test(D3D9DeviceDirtyFlag::FogState)) {
         m_dirty.clr(D3D9DeviceDirtyFlag::FogState);
 
         UpdateFogModeSpec(true, mode, D3DFOG_NONE);
@@ -6911,7 +6911,7 @@ namespace dxvk {
 
       UpdateFogConstants(mode);
 
-      if (m_flags.test(D3D9DeviceFlag::DirtyFogState)) {
+      if (m_dirty.test(D3D9DeviceDirtyFlag::FogState)) {
         m_dirty.clr(D3D9DeviceDirtyFlag::FogState);
 
         UpdateFogModeSpec(true, D3DFOG_NONE, mode);
@@ -6921,7 +6921,7 @@ namespace dxvk {
       if (fogEnabled)
         UpdateFogConstants(D3DFOG_NONE);
 
-      if (m_flags.test(D3D9DeviceFlag::DirtyFogState)) {
+      if (m_dirty.test(D3D9DeviceDirtyFlag::FogState)) {
         m_dirty.clr(D3D9DeviceDirtyFlag::FogState);
 
         UpdateFogModeSpec(fogEnabled, D3DFOG_NONE, D3DFOG_NONE);
@@ -7677,7 +7677,7 @@ namespace dxvk {
     UpdatePointMode(PrimitiveType == D3DPT_POINTLIST);
 
     if (likely(UseProgrammableVS())) {
-      if (unlikely(m_flags.test(D3D9DeviceFlag::DirtyProgVertexShader))) {
+      if (unlikely(m_dirty.test(D3D9DeviceDirtyFlag::ProgVertexShader))) {
         m_dirty.set(D3D9DeviceDirtyFlag::InputLayout);
 
         BindShader<DxsoProgramType::VertexShader>(
@@ -8202,10 +8202,10 @@ namespace dxvk {
         vertexBlendMode = D3D9FF_VertexBlendMode_Disabled;
     }
 
-    if (unlikely(hasPositionT && m_state.vertexShader != nullptr && !m_flags.test(D3D9DeviceFlag::DirtyProgVertexShader))) {
+    if (unlikely(hasPositionT && m_state.vertexShader != nullptr && !m_dirty.test(D3D9DeviceDirtyFlag::ProgVertexShader))) {
       m_dirty.set(D3D9DeviceDirtyFlag::InputLayout);
       m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
-      m_flags.set(D3D9DeviceFlag::DirtyProgVertexShader);
+      m_dirty.set(D3D9DeviceDirtyFlag::ProgVertexShader);
     }
 
     if (m_dirty.test(D3D9DeviceDirtyFlag::FFVertexShader)) {

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -161,35 +161,35 @@ namespace dxvk {
 
     // Initially set all the dirty flags so we
     // always end up giving the backend *something* to work with.
-    m_flags.set(D3D9DeviceFlag::DirtyFramebuffer);
-    m_flags.set(D3D9DeviceFlag::DirtyClipPlanes);
-    m_flags.set(D3D9DeviceFlag::DirtyDepthStencilState);
-    m_flags.set(D3D9DeviceFlag::DirtyBlendState);
-    m_flags.set(D3D9DeviceFlag::DirtyRasterizerState);
-    m_flags.set(D3D9DeviceFlag::DirtyDepthBias);
-    m_flags.set(D3D9DeviceFlag::DirtyAlphaTestState);
-    m_flags.set(D3D9DeviceFlag::DirtyInputLayout);
-    m_flags.set(D3D9DeviceFlag::DirtyViewportScissor);
-    m_flags.set(D3D9DeviceFlag::DirtyMultiSampleState);
+    m_dirty.set(D3D9DeviceDirtyFlag::Framebuffer);
+    m_dirty.set(D3D9DeviceDirtyFlag::ClipPlanes);
+    m_dirty.set(D3D9DeviceDirtyFlag::DepthStencilState);
+    m_dirty.set(D3D9DeviceDirtyFlag::BlendState);
+    m_dirty.set(D3D9DeviceDirtyFlag::RasterizerState);
+    m_dirty.set(D3D9DeviceDirtyFlag::DepthBias);
+    m_dirty.set(D3D9DeviceDirtyFlag::AlphaTestState);
+    m_dirty.set(D3D9DeviceDirtyFlag::InputLayout);
+    m_dirty.set(D3D9DeviceDirtyFlag::ViewportScissor);
+    m_dirty.set(D3D9DeviceDirtyFlag::MultiSampleState);
 
-    m_flags.set(D3D9DeviceFlag::DirtyFogState);
-    m_flags.set(D3D9DeviceFlag::DirtyFogColor);
-    m_flags.set(D3D9DeviceFlag::DirtyFogDensity);
-    m_flags.set(D3D9DeviceFlag::DirtyFogScale);
-    m_flags.set(D3D9DeviceFlag::DirtyFogEnd);
+    m_dirty.set(D3D9DeviceDirtyFlag::FogState);
+    m_dirty.set(D3D9DeviceDirtyFlag::FogColor);
+    m_dirty.set(D3D9DeviceDirtyFlag::FogDensity);
+    m_dirty.set(D3D9DeviceDirtyFlag::FogScale);
+    m_dirty.set(D3D9DeviceDirtyFlag::FogEnd);
 
-    m_flags.set(D3D9DeviceFlag::DirtyFFVertexData);
-    m_flags.set(D3D9DeviceFlag::DirtyFFVertexBlend);
-    m_flags.set(D3D9DeviceFlag::DirtyFFVertexShader);
-    m_flags.set(D3D9DeviceFlag::DirtyFFPixelShader);
-    m_flags.set(D3D9DeviceFlag::DirtyFFViewport);
-    m_flags.set(D3D9DeviceFlag::DirtyFFPixelData);
+    m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
+    m_dirty.set(D3D9DeviceDirtyFlag::FFVertexBlend);
+    m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
+    m_dirty.set(D3D9DeviceDirtyFlag::FFPixelShader);
+    m_dirty.set(D3D9DeviceDirtyFlag::FFViewport);
+    m_dirty.set(D3D9DeviceDirtyFlag::FFPixelData);
     m_flags.set(D3D9DeviceFlag::DirtyProgVertexShader);
-    m_flags.set(D3D9DeviceFlag::DirtySharedPixelShaderData);
-    m_flags.set(D3D9DeviceFlag::DirtyDepthBounds);
-    m_flags.set(D3D9DeviceFlag::DirtyPointScale);
+    m_dirty.set(D3D9DeviceDirtyFlag::SharedPixelShaderData);
+    m_dirty.set(D3D9DeviceDirtyFlag::DepthBounds);
+    m_dirty.set(D3D9DeviceDirtyFlag::PointScale);
 
-    m_flags.set(D3D9DeviceFlag::DirtySpecializationEntries);
+    m_dirty.set(D3D9DeviceDirtyFlag::SpecializationEntries);
 
     m_specInfo.set<SpecDrefScaling, uint32_t>(m_d3d9Options.drefScaling);
 
@@ -525,7 +525,7 @@ namespace dxvk {
       // while D3D9Ex doesn't.
       // Observed in Empires: Dawn of the Modern World (D3D8)
       // and the OSU compatibility mode (D3D9Ex).
-      m_flags.clr(D3D9DeviceFlag::InScene);
+      m_inScene = false;
     } else {
       // Extended devices will not reset the MinZ/MaxZ viewport values
       const float MinZ = m_state.viewport.MinZ;
@@ -1357,7 +1357,7 @@ namespace dxvk {
       if (unlikely(srcCopyExtent.width != srcExtent.width || srcCopyExtent.height != srcExtent.height))
         return D3DERR_INVALIDCALL;
 
-      if (unlikely(m_flags.test(D3D9DeviceFlag::InScene)))
+      if (unlikely(m_inScene))
         return D3DERR_INVALIDCALL;
     }
 
@@ -1670,6 +1670,8 @@ namespace dxvk {
       return D3DERR_INVALIDCALL;
 
     if (RenderTargetIndex == 0) {
+      // Setting Render target 0 changes viewport & scissor
+      // even if it gets changed to the one that's already bound.
       D3DVIEWPORT9 viewport;
       viewport.X       = 0;
       viewport.Y       = 0;
@@ -1694,14 +1696,14 @@ namespace dxvk {
       }
 
       if (m_state.viewport != viewport) {
-        m_flags.set(D3D9DeviceFlag::DirtyFFViewport);
-        m_flags.set(D3D9DeviceFlag::DirtyPointScale);
-        m_flags.set(D3D9DeviceFlag::DirtyViewportScissor);
+        m_dirty.set(D3D9DeviceDirtyFlag::FFViewport);
+        m_dirty.set(D3D9DeviceDirtyFlag::PointScale);
+        m_dirty.set(D3D9DeviceDirtyFlag::ViewportScissor);
         m_state.viewport = viewport;
       }
 
       if (m_state.scissorRect != scissorRect) {
-        m_flags.set(D3D9DeviceFlag::DirtyViewportScissor);
+        m_dirty.set(D3D9DeviceDirtyFlag::ViewportScissor);
         m_state.scissorRect = scissorRect;
       }
     }
@@ -1709,35 +1711,40 @@ namespace dxvk {
     if (m_state.renderTargets[RenderTargetIndex] == rt)
       return D3D_OK;
 
-      UpdateAlphaToCoverangeAndAlphaTest();
+    m_state.renderTargets[RenderTargetIndex] = rt;
 
     // Do a strong flush if the first render target is changed.
     ConsiderFlush(RenderTargetIndex == 0
       ? GpuFlushType::ImplicitStrongHint
       : GpuFlushType::ImplicitWeakHint);
-    m_flags.set(D3D9DeviceFlag::DirtyFramebuffer);
 
-    m_state.renderTargets[RenderTargetIndex] = rt;
+    m_dirty.set(D3D9DeviceDirtyFlag::Framebuffer);
 
-    // Update feedback loop tracking bitmasks
-    UpdateActiveRTs(RenderTargetIndex);
+    // Update tracking bitmasks
+    uint32_t oldAlphaSwizzleRTs = m_rtSlotTracking.hasAlphaSwizzle;
+    const uint32_t bit = 1u << RenderTargetIndex;
+    m_rtSlotTracking.canBeSampled    &= ~bit;
+    m_rtSlotTracking.hasAlphaSwizzle &= ~bit;
 
-    // Update render target alpha swizzle bitmask if we need to fix up the alpha channel
-    // for XRGB formats
-    uint32_t originalAlphaSwizzleRTs = m_rtSlotTracking.hasAlphaSwizzle;
+    if (texInfo != nullptr) {
+      // Update render target sampling usage bitmask for hazard tracking
+      m_rtSlotTracking.canBeSampled |= uint8_t(HasRenderTargetBound(RenderTargetIndex) &&
+        rt->GetBaseTexture() != nullptr) << RenderTargetIndex;
 
-    m_rtSlotTracking.hasAlphaSwizzle &= ~(1 << RenderTargetIndex);
-
-    if (rt != nullptr) {
-      if (texInfo->GetMapping().Swizzle.a == VK_COMPONENT_SWIZZLE_ONE)
-        m_rtSlotTracking.hasAlphaSwizzle |= 1 << RenderTargetIndex;
+      // Update render target alpha swizzle bitmask if we need to fix up the alpha channel
+      // for XRGB formats
+      m_rtSlotTracking.hasAlphaSwizzle |= uint8_t(texInfo->GetMapping().Swizzle.a == VK_COMPONENT_SWIZZLE_ONE) << RenderTargetIndex;
 
       if (texInfo->IsAutomaticMip())
         texInfo->SetNeedsMipGen(true);
     }
 
-    if (originalAlphaSwizzleRTs != m_rtSlotTracking.hasAlphaSwizzle)
-      m_flags.set(D3D9DeviceFlag::DirtyBlendState);
+    // Update hazards now that the RT has changed
+    UpdateActiveHazardsRT(std::numeric_limits<uint32_t>::max());
+
+    // The blend factors need to get adjusted to the swizzle.
+    if (oldAlphaSwizzleRTs != m_rtSlotTracking.hasAlphaSwizzle)
+      m_dirty.set(D3D9DeviceDirtyFlag::BlendState);
 
     if (RenderTargetIndex == 0) {
       // Changing RT0 can disable ATOC and
@@ -1746,24 +1753,20 @@ namespace dxvk {
       UpdateAlphaToCoverangeAndAlphaTest();
 
       if (likely(texInfo != nullptr)) {
-        if (m_alphaTestEnabled) {
-          // We need to recalculate the precision.
-          m_flags.set(D3D9DeviceFlag::DirtyAlphaTestState);
-        }
+        // We need to recalculate the alpha test precision for the potentially changed RT format.
+        // Updating the precision is cheap, so there's no need to compare the previous format to the new one.
+        if (m_alphaTestEnabled)
+          m_dirty.set(D3D9DeviceDirtyFlag::AlphaTestState);
 
-        bool validSampleMask = texInfo->Desc()->MultiSample > D3DMULTISAMPLE_NONMASKABLE;
-
-        if (validSampleMask != m_flags.test(D3D9DeviceFlag::ValidSampleMask)) {
-          m_flags.clr(D3D9DeviceFlag::ValidSampleMask);
-          if (validSampleMask)
-            m_flags.set(D3D9DeviceFlag::ValidSampleMask);
-
-          m_flags.set(D3D9DeviceFlag::DirtyMultiSampleState);
-        }
+        bool oldValidSampleMask = m_validSampleMask;
+        m_validSampleMask = texInfo->Desc()->MultiSample > D3DMULTISAMPLE_NONMASKABLE;
+        // We need to update the multisample state to account for the changed sample mask.
+        if (m_validSampleMask != oldValidSampleMask)
+          m_dirty.set(D3D9DeviceDirtyFlag::MultiSampleState);
       } else {
-        m_flags.clr(D3D9DeviceFlag::ValidSampleMask);
-        m_flags.set(D3D9DeviceFlag::DirtyMultiSampleState);
-        m_flags.set(D3D9DeviceFlag::DirtyAlphaTestState);
+        m_validSampleMask = false;
+        m_dirty.set(D3D9DeviceDirtyFlag::MultiSampleState);
+        m_dirty.set(D3D9DeviceDirtyFlag::AlphaTestState);
       }
     }
 
@@ -1802,7 +1805,7 @@ namespace dxvk {
       return D3D_OK;
 
     ConsiderFlush(GpuFlushType::ImplicitWeakHint);
-    m_flags.set(D3D9DeviceFlag::DirtyFramebuffer);
+    m_dirty.set(D3D9DeviceDirtyFlag::Framebuffer);
 
     // Update depth bias if necessary
     if (ds != nullptr && m_depthBiasRepresentation.depthBiasRepresentation != VK_DEPTH_BIAS_REPRESENTATION_FLOAT_EXT) {
@@ -1812,7 +1815,7 @@ namespace dxvk {
       const float rValue = GetDepthBufferRValue(ds->GetCommonTexture()->GetFormatMapping().FormatColor, vendorId, exact, forceUnorm);
       if (m_depthBiasScale != rValue) {
         m_depthBiasScale = rValue;
-        m_flags.set(D3D9DeviceFlag::DirtyDepthBias);
+        m_dirty.set(D3D9DeviceDirtyFlag::DepthBias);
       }
     }
 
@@ -1846,10 +1849,10 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D9DeviceEx::BeginScene() {
     D3D9DeviceLock lock = LockDevice();
 
-    if (unlikely(m_flags.test(D3D9DeviceFlag::InScene)))
+    if (unlikely(m_inScene))
       return D3DERR_INVALIDCALL;
 
-    m_flags.set(D3D9DeviceFlag::InScene);
+    m_inScene = true;
 
     return D3D_OK;
   }
@@ -1858,12 +1861,12 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D9DeviceEx::EndScene() {
     D3D9DeviceLock lock = LockDevice();
 
-    if (unlikely(!m_flags.test(D3D9DeviceFlag::InScene)))
+    if (unlikely(!m_inScene))
       return D3DERR_INVALIDCALL;
 
     ConsiderFlush(GpuFlushType::ImplicitStrongHint);
 
-    m_flags.clr(D3D9DeviceFlag::InScene);
+    m_inScene = false;
 
     // D3D9 resets the internally bound vertex buffers and index buffer in EndScene if they were unbound in the meantime.
     // We have to ignore unbinding those buffers because of Operation Flashpoint Red River,
@@ -2090,10 +2093,10 @@ namespace dxvk {
 
     m_state.transforms[idx] = m_state.transforms[idx] * ConvertMatrix(pMatrix);
 
-    m_flags.set(D3D9DeviceFlag::DirtyFFVertexData);
+    m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
 
     if (idx == GetTransformIndex(D3DTS_VIEW) || idx >= GetTransformIndex(D3DTS_WORLD))
-      m_flags.set(D3D9DeviceFlag::DirtyFFVertexBlend);
+      m_dirty.set(D3D9DeviceDirtyFlag::FFVertexBlend);
 
     return D3D_OK;
   }
@@ -2120,9 +2123,9 @@ namespace dxvk {
     m_state.viewport.MinZ = pViewport->MinZ;
     m_state.viewport.MaxZ = pViewport->MinZ < pViewport->MaxZ ? pViewport->MaxZ : pViewport->MinZ + 0.001f;
 
-    m_flags.set(D3D9DeviceFlag::DirtyViewportScissor);
-    m_flags.set(D3D9DeviceFlag::DirtyFFViewport);
-    m_flags.set(D3D9DeviceFlag::DirtyPointScale);
+    m_dirty.set(D3D9DeviceDirtyFlag::ViewportScissor);
+    m_dirty.set(D3D9DeviceDirtyFlag::FFViewport);
+    m_dirty.set(D3D9DeviceDirtyFlag::PointScale);
 
     return D3D_OK;
   }
@@ -2150,7 +2153,7 @@ namespace dxvk {
       return m_recorder->SetMaterial(pMaterial);
 
     m_state.material = *pMaterial;
-    m_flags.set(D3D9DeviceFlag::DirtyFFVertexData);
+    m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
 
     return D3D_OK;
   }
@@ -2185,7 +2188,7 @@ namespace dxvk {
     m_state.lights[Index] = *pLight;
 
     if (m_state.IsLightEnabled(Index))
-      m_flags.set(D3D9DeviceFlag::DirtyFFVertexData);
+      m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
 
     return D3D_OK;
   }
@@ -2232,8 +2235,8 @@ namespace dxvk {
     for (auto& idx : m_state.enabledLightIndices) {
       if (idx == searchIndex) {
         idx = setIndex;
-        m_flags.set(D3D9DeviceFlag::DirtyFFVertexData);
-        m_flags.set(D3D9DeviceFlag::DirtyFFVertexShader);
+        m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
+        m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
         break;
       }
     }
@@ -2281,7 +2284,7 @@ namespace dxvk {
     dirty &= enabled;
 
     if (dirty)
-      m_flags.set(D3D9DeviceFlag::DirtyClipPlanes);
+      m_dirty.set(D3D9DeviceDirtyFlag::ClipPlanes);
 
     return D3D_OK;
   }
@@ -2334,28 +2337,28 @@ namespace dxvk {
         case D3DRS_DESTBLENDALPHA:
         case D3DRS_SRCBLEND:
         case D3DRS_SRCBLENDALPHA:
-          m_flags.set(D3D9DeviceFlag::DirtyBlendState);
+          m_dirty.set(D3D9DeviceDirtyFlag::BlendState);
           break;
 
         case D3DRS_COLORWRITEENABLE:
           if (likely(!Value != !oldValue))
             UpdateAnyColorWrites<0>();
-          m_flags.set(D3D9DeviceFlag::DirtyBlendState);
+          m_dirty.set(D3D9DeviceDirtyFlag::BlendState);
           break;
         case D3DRS_COLORWRITEENABLE1:
           if (likely(!Value != !oldValue))
             UpdateAnyColorWrites<1>();
-          m_flags.set(D3D9DeviceFlag::DirtyBlendState);
+          m_dirty.set(D3D9DeviceDirtyFlag::BlendState);
           break;
         case D3DRS_COLORWRITEENABLE2:
           if (likely(!Value != !oldValue))
             UpdateAnyColorWrites<2>();
-          m_flags.set(D3D9DeviceFlag::DirtyBlendState);
+          m_dirty.set(D3D9DeviceDirtyFlag::BlendState);
           break;
         case D3DRS_COLORWRITEENABLE3:
           if (likely(!Value != !oldValue))
             UpdateAnyColorWrites<3>();
-          m_flags.set(D3D9DeviceFlag::DirtyBlendState);
+          m_dirty.set(D3D9DeviceDirtyFlag::BlendState);
           break;
 
         case D3DRS_ALPHATESTENABLE: {
@@ -2364,7 +2367,7 @@ namespace dxvk {
         }
 
         case D3DRS_ALPHAFUNC:
-          m_flags.set(D3D9DeviceFlag::DirtyAlphaTestState);
+          m_dirty.set(D3D9DeviceDirtyFlag::AlphaTestState);
           break;
 
         case D3DRS_BLENDFACTOR:
@@ -2372,8 +2375,8 @@ namespace dxvk {
           break;
 
         case D3DRS_MULTISAMPLEMASK:
-          if (m_flags.test(D3D9DeviceFlag::ValidSampleMask))
-            m_flags.set(D3D9DeviceFlag::DirtyMultiSampleState);
+          if (m_validSampleMask)
+            m_dirty.set(D3D9DeviceDirtyFlag::MultiSampleState);
           break;
 
         case D3DRS_ZWRITEENABLE:
@@ -2384,12 +2387,12 @@ namespace dxvk {
               UpdateActiveHazardsDS(std::numeric_limits<uint32_t>::max());
             }
 
-            m_flags.set(D3D9DeviceFlag::DirtyDepthStencilState);
+            m_dirty.set(D3D9DeviceDirtyFlag::DepthStencilState);
           }
           break;
         case D3DRS_STENCILENABLE:
           if (likely(!Value != !oldValue)) {
-            m_flags.set(D3D9DeviceFlag::DirtyDepthStencilState);
+            m_dirty.set(D3D9DeviceDirtyFlag::DepthStencilState);
           }
           break;
         case D3DRS_ZENABLE:
@@ -2399,7 +2402,7 @@ namespace dxvk {
               UpdateActiveHazardsDS(std::numeric_limits<uint32_t>::max());
             }
 
-            m_flags.set(D3D9DeviceFlag::DirtyDepthStencilState);
+            m_dirty.set(D3D9DeviceDirtyFlag::DepthStencilState);
           }
           break;
 
@@ -2415,7 +2418,7 @@ namespace dxvk {
         case D3DRS_CCW_STENCILFUNC:
         case D3DRS_STENCILMASK:
         case D3DRS_STENCILWRITEMASK:
-          m_flags.set(D3D9DeviceFlag::DirtyDepthStencilState);
+          m_dirty.set(D3D9DeviceDirtyFlag::DepthStencilState);
           break;
 
         case D3DRS_STENCILREF:
@@ -2423,29 +2426,29 @@ namespace dxvk {
           break;
 
         case D3DRS_SCISSORTESTENABLE:
-          m_flags.set(D3D9DeviceFlag::DirtyViewportScissor);
+          m_dirty.set(D3D9DeviceDirtyFlag::ViewportScissor);
           break;
 
         case D3DRS_SRGBWRITEENABLE:
-          m_flags.set(D3D9DeviceFlag::DirtyFramebuffer);
+          m_dirty.set(D3D9DeviceDirtyFlag::Framebuffer);
           break;
 
         case D3DRS_DEPTHBIAS:
         case D3DRS_SLOPESCALEDEPTHBIAS:
-          m_flags.set(D3D9DeviceFlag::DirtyDepthBias);
+          m_dirty.set(D3D9DeviceDirtyFlag::DepthBias);
           break;
 
         case D3DRS_CULLMODE:
         case D3DRS_FILLMODE:
         case D3DRS_MULTISAMPLEANTIALIAS:
-          m_flags.set(D3D9DeviceFlag::DirtyRasterizerState);
+          m_dirty.set(D3D9DeviceDirtyFlag::RasterizerState);
           break;
 
         case D3DRS_CLIPPLANEENABLE:
           if (!Value != !oldValue)
-            m_flags.set(D3D9DeviceFlag::DirtyFFVertexShader);
+            m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
 
-          m_flags.set(D3D9DeviceFlag::DirtyClipPlanes);
+          m_dirty.set(D3D9DeviceDirtyFlag::ClipPlanes);
           break;
 
         case D3DRS_ALPHAREF:
@@ -2453,7 +2456,7 @@ namespace dxvk {
           break;
 
         case D3DRS_TEXTUREFACTOR:
-          m_flags.set(D3D9DeviceFlag::DirtyFFPixelData);
+          m_dirty.set(D3D9DeviceDirtyFlag::FFPixelData);
           break;
 
         case D3DRS_DIFFUSEMATERIALSOURCE:
@@ -2464,42 +2467,42 @@ namespace dxvk {
         case D3DRS_LIGHTING:
         case D3DRS_NORMALIZENORMALS:
         case D3DRS_LOCALVIEWER:
-          m_flags.set(D3D9DeviceFlag::DirtyFFVertexShader);
+          m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
           break;
 
         case D3DRS_AMBIENT:
-          m_flags.set(D3D9DeviceFlag::DirtyFFVertexData);
+          m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
           break;
 
         case D3DRS_SPECULARENABLE:
-          m_flags.set(D3D9DeviceFlag::DirtyFFPixelShader);
+          m_dirty.set(D3D9DeviceDirtyFlag::FFPixelShader);
           break;
 
         case D3DRS_FOGENABLE:
         case D3DRS_FOGVERTEXMODE:
         case D3DRS_FOGTABLEMODE:
-          m_flags.set(D3D9DeviceFlag::DirtyFogState);
+          m_dirty.set(D3D9DeviceDirtyFlag::FogState);
           break;
 
         case D3DRS_RANGEFOGENABLE:
-          m_flags.set(D3D9DeviceFlag::DirtyFFVertexShader);
+          m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
           break;
 
         case D3DRS_FOGCOLOR:
-          m_flags.set(D3D9DeviceFlag::DirtyFogColor);
+          m_dirty.set(D3D9DeviceDirtyFlag::FogColor);
           break;
 
         case D3DRS_FOGSTART:
-          m_flags.set(D3D9DeviceFlag::DirtyFogScale);
+          m_dirty.set(D3D9DeviceDirtyFlag::FogScale);
           break;
 
         case D3DRS_FOGEND:
-          m_flags.set(D3D9DeviceFlag::DirtyFogScale);
-          m_flags.set(D3D9DeviceFlag::DirtyFogEnd);
+          m_dirty.set(D3D9DeviceDirtyFlag::FogScale);
+          m_dirty.set(D3D9DeviceDirtyFlag::FogEnd);
           break;
 
         case D3DRS_FOGDENSITY:
-          m_flags.set(D3D9DeviceFlag::DirtyFogDensity);
+          m_dirty.set(D3D9DeviceDirtyFlag::FogDensity);
           break;
 
         case D3DRS_POINTSIZE: {
@@ -2562,7 +2565,7 @@ namespace dxvk {
         case D3DRS_POINTSCALE_A:
         case D3DRS_POINTSCALE_B:
         case D3DRS_POINTSCALE_C:
-          m_flags.set(D3D9DeviceFlag::DirtyPointScale);
+          m_dirty.set(D3D9DeviceDirtyFlag::PointScale);
           break;
 
         case D3DRS_POINTSCALEENABLE:
@@ -2572,22 +2575,22 @@ namespace dxvk {
           break;
 
         case D3DRS_SHADEMODE:
-          m_flags.set(D3D9DeviceFlag::DirtyRasterizerState);
+          m_dirty.set(D3D9DeviceDirtyFlag::RasterizerState);
           break;
 
         case D3DRS_TWEENFACTOR:
-          m_flags.set(D3D9DeviceFlag::DirtyFFVertexData);
+          m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
           break;
 
         case D3DRS_VERTEXBLEND:
-          m_flags.set(D3D9DeviceFlag::DirtyFFVertexShader);
+          m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
           break;
 
         case D3DRS_INDEXEDVERTEXBLENDENABLE:
           if (CanSWVP() && Value)
-            m_flags.set(D3D9DeviceFlag::DirtyFFVertexBlend);
+            m_dirty.set(D3D9DeviceDirtyFlag::FFVertexBlend);
 
-          m_flags.set(D3D9DeviceFlag::DirtyFFVertexShader);
+          m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
           break;
 
         case D3DRS_ADAPTIVETESS_Y: {
@@ -2632,10 +2635,10 @@ namespace dxvk {
           const bool nvdbEnabled = vendorId == nvidiaVendorId && IsNVDepthBoundsTestEnabled();
 
           if (nvdbEnabled || m_nvdbEnabled) {
-            m_flags.set(D3D9DeviceFlag::DirtyDepthBounds);
+            m_dirty.set(D3D9DeviceDirtyFlag::DepthBounds);
 
             if (likely(IsZTestEnabled()))
-              m_flags.set(D3D9DeviceFlag::DirtyFramebuffer);
+              m_dirty.set(D3D9DeviceDirtyFlag::Framebuffer);
 
             // NVDB state changes happen on D3DRS_ADAPTIVETESS_X,
             // whereas D3DRS_ADAPTIVETESS_Z and D3DRS_ADAPTIVETESS_W
@@ -2952,7 +2955,7 @@ namespace dxvk {
 
     m_state.scissorRect = *pRect;
 
-    m_flags.set(D3D9DeviceFlag::DirtyViewportScissor);
+    m_dirty.set(D3D9DeviceDirtyFlag::ViewportScissor);
 
     return D3D_OK;
   }
@@ -3358,7 +3361,7 @@ namespace dxvk {
 
     // We unbound the pixel shader before,
     // let's make sure that gets rebound.
-    m_flags.set(D3D9DeviceFlag::DirtyFFPixelShader);
+    m_dirty.set(D3D9DeviceDirtyFlag::FFPixelShader);
 
     if (m_state.pixelShader != nullptr) {
       BindShader<DxsoProgramTypes::PixelShader>(
@@ -3428,11 +3431,11 @@ namespace dxvk {
                     || decl->GetTexcoordMask() != m_state.vertexDecl->GetTexcoordMask();
 
     if (dirtyFFShader)
-      m_flags.set(D3D9DeviceFlag::DirtyFFVertexShader);
+      m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
 
     m_state.vertexDecl = decl;
 
-    m_flags.set(D3D9DeviceFlag::DirtyInputLayout);
+    m_dirty.set(D3D9DeviceDirtyFlag::InputLayout);
 
     return D3D_OK;
   }
@@ -3553,13 +3556,13 @@ namespace dxvk {
 
     if (shader != nullptr) {
       m_flags.clr(D3D9DeviceFlag::DirtyProgVertexShader);
-      m_flags.set(D3D9DeviceFlag::DirtyFFVertexShader);
+      m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
 
       BindShader<DxsoProgramTypes::VertexShader>(GetCommonShader(shader));
       UpdateTextureTypeMismatchesForShader(newShader, VSShaderMasks().samplerMask, FirstVSSamplerSlot);
     }
 
-    m_flags.set(D3D9DeviceFlag::DirtyInputLayout);
+    m_dirty.set(D3D9DeviceDirtyFlag::InputLayout);
 
     return D3D_OK;
   }
@@ -3794,7 +3797,7 @@ namespace dxvk {
     else
       m_vbSlotTracking.instanced &= ~(1u << StreamNumber);
 
-    m_flags.set(D3D9DeviceFlag::DirtyInputLayout);
+    m_dirty.set(D3D9DeviceDirtyFlag::InputLayout);
 
     return D3D_OK;
   }
@@ -3924,7 +3927,7 @@ namespace dxvk {
     const D3D9ShaderMasks newShaderMasks = PSShaderMasks();
 
     if (shader != nullptr) {
-      m_flags.set(D3D9DeviceFlag::DirtyFFPixelShader);
+      m_dirty.set(D3D9DeviceDirtyFlag::FFPixelShader);
 
       BindShader<DxsoProgramTypes::PixelShader>(newShader);
 
@@ -4606,7 +4609,7 @@ namespace dxvk {
       // we need to update the fixed function shader
       // because we generate a different shader based on whether each texture is bound.
       if (newTexture == nullptr || oldTexture == nullptr)
-        m_flags.set(D3D9DeviceFlag::DirtyFFPixelShader);
+        m_dirty.set(D3D9DeviceDirtyFlag::FFPixelShader);
     }
 
     bool oldTextureIsCube = oldTexture != nullptr && oldTexture->IsCube();
@@ -4634,10 +4637,10 @@ namespace dxvk {
 
     m_state.transforms[idx] = ConvertMatrix(pMatrix);
 
-    m_flags.set(D3D9DeviceFlag::DirtyFFVertexData);
+    m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
 
     if (idx == GetTransformIndex(D3DTS_VIEW) || idx >= GetTransformIndex(D3DTS_WORLD))
-      m_flags.set(D3D9DeviceFlag::DirtyFFVertexBlend);
+      m_dirty.set(D3D9DeviceDirtyFlag::FFVertexBlend);
 
     return D3D_OK;
   }
@@ -4671,11 +4674,11 @@ namespace dxvk {
         case DXVK_TSS_ALPHAARG1:
         case DXVK_TSS_ALPHAARG2:
         case DXVK_TSS_RESULTARG:
-          m_flags.set(D3D9DeviceFlag::DirtyFFPixelShader);
+          m_dirty.set(D3D9DeviceDirtyFlag::FFPixelShader);
           break;
 
         case DXVK_TSS_TEXCOORDINDEX:
-          m_flags.set(D3D9DeviceFlag::DirtyFFVertexShader);
+          m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
           break;
 
         case DXVK_TSS_TEXTURETRANSFORMFLAGS:
@@ -4683,8 +4686,8 @@ namespace dxvk {
           if (Value & D3DTTFF_PROJECTED)
             m_textureSlotTracking.projected |= 1 << Stage;
 
-          m_flags.set(D3D9DeviceFlag::DirtyFFVertexShader);
-          m_flags.set(D3D9DeviceFlag::DirtyFFPixelShader);
+          m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
+          m_dirty.set(D3D9DeviceDirtyFlag::FFPixelShader);
           break;
 
         case DXVK_TSS_BUMPENVMAT00:
@@ -4694,7 +4697,7 @@ namespace dxvk {
         case DXVK_TSS_BUMPENVLSCALE:
         case DXVK_TSS_BUMPENVLOFFSET:
         case DXVK_TSS_CONSTANT:
-          m_flags.set(D3D9DeviceFlag::DirtySharedPixelShaderData);
+          m_dirty.set(D3D9DeviceDirtyFlag::SharedPixelShaderData);
           break;
 
         default: break;
@@ -6239,7 +6242,7 @@ namespace dxvk {
       dst[i] = D3D9ClipPlane();
 
     if (m_specInfo.set<SpecClipPlaneCount>(clipPlaneCount))
-      m_flags.set(D3D9DeviceFlag::DirtySpecializationEntries);
+      m_dirty.set(D3D9DeviceDirtyFlag::SpecializationEntries);
   }
 
 
@@ -6418,7 +6421,7 @@ namespace dxvk {
 
     // Writes to render target 0 have been enabled and the RT might not be bound due to the 1x1 hack.
     if (Index == 0 && m_state.depthStencil != nullptr)
-      m_flags.set(D3D9DeviceFlag::DirtyFramebuffer);
+      m_dirty.set(D3D9DeviceDirtyFlag::Framebuffer);
   }
 
 
@@ -6449,7 +6452,7 @@ namespace dxvk {
       m_textureSlotTracking.textureType &= ~textureBitMask;
       m_textureSlotTracking.textureType |=  textureBits;
       if (oldTextureTypes != m_textureSlotTracking.textureType) {
-        m_flags.set(D3D9DeviceFlag::DirtyFFPixelShader);
+        m_dirty.set(D3D9DeviceDirtyFlag::FFPixelShader);
       }
     }
 
@@ -6560,7 +6563,7 @@ namespace dxvk {
     // Only dirty the framebuffer if we need to make changes for a new hazard
     if (unlikely(m_textureSlotTracking.hazardRT != oldHazardMask
       || m_textureSlotTracking.unresolvableHazardRT != oldUnresolvableHazardMask)) {
-      m_flags.set(D3D9DeviceFlag::DirtyFramebuffer);
+      m_dirty.set(D3D9DeviceDirtyFlag::Framebuffer);
     }
   }
 
@@ -6615,7 +6618,7 @@ namespace dxvk {
     // Only dirty the framebuffer if we need to make changes for a new hazard
     if (unlikely(m_textureSlotTracking.hazardDS != oldHazardMask
       || m_textureSlotTracking.unresolvableHazardDS != oldUnresolvableHazardMask)) {
-      m_flags.set(D3D9DeviceFlag::DirtyFramebuffer);
+      m_dirty.set(D3D9DeviceDirtyFlag::Framebuffer);
     }
   }
 
@@ -6655,7 +6658,7 @@ namespace dxvk {
       auto tex = GetCommonTexture(m_state.textures[samplerIdx]);
       if (unlikely(!tex->MarkTransitionedToHazardLayout())) {
         TransitionImage(tex, m_hazardLayout);
-        m_flags.set(D3D9DeviceFlag::DirtyFramebuffer);
+        m_dirty.set(D3D9DeviceDirtyFlag::Framebuffer);
       }
     }
   }
@@ -6848,7 +6851,7 @@ namespace dxvk {
     uint32_t mode = scaleBit | spriteBit;
 
     if (rs[D3DRS_POINTSCALEENABLE] && m_flags.test(D3D9DeviceFlag::DirtyPointScale)) {
-      m_flags.clr(D3D9DeviceFlag::DirtyPointScale);
+      m_dirty.clr(D3D9DeviceDirtyFlag::PointScale);
 
       UpdatePushConstant<D3D9RenderStateItem::PointScaleA>();
       UpdatePushConstant<D3D9RenderStateItem::PointScaleB>();
@@ -6869,24 +6872,24 @@ namespace dxvk {
 
     auto UpdateFogConstants = [&](D3DFOGMODE FogMode) {
       if (m_flags.test(D3D9DeviceFlag::DirtyFogColor)) {
-        m_flags.clr(D3D9DeviceFlag::DirtyFogColor);
+        m_dirty.clr(D3D9DeviceDirtyFlag::FogColor);
         UpdatePushConstant<D3D9RenderStateItem::FogColor>();
       }
 
       if (FogMode == D3DFOG_LINEAR) {
         if (m_flags.test(D3D9DeviceFlag::DirtyFogScale)) {
-          m_flags.clr(D3D9DeviceFlag::DirtyFogScale);
+          m_dirty.clr(D3D9DeviceDirtyFlag::FogScale);
           UpdatePushConstant<D3D9RenderStateItem::FogScale>();
         }
 
         if (m_flags.test(D3D9DeviceFlag::DirtyFogEnd)) {
-          m_flags.clr(D3D9DeviceFlag::DirtyFogEnd);
+          m_dirty.clr(D3D9DeviceDirtyFlag::FogEnd);
           UpdatePushConstant<D3D9RenderStateItem::FogEnd>();
         }
       }
       else if (FogMode == D3DFOG_EXP || FogMode == D3DFOG_EXP2) {
         if (m_flags.test(D3D9DeviceFlag::DirtyFogDensity)) {
-          m_flags.clr(D3D9DeviceFlag::DirtyFogDensity);
+          m_dirty.clr(D3D9DeviceDirtyFlag::FogDensity);
           UpdatePushConstant<D3D9RenderStateItem::FogDensity>();
         }
       }
@@ -6898,7 +6901,7 @@ namespace dxvk {
       UpdateFogConstants(mode);
 
       if (m_flags.test(D3D9DeviceFlag::DirtyFogState)) {
-        m_flags.clr(D3D9DeviceFlag::DirtyFogState);
+        m_dirty.clr(D3D9DeviceDirtyFlag::FogState);
 
         UpdateFogModeSpec(true, mode, D3DFOG_NONE);
       }
@@ -6909,7 +6912,7 @@ namespace dxvk {
       UpdateFogConstants(mode);
 
       if (m_flags.test(D3D9DeviceFlag::DirtyFogState)) {
-        m_flags.clr(D3D9DeviceFlag::DirtyFogState);
+        m_dirty.clr(D3D9DeviceDirtyFlag::FogState);
 
         UpdateFogModeSpec(true, D3DFOG_NONE, mode);
       }
@@ -6919,7 +6922,7 @@ namespace dxvk {
         UpdateFogConstants(D3DFOG_NONE);
 
       if (m_flags.test(D3D9DeviceFlag::DirtyFogState)) {
-        m_flags.clr(D3D9DeviceFlag::DirtyFogState);
+        m_dirty.clr(D3D9DeviceDirtyFlag::FogState);
 
         UpdateFogModeSpec(fogEnabled, D3DFOG_NONE, D3DFOG_NONE);
       }
@@ -6929,7 +6932,7 @@ namespace dxvk {
 
   void D3D9DeviceEx::BindFramebuffer() {
 
-    m_flags.clr(D3D9DeviceFlag::DirtyFramebuffer);
+    m_dirty.clr(D3D9DeviceDirtyFlag::Framebuffer);
 
     DxvkRenderTargets attachments;
 
@@ -7070,7 +7073,7 @@ namespace dxvk {
 
 
   void D3D9DeviceEx::BindViewportAndScissor() {
-    m_flags.clr(D3D9DeviceFlag::DirtyViewportScissor);
+    m_dirty.clr(D3D9DeviceDirtyFlag::ViewportScissor);
 
     // D3D9's coordinate system has its origin in the bottom left,
     // but the viewport coordinates are aligned to the top-left
@@ -7161,7 +7164,7 @@ namespace dxvk {
       alphaToCoverageEnabled &= isMultisampled;
 
       if (m_atocEnabled != alphaToCoverageEnabled) {
-        m_flags.set(D3D9DeviceFlag::DirtyMultiSampleState);
+        m_dirty.set(D3D9DeviceDirtyFlag::MultiSampleState);
         m_atocEnabled = alphaToCoverageEnabled;
       }
     }
@@ -7169,17 +7172,17 @@ namespace dxvk {
     // Update alpha test state
     bool alphaTestEnabled = m_state.renderStates[D3DRS_ALPHATESTENABLE] && !m_atocEnabled;
     if (m_alphaTestEnabled != alphaTestEnabled) {
-      m_flags.set(D3D9DeviceFlag::DirtyAlphaTestState);
+      m_dirty.set(D3D9DeviceDirtyFlag::AlphaTestState);
       m_alphaTestEnabled = alphaTestEnabled;
     }
   }
 
 
   void D3D9DeviceEx::BindMultiSampleState() {
-    m_flags.clr(D3D9DeviceFlag::DirtyMultiSampleState);
+    m_dirty.clr(D3D9DeviceDirtyFlag::MultiSampleState);
 
     DxvkMultisampleState msState = { };
-    msState.setSampleMask(m_flags.test(D3D9DeviceFlag::ValidSampleMask)
+    msState.setSampleMask(m_validSampleMask
       ? uint16_t(m_state.renderStates[D3DRS_MULTISAMPLEMASK])
       : uint16_t(0xffffu));
     msState.setAlphaToCoverage(m_atocEnabled);
@@ -7193,7 +7196,7 @@ namespace dxvk {
 
 
   void D3D9DeviceEx::BindBlendState() {
-    m_flags.clr(D3D9DeviceFlag::DirtyBlendState);
+    m_dirty.clr(D3D9DeviceDirtyFlag::BlendState);
 
     auto& state = m_state.renderStates;
 
@@ -7279,7 +7282,7 @@ namespace dxvk {
 
 
   void D3D9DeviceEx::BindDepthStencilState() {
-    m_flags.clr(D3D9DeviceFlag::DirtyDepthStencilState);
+    m_dirty.clr(D3D9DeviceDirtyFlag::DepthStencilState);
 
     auto& rs = m_state.renderStates;
 
@@ -7328,7 +7331,7 @@ namespace dxvk {
 
 
   void D3D9DeviceEx::BindRasterizerState() {
-    m_flags.clr(D3D9DeviceFlag::DirtyRasterizerState);
+    m_dirty.clr(D3D9DeviceDirtyFlag::RasterizerState);
 
     auto& rs = m_state.renderStates;
 
@@ -7351,7 +7354,7 @@ namespace dxvk {
 
 
   void D3D9DeviceEx::BindDepthBias() {
-    m_flags.clr(D3D9DeviceFlag::DirtyDepthBias);
+    m_dirty.clr(D3D9DeviceDirtyFlag::DepthBias);
 
     auto& rs = m_state.renderStates;
 
@@ -7408,7 +7411,7 @@ namespace dxvk {
 
 
   void D3D9DeviceEx::BindAlphaTestState() {
-    m_flags.clr(D3D9DeviceFlag::DirtyAlphaTestState);
+    m_dirty.clr(D3D9DeviceDirtyFlag::AlphaTestState);
 
     auto& rs = m_state.renderStates;
 
@@ -7636,10 +7639,10 @@ namespace dxvk {
 
     UpdateFog();
 
-    if (unlikely(m_flags.test(D3D9DeviceFlag::DirtyFramebuffer)))
+    if (unlikely(m_dirty.test(D3D9DeviceDirtyFlag::Framebuffer)))
       BindFramebuffer();
 
-    if (unlikely(m_flags.test(D3D9DeviceFlag::DirtyViewportScissor)))
+    if (unlikely(m_dirty.test(D3D9DeviceDirtyFlag::ViewportScissor)))
       BindViewportAndScissor();
 
     const uint32_t activeDirtySamplers = m_textureSlotTracking.samplerStateDirty & usedTextureMask;
@@ -7650,32 +7653,32 @@ namespace dxvk {
     if (likely(usedDirtyTextures))
       UndirtyTextures(usedDirtyTextures);
 
-    if (unlikely(m_flags.test(D3D9DeviceFlag::DirtyBlendState)))
+    if (unlikely(m_dirty.test(D3D9DeviceDirtyFlag::BlendState)))
       BindBlendState();
 
-    if (unlikely(m_flags.test(D3D9DeviceFlag::DirtyDepthStencilState)))
+    if (unlikely(m_dirty.test(D3D9DeviceDirtyFlag::DepthStencilState)))
       BindDepthStencilState();
 
-    if (unlikely(m_flags.test(D3D9DeviceFlag::DirtyRasterizerState)))
+    if (unlikely(m_dirty.test(D3D9DeviceDirtyFlag::RasterizerState)))
       BindRasterizerState();
 
-    if (unlikely(m_flags.test(D3D9DeviceFlag::DirtyDepthBias)))
+    if (unlikely(m_dirty.test(D3D9DeviceDirtyFlag::DepthBias)))
       BindDepthBias();
 
-    if (unlikely(m_flags.test(D3D9DeviceFlag::DirtyMultiSampleState)))
+    if (unlikely(m_dirty.test(D3D9DeviceDirtyFlag::MultiSampleState)))
       BindMultiSampleState();
 
-    if (unlikely(m_flags.test(D3D9DeviceFlag::DirtyAlphaTestState)))
+    if (unlikely(m_dirty.test(D3D9DeviceDirtyFlag::AlphaTestState)))
       BindAlphaTestState();
 
-    if (unlikely(m_flags.test(D3D9DeviceFlag::DirtyClipPlanes)))
+    if (unlikely(m_dirty.test(D3D9DeviceDirtyFlag::ClipPlanes)))
       UpdateClipPlanes();
 
     UpdatePointMode(PrimitiveType == D3DPT_POINTLIST);
 
     if (likely(UseProgrammableVS())) {
       if (unlikely(m_flags.test(D3D9DeviceFlag::DirtyProgVertexShader))) {
-        m_flags.set(D3D9DeviceFlag::DirtyInputLayout);
+        m_dirty.set(D3D9DeviceDirtyFlag::InputLayout);
 
         BindShader<DxsoProgramType::VertexShader>(
           GetCommonShader(m_state.vertexShader));
@@ -7694,7 +7697,7 @@ namespace dxvk {
       UpdateFixedFunctionVS();
     }
 
-    if (unlikely(m_flags.test(D3D9DeviceFlag::DirtyInputLayout)))
+    if (unlikely(m_dirty.test(D3D9DeviceDirtyFlag::InputLayout)))
       BindInputLayout();
 
     if (likely(UseProgrammablePS())) {
@@ -7727,8 +7730,8 @@ namespace dxvk {
     const uint32_t drefClampMask = m_textureSlotTracking.drefClamp & depthTextureMask;
     UpdateCommonSamplerSpec(nullTextureMask, depthTextureMask, drefClampMask);
 
-    if (unlikely(m_flags.test(D3D9DeviceFlag::DirtySharedPixelShaderData))) {
-      m_flags.clr(D3D9DeviceFlag::DirtySharedPixelShaderData);
+    if (unlikely(m_dirty.test(D3D9DeviceDirtyFlag::SharedPixelShaderData))) {
+      m_dirty.clr(D3D9DeviceDirtyFlag::SharedPixelShaderData);
 
       auto mapPtr = m_psShared.AllocSlice();
       D3D9SharedPS* data = reinterpret_cast<D3D9SharedPS*>(mapPtr);
@@ -7748,8 +7751,8 @@ namespace dxvk {
       }
     }
 
-    if (unlikely(m_flags.test(D3D9DeviceFlag::DirtyDepthBounds))) {
-      m_flags.clr(D3D9DeviceFlag::DirtyDepthBounds);
+    if (unlikely(m_dirty.test(D3D9DeviceDirtyFlag::DepthBounds))) {
+      m_dirty.clr(D3D9DeviceDirtyFlag::DepthBounds);
 
       DxvkDepthBounds db = { };
       db.minDepthBounds = 0.0f;
@@ -7774,18 +7777,18 @@ namespace dxvk {
 
     BindSpecConstants();
 
-    if (unlikely(m_flags.test(D3D9DeviceFlag::DirtyVertexBuffers) && UploadVBOs)) {
+    if (unlikely(m_dirty.test(D3D9DeviceDirtyFlag::VertexBuffers) && UploadVBOs)) {
       for (uint32_t i = 0; i < caps::MaxStreams; i++) {
         const D3D9VBO& vbo = m_state.vertexBuffers[i];
         BindVertexBuffer(i, vbo.vertexBuffer.ptr(),
           vbo.offset, vbo.length, vbo.stride);
       }
-      m_flags.clr(D3D9DeviceFlag::DirtyVertexBuffers);
+      m_dirty.clr(D3D9DeviceDirtyFlag::VertexBuffers);
     }
 
-    if (unlikely(m_flags.test(D3D9DeviceFlag::DirtyIndexBuffer) && UploadIBO)) {
+    if (unlikely(m_dirty.test(D3D9DeviceDirtyFlag::IndexBuffer) && UploadIBO)) {
       BindIndices();
-      m_flags.clr(D3D9DeviceFlag::DirtyIndexBuffer);
+      m_dirty.clr(D3D9DeviceDirtyFlag::IndexBuffer);
     }
   }
 
@@ -7871,7 +7874,7 @@ namespace dxvk {
 
 
   void D3D9DeviceEx::BindInputLayout() {
-    m_flags.clr(D3D9DeviceFlag::DirtyInputLayout);
+    m_dirty.clr(D3D9DeviceDirtyFlag::InputLayout);
 
     if (m_state.vertexDecl == nullptr) {
       EmitCs([&cIaState = m_iaState] (DxvkContext* ctx) {
@@ -8200,13 +8203,13 @@ namespace dxvk {
     }
 
     if (unlikely(hasPositionT && m_state.vertexShader != nullptr && !m_flags.test(D3D9DeviceFlag::DirtyProgVertexShader))) {
-      m_flags.set(D3D9DeviceFlag::DirtyInputLayout);
-      m_flags.set(D3D9DeviceFlag::DirtyFFVertexShader);
+      m_dirty.set(D3D9DeviceDirtyFlag::InputLayout);
+      m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
       m_flags.set(D3D9DeviceFlag::DirtyProgVertexShader);
     }
 
-    if (m_flags.test(D3D9DeviceFlag::DirtyFFVertexShader)) {
-      m_flags.clr(D3D9DeviceFlag::DirtyFFVertexShader);
+    if (m_dirty.test(D3D9DeviceDirtyFlag::FFVertexShader)) {
+      m_dirty.clr(D3D9DeviceDirtyFlag::FFVertexShader);
 
       D3D9FFShaderKeyVS key;
       key.Data.Contents.VertexHasPositionT = hasPositionT;
@@ -8279,9 +8282,9 @@ namespace dxvk {
       });
     }
 
-    if (hasPositionT && (m_flags.test(D3D9DeviceFlag::DirtyFFViewport) || m_ffZTest != IsZTestEnabled())) {
-      m_flags.clr(D3D9DeviceFlag::DirtyFFViewport);
-      m_flags.set(D3D9DeviceFlag::DirtyFFVertexData);
+    if (hasPositionT && (m_dirty.test(D3D9DeviceDirtyFlag::FFViewport) || m_ffZTest != IsZTestEnabled())) {
+      m_dirty.clr(D3D9DeviceDirtyFlag::FFViewport);
+      m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
 
       const auto& vp = m_state.viewport;
       // For us to account for the Vulkan viewport rules
@@ -8310,8 +8313,8 @@ namespace dxvk {
     }
 
     // Constants...
-    if (m_flags.test(D3D9DeviceFlag::DirtyFFVertexData)) {
-      m_flags.clr(D3D9DeviceFlag::DirtyFFVertexData);
+    if (m_dirty.test(D3D9DeviceDirtyFlag::FFVertexData)) {
+      m_dirty.clr(D3D9DeviceDirtyFlag::FFVertexData);
 
       auto mapPtr = m_vsFixedFunction.AllocSlice();
 
@@ -8344,8 +8347,8 @@ namespace dxvk {
       data->TweenFactor = bit::cast<float>(m_state.renderStates[D3DRS_TWEENFACTOR]);
     }
 
-    if (m_flags.test(D3D9DeviceFlag::DirtyFFVertexBlend) && vertexBlendMode == D3D9FF_VertexBlendMode_Normal) {
-      m_flags.clr(D3D9DeviceFlag::DirtyFFVertexBlend);
+    if (m_dirty.test(D3D9DeviceDirtyFlag::FFVertexBlend) && vertexBlendMode == D3D9FF_VertexBlendMode_Normal) {
+      m_dirty.clr(D3D9DeviceDirtyFlag::FFVertexBlend);
 
       auto mapPtr = m_vsVertexBlend.AllocSlice();
       auto UploadVertexBlendData = [&](auto data) {
@@ -8362,8 +8365,8 @@ namespace dxvk {
 
   void D3D9DeviceEx::UpdateFixedFunctionPS() {
     // Shader...
-    if (m_flags.test(D3D9DeviceFlag::DirtyFFPixelShader)) {
-      m_flags.clr(D3D9DeviceFlag::DirtyFFPixelShader);
+    if (m_dirty.test(D3D9DeviceDirtyFlag::FFPixelShader)) {
+      m_dirty.clr(D3D9DeviceDirtyFlag::FFPixelShader);
 
       // Used args for a given operation.
       auto ArgsMask = [](DWORD Op) {
@@ -8456,8 +8459,8 @@ namespace dxvk {
 
     // Constants
 
-    if (m_flags.test(D3D9DeviceFlag::DirtyFFPixelData)) {
-      m_flags.clr(D3D9DeviceFlag::DirtyFFPixelData);
+    if (m_dirty.test(D3D9DeviceDirtyFlag::FFPixelData)) {
+      m_dirty.clr(D3D9DeviceDirtyFlag::FFPixelData);
 
       auto mapPtr = m_psFixedFunction.AllocSlice();
       auto& rs = m_state.renderStates;
@@ -8682,7 +8685,7 @@ namespace dxvk {
     BindMultiSampleState();
 
     rs[D3DRS_TEXTUREFACTOR]       = 0xffffffff;
-    m_flags.set(D3D9DeviceFlag::DirtyFFPixelData);
+    m_dirty.set(D3D9DeviceDirtyFlag::FFPixelData);
 
     rs[D3DRS_DIFFUSEMATERIALSOURCE]  = D3DMCS_COLOR1;
     rs[D3DRS_SPECULARMATERIALSOURCE] = D3DMCS_COLOR2;
@@ -8693,13 +8696,13 @@ namespace dxvk {
     rs[D3DRS_LOCALVIEWER]            = TRUE;
     rs[D3DRS_RANGEFOGENABLE]         = FALSE;
     rs[D3DRS_NORMALIZENORMALS]       = FALSE;
-    m_flags.set(D3D9DeviceFlag::DirtyFFVertexShader);
+    m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
 
     // PS
     rs[D3DRS_SPECULARENABLE] = FALSE;
 
     rs[D3DRS_AMBIENT]                = 0;
-    m_flags.set(D3D9DeviceFlag::DirtyFFVertexData);
+    m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
 
     rs[D3DRS_FOGENABLE]                  = FALSE;
     rs[D3DRS_FOGCOLOR]                   = 0;
@@ -8708,14 +8711,14 @@ namespace dxvk {
     rs[D3DRS_FOGEND]                     = bit::cast<DWORD>(1.0f);
     rs[D3DRS_FOGDENSITY]                 = bit::cast<DWORD>(1.0f);
     rs[D3DRS_FOGVERTEXMODE]              = D3DFOG_NONE;
-    m_flags.set(D3D9DeviceFlag::DirtyFogColor);
-    m_flags.set(D3D9DeviceFlag::DirtyFogDensity);
-    m_flags.set(D3D9DeviceFlag::DirtyFogEnd);
-    m_flags.set(D3D9DeviceFlag::DirtyFogScale);
-    m_flags.set(D3D9DeviceFlag::DirtyFogState);
+    m_dirty.set(D3D9DeviceDirtyFlag::FogColor);
+    m_dirty.set(D3D9DeviceDirtyFlag::FogDensity);
+    m_dirty.set(D3D9DeviceDirtyFlag::FogEnd);
+    m_dirty.set(D3D9DeviceDirtyFlag::FogScale);
+    m_dirty.set(D3D9DeviceDirtyFlag::FogState);
 
     rs[D3DRS_CLIPPLANEENABLE] = 0;
-    m_flags.set(D3D9DeviceFlag::DirtyClipPlanes);
+    m_dirty.set(D3D9DeviceDirtyFlag::ClipPlanes);
 
     const VkPhysicalDeviceLimits& limits = m_dxvkDevice->adapter()->deviceProperties().limits;
 
@@ -8730,7 +8733,7 @@ namespace dxvk {
     UpdatePushConstant<D3D9RenderStateItem::PointSize>();
     UpdatePushConstant<D3D9RenderStateItem::PointSizeMin>();
     UpdatePushConstant<D3D9RenderStateItem::PointSizeMax>();
-    m_flags.set(D3D9DeviceFlag::DirtyPointScale);
+    m_dirty.set(D3D9DeviceDirtyFlag::PointScale);
     UpdatePointMode(false);
 
     rs[D3DRS_SRGBWRITEENABLE]            = 0;
@@ -8740,7 +8743,7 @@ namespace dxvk {
     rs[D3DRS_VERTEXBLEND]                = D3DVBF_DISABLE;
     rs[D3DRS_INDEXEDVERTEXBLENDENABLE]   = FALSE;
     rs[D3DRS_TWEENFACTOR]                = bit::cast<DWORD>(0.0f);
-    m_flags.set(D3D9DeviceFlag::DirtyFFVertexBlend);
+    m_dirty.set(D3D9DeviceDirtyFlag::FFVertexBlend);
 
     // Render States not implemented beyond this point.
     rs[D3DRS_LASTPIXEL]                  = TRUE;
@@ -8799,8 +8802,12 @@ namespace dxvk {
       stage[DXVK_TSS_RESULTARG]             = D3DTA_CURRENT;
       stage[DXVK_TSS_CONSTANT]              = 0x00000000;
     }
-    m_flags.set(D3D9DeviceFlag::DirtySharedPixelShaderData);
-    m_flags.set(D3D9DeviceFlag::DirtyFFPixelShader);
+
+    // Projected is set based on DXVK_TSS_TEXTURETRANSFORMFLAGS
+    m_textureSlotTracking.projected = 0;
+
+    m_dirty.set(D3D9DeviceDirtyFlag::SharedPixelShaderData);
+    m_dirty.set(D3D9DeviceDirtyFlag::FFPixelShader);
 
     for (uint32_t i = 0; i < caps::MaxStreams; i++)
       m_state.streamFreq[i] = 1;
@@ -8852,7 +8859,7 @@ namespace dxvk {
     }
 
     // We should do this...
-    m_flags.set(D3D9DeviceFlag::DirtyInputLayout);
+    m_dirty.set(D3D9DeviceDirtyFlag::InputLayout);
 
     UpdatePixelShaderSamplerSpec(0u, 0u, 0u);
     UpdateVertexBoolSpec(0u);
@@ -9105,19 +9112,19 @@ namespace dxvk {
          dirty |= m_specInfo.set<SpecAlphaPrecisionBits>(precision);
 
     if (dirty)
-      m_flags.set(D3D9DeviceFlag::DirtySpecializationEntries);
+      m_dirty.set(D3D9DeviceDirtyFlag::SpecializationEntries);
   }
 
 
   void D3D9DeviceEx::UpdateVertexBoolSpec(uint32_t value) {
     if (m_specInfo.set<SpecVertexShaderBools>(value))
-      m_flags.set(D3D9DeviceFlag::DirtySpecializationEntries);
+      m_dirty.set(D3D9DeviceDirtyFlag::SpecializationEntries);
   }
 
 
   void D3D9DeviceEx::UpdatePixelBoolSpec(uint32_t value) {
     if (m_specInfo.set<SpecPixelShaderBools>(value))
-      m_flags.set(D3D9DeviceFlag::DirtySpecializationEntries);
+      m_dirty.set(D3D9DeviceDirtyFlag::SpecializationEntries);
   }
 
 
@@ -9127,7 +9134,7 @@ namespace dxvk {
          dirty |= m_specInfo.set<SpecSamplerFetch4>(fetch4);
 
     if (dirty)
-      m_flags.set(D3D9DeviceFlag::DirtySpecializationEntries);
+      m_dirty.set(D3D9DeviceDirtyFlag::SpecializationEntries);
   }
 
 
@@ -9137,13 +9144,13 @@ namespace dxvk {
          dirty |= m_specInfo.set<SpecSamplerDrefClamp>(drefMask);
 
     if (dirty)
-      m_flags.set(D3D9DeviceFlag::DirtySpecializationEntries);
+      m_dirty.set(D3D9DeviceDirtyFlag::SpecializationEntries);
   }
 
 
   void D3D9DeviceEx::UpdatePointModeSpec(uint32_t mode) {
     if (m_specInfo.set<SpecPointMode>(mode))
-      m_flags.set(D3D9DeviceFlag::DirtySpecializationEntries);
+      m_dirty.set(D3D9DeviceDirtyFlag::SpecializationEntries);
   }
 
 
@@ -9153,12 +9160,12 @@ namespace dxvk {
          dirty |= m_specInfo.set<SpecPixelFogMode>(pixelFogMode);
 
     if (dirty)
-      m_flags.set(D3D9DeviceFlag::DirtySpecializationEntries);
+      m_dirty.set(D3D9DeviceDirtyFlag::SpecializationEntries);
   }
 
 
   void D3D9DeviceEx::BindSpecConstants() {
-    if (!m_flags.test(D3D9DeviceFlag::DirtySpecializationEntries))
+    if (!m_dirty.test(D3D9DeviceDirtyFlag::SpecializationEntries))
       return;
 
     EmitCs([cSpecInfo = m_specInfo](DxvkContext* ctx) {
@@ -9173,7 +9180,7 @@ namespace dxvk {
       memcpy(mapPtr, m_specInfo.data.data(), D3D9SpecializationInfo::UBOSize);
     }
 
-    m_flags.clr(D3D9DeviceFlag::DirtySpecializationEntries);
+    m_dirty.clr(D3D9DeviceDirtyFlag::SpecializationEntries);
   }
 
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -513,11 +513,12 @@ namespace dxvk {
       m_autoDepthStencil = nullptr;
 
       // Unbind all buffers that were still bound to the backend to avoid leaks.
-      EmitCs([](DxvkContext* ctx) {
+      EmitCs([] (DxvkContext* ctx) {
         ctx->bindIndexBuffer(DxvkBufferSlice(), VK_INDEX_TYPE_UINT32);
-        for (uint32_t i = 0; i < caps::MaxStreams; i++) {
+
+        for (uint32_t i = 0; i < caps::MaxStreams; i++)
           ctx->bindVertexBuffer(i, DxvkBufferSlice(), 0);
-        }
+
       });
 
       // Tests show that regular D3D9 ends the scene in Reset
@@ -3157,8 +3158,8 @@ namespace dxvk {
 
     m_state.vertexBuffers[0].vertexBuffer = nullptr;
     m_state.vertexBuffers[0].offset       = 0;
+    m_state.vertexBuffers[0].length       = 0;
     m_state.vertexBuffers[0].stride       = 0;
-
     return D3D_OK;
   }
 
@@ -3227,10 +3228,10 @@ namespace dxvk {
 
     m_state.vertexBuffers[0].vertexBuffer = nullptr;
     m_state.vertexBuffers[0].offset       = 0;
+    m_state.vertexBuffers[0].length       = 0;
     m_state.vertexBuffers[0].stride       = 0;
 
     m_state.indices = nullptr;
-
     return D3D_OK;
   }
 
@@ -3680,56 +3681,52 @@ namespace dxvk {
 
     D3D9VertexBuffer* buffer = static_cast<D3D9VertexBuffer*>(pStreamData);
 
-    if (unlikely(ShouldRecord()))
+    if (unlikely(ShouldRecord())) {
       return m_recorder->SetStreamSource(
-        StreamNumber,
-        buffer,
-        OffsetInBytes,
-        Stride);
-
-    auto& vbo = m_state.vertexBuffers[StreamNumber];
-    bool needsUpdate = vbo.vertexBuffer != buffer;
-
-    if (needsUpdate) {
-      if (likely(vbo.vertexBuffer != nullptr)) {
-        D3D9CommonBuffer* oldBuffer = vbo.vertexBuffer->GetCommonBuffer();
-        oldBuffer->SetBound(StreamNumber, false);
-        if (oldBuffer->GetMapMode() == D3D9_COMMON_BUFFER_MAP_MODE_DIRECT) {
-          TrackBufferSequenceNumber(oldBuffer);
-        }
-      }
-      vbo.vertexBuffer = buffer;
+        StreamNumber, buffer, OffsetInBytes, Stride);
     }
 
-    const uint32_t bit = 1u << StreamNumber;
-    m_vbSlotTracking.bound &= ~bit;
-    m_vbSlotTracking.uploadPerDraw &= ~bit;
-    m_vbSlotTracking.needsUpload &= ~bit;
+    auto& vbo = m_state.vertexBuffers[StreamNumber];
 
-    if (buffer != nullptr) {
-      buffer->GetCommonBuffer()->SetBound(StreamNumber, true);
+    if (vbo.vertexBuffer != buffer) {
+      const uint32_t bit = 1u << StreamNumber;
+      m_vbSlotTracking.uploadPerDraw &= ~bit;
+      m_vbSlotTracking.needsUpload &= ~bit;
 
-      needsUpdate |= vbo.offset != OffsetInBytes
-                  || vbo.stride != Stride;
+      if (likely(buffer)) {
+        const D3D9CommonBuffer* commonBuffer = GetCommonBuffer(buffer);
+        m_vbSlotTracking.bound |= bit;
 
+        if (commonBuffer->DoPerDrawUpload() || CanOnlySWVP())
+          m_vbSlotTracking.uploadPerDraw |= bit;
+
+        if (commonBuffer->NeedsUpload())
+          m_vbSlotTracking.needsUpload |= bit;
+
+        vbo.vertexBuffer = buffer;
+        vbo.length = commonBuffer->Desc()->Size;
+        vbo.offset = OffsetInBytes;
+        vbo.stride = Stride;
+
+        BindVertexBuffer(StreamNumber, buffer,
+          vbo.offset, vbo.length, vbo.stride);
+      } else {
+        // D3D9 doesn't actually unbind any vertex buffer when passing null.
+        // Operation Flashpoint: Red River relies on this behavior.
+        m_vbSlotTracking.bound &= ~bit;
+
+        vbo.vertexBuffer = nullptr;
+        vbo.offset = 0u;
+        vbo.length = 0u;
+        vbo.stride = 0u;
+      }
+    } else if (likely(buffer && (vbo.offset != OffsetInBytes || vbo.stride != Stride))) {
       vbo.offset = OffsetInBytes;
       vbo.stride = Stride;
 
-      const D3D9CommonBuffer* commonBuffer = GetCommonBuffer(buffer);
-      m_vbSlotTracking.bound |= bit;
-      if (commonBuffer->DoPerDrawUpload() || CanOnlySWVP())
-        m_vbSlotTracking.uploadPerDraw |= bit;
-      if (commonBuffer->NeedsUpload()) {
-        m_vbSlotTracking.needsUpload |= bit;
-      }
-    } else {
-      // D3D9 doesn't actually unbind any vertex buffer when passing null.
-      // Operation Flashpoint: Red River relies on this behavior.
-      needsUpdate = false;
+      BindVertexBufferRange(StreamNumber,
+        vbo.offset, vbo.length, vbo.stride);
     }
-
-    if (needsUpdate)
-      BindVertexBuffer(StreamNumber, buffer, OffsetInBytes, Stride);
 
     return D3D_OK;
   }
@@ -7780,7 +7777,8 @@ namespace dxvk {
     if (unlikely(m_flags.test(D3D9DeviceFlag::DirtyVertexBuffers) && UploadVBOs)) {
       for (uint32_t i = 0; i < caps::MaxStreams; i++) {
         const D3D9VBO& vbo = m_state.vertexBuffers[i];
-        BindVertexBuffer(i, vbo.vertexBuffer.ptr(), vbo.offset, vbo.stride);
+        BindVertexBuffer(i, vbo.vertexBuffer.ptr(),
+          vbo.offset, vbo.length, vbo.stride);
       }
       m_flags.clr(D3D9DeviceFlag::DirtyVertexBuffers);
     }
@@ -7982,33 +7980,65 @@ namespace dxvk {
         UINT                              Slot,
         D3D9VertexBuffer*                 pBuffer,
         UINT                              Offset,
+        UINT                              Length,
         UINT                              Stride) {
+    if (likely(pBuffer)) {
+      Offset = std::min(Offset, Length);
+
+      EmitCs([
+        cSlotId       = Slot,
+        cBuffer       = pBuffer->GetCommonBuffer()->GetBuffer<D3D9_COMMON_BUFFER_TYPE_REAL>(),
+        cOffset       = Offset,
+        cLength       = Length - Offset,
+        cStride       = Stride
+      ] (DxvkContext* ctx) mutable {
+        DxvkBufferSlice slice(std::move(cBuffer), cOffset, cLength);
+        ctx->bindVertexBuffer(cSlotId, std::move(slice), cStride);
+      });
+    } else {
+      EmitCs([cSlotId = Slot] (DxvkContext* ctx) mutable {
+        ctx->bindVertexBuffer(cSlotId, DxvkBufferSlice(), 0);
+      });
+    }
+  }
+
+
+  void D3D9DeviceEx::BindVertexBufferRange(
+          UINT                              Slot,
+          UINT                              Offset,
+          UINT                              Length,
+          UINT                              Stride) {
+    // Fast path for when only the offset of an already bound
+    // buffer changes to avoid ref-counting overhead.
+    Offset = std::min(Offset, Length);
+
     EmitCs([
       cSlotId       = Slot,
-      cBufferSlice  = pBuffer != nullptr ?
-          pBuffer->GetCommonBuffer()->GetBufferSlice<D3D9_COMMON_BUFFER_TYPE_REAL>(Offset)
-        : DxvkBufferSlice(),
-      cStride       = pBuffer != nullptr ? Stride : 0
-    ] (DxvkContext* ctx) mutable {
-      ctx->bindVertexBuffer(cSlotId, std::move(cBufferSlice), cStride);
+      cOffset       = Offset,
+      cLength       = Length - Offset,
+      cStride       = Stride
+    ] (DxvkContext* ctx) {
+      ctx->bindVertexBufferRange(cSlotId, cOffset, cLength, cStride);
     });
   }
 
+
   void D3D9DeviceEx::BindIndices() {
-    D3D9CommonBuffer* buffer = GetCommonBuffer(m_state.indices);
+    if (likely(m_state.indices)) {
+      D3D9CommonBuffer* buffer = m_state.indices->GetCommonBuffer();
+      VkIndexType indexType = DecodeIndexType(buffer->Desc()->Format);
 
-    D3D9Format format = buffer != nullptr
-                      ? buffer->Desc()->Format
-                      : D3D9Format::INDEX32;
-
-    const VkIndexType indexType = DecodeIndexType(format);
-
-    EmitCs([
-      cBufferSlice = buffer != nullptr ? buffer->GetBufferSlice<D3D9_COMMON_BUFFER_TYPE_REAL>() : DxvkBufferSlice(),
-      cIndexType   = indexType
-    ](DxvkContext* ctx) mutable {
-      ctx->bindIndexBuffer(std::move(cBufferSlice), cIndexType);
-    });
+      EmitCs([
+        cBufferSlice = buffer->GetBufferSlice<D3D9_COMMON_BUFFER_TYPE_REAL>(),
+        cIndexType   = indexType
+      ](DxvkContext* ctx) mutable {
+        ctx->bindIndexBuffer(std::move(cBufferSlice), cIndexType);
+      });
+    } else {
+      EmitCs([] (DxvkContext* ctx) {
+        ctx->bindIndexBuffer(DxvkBufferSlice(), VK_INDEX_TYPE_UINT32);
+      });
+    }
   }
 
 

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -80,6 +80,7 @@ namespace dxvk {
     FFPixelShader,
     FFViewport,
     FFPixelData,
+    ProgVertexShader,
     SharedPixelShaderData,
     DepthBounds,
     PointScale,

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -1101,6 +1101,13 @@ namespace dxvk {
             UINT                              Slot,
             D3D9VertexBuffer*                 pBuffer,
             UINT                              Offset,
+            UINT                              Length,
+            UINT                              Stride);
+
+    void BindVertexBufferRange(
+            UINT                              Slot,
+            UINT                              Offset,
+            UINT                              Length,
             UINT                              Stride);
 
     void BindIndices();

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -54,7 +54,7 @@ namespace dxvk {
   class D3D9FormatHelper;
   class D3D9UserDefinedAnnotation;
 
-  enum class D3D9DeviceFlag : uint32_t {
+  enum class D3D9DeviceDirtyFlag : uint32_t {
     Framebuffer,
     ClipPlanes,
     DepthStencilState,

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -55,43 +55,39 @@ namespace dxvk {
   class D3D9UserDefinedAnnotation;
 
   enum class D3D9DeviceFlag : uint32_t {
-    DirtyFramebuffer,
-    DirtyClipPlanes,
-    DirtyDepthStencilState,
-    DirtyBlendState,
-    DirtyRasterizerState,
-    DirtyDepthBias,
-    DirtyAlphaTestState,
-    DirtyInputLayout,
-    DirtyViewportScissor,
-    DirtyMultiSampleState,
-    DirtyVertexBuffers,
-    DirtyIndexBuffer,
+    Framebuffer,
+    ClipPlanes,
+    DepthStencilState,
+    BlendState,
+    RasterizerState,
+    DepthBias,
+    AlphaTestState,
+    InputLayout,
+    ViewportScissor,
+    MultiSampleState,
+    VertexBuffers,
+    IndexBuffer,
 
-    DirtyFogState,
-    DirtyFogColor,
-    DirtyFogDensity,
-    DirtyFogScale,
-    DirtyFogEnd,
+    FogState,
+    FogColor,
+    FogDensity,
+    FogScale,
+    FogEnd,
 
-    DirtyFFVertexData,
-    DirtyFFVertexBlend,
-    DirtyFFVertexShader,
-    DirtyFFPixelShader,
-    DirtyFFViewport,
-    DirtyFFPixelData,
-    DirtyProgVertexShader,
-    DirtySharedPixelShaderData,
-    ValidSampleMask,
-    DirtyDepthBounds,
-    DirtyPointScale,
+    FFVertexData,
+    FFVertexBlend,
+    FFVertexShader,
+    FFPixelShader,
+    FFViewport,
+    FFPixelData,
+    SharedPixelShaderData,
+    DepthBounds,
+    PointScale,
 
-    InScene,
-
-    DirtySpecializationEntries,
+    SpecializationEntries,
   };
 
-  using D3D9DeviceFlags = Flags<D3D9DeviceFlag>;
+  using D3D9DeviceDirtyFlags = Flags<D3D9DeviceDirtyFlag>;
 
   enum class D3D9DeviceLostState {
     Ok = 0,
@@ -1640,7 +1636,7 @@ namespace dxvk {
     D3D9Multithread                 m_multithread;
     D3D9InputAssemblyState          m_iaState;
 
-    D3D9DeviceFlags                 m_flags;
+    D3D9DeviceDirtyFlags            m_dirty;
 
     D3D9TextureSlotTracking         m_textureSlotTracking;
 
@@ -1663,6 +1659,9 @@ namespace dxvk {
     // vendor hack state tracking
     bool                            m_atocEnabled      = false;
     bool                            m_nvdbEnabled      = false;
+
+    bool                            m_inScene          = false;
+    bool                            m_validSampleMask  = false;
 
     VkImageLayout                   m_hazardLayout = VK_IMAGE_LAYOUT_GENERAL;
 

--- a/src/d3d9/d3d9_fixed_function.cpp
+++ b/src/d3d9/d3d9_fixed_function.cpp
@@ -15,7 +15,6 @@ namespace dxvk {
   D3D9FixedFunctionOptions::D3D9FixedFunctionOptions(const D3D9Options* options) {
     invariantPosition = options->invariantPosition;
     forceSampleRateShading = options->forceSampleRateShading;
-    drefScaling = options->drefScaling;
   }
 
   uint32_t DoFixedFunctionFog(D3D9ShaderSpecConstantManager& spec, SpirvModule& spvModule, const D3D9FogContext& fogCtx) {
@@ -108,7 +107,7 @@ namespace dxvk {
 
       for (uint32_t i = 0; i < fogCaseLabels.size(); i++) {
         spvModule.opLabel(fogCaseLabels[i].labelId);
-        
+
         fogVariables[i].labelId = fogCaseLabels[i].labelId;
         fogVariables[i].varId   = [&] {
           auto mode = D3DFOGMODE(fogCaseLabels[i].literal);
@@ -149,7 +148,7 @@ namespace dxvk {
             }
           }
         }();
-        
+
         spvModule.opBranch(applyFogFactor);
       }
 
@@ -362,7 +361,7 @@ namespace dxvk {
     uint32_t rsBlock = spvModule.newVar(
       spvModule.defPointerType(rsStruct, spv::StorageClassPushConstant),
       spv::StorageClassPushConstant);
-    
+
     spvModule.setDebugName         (rsBlock, "render_state");
 
     spvModule.setDebugName         (rsStruct, "render_state_t");
@@ -600,7 +599,7 @@ namespace dxvk {
     NormalMatrix,
     InverseViewMatrix,
     ProjMatrix,
-      
+
     Texcoord0,
     Texcoord1,
     Texcoord2,
@@ -798,6 +797,7 @@ namespace dxvk {
     uint32_t              m_vec2Type        = 0u;
     uint32_t              m_mat3Type        = 0u;
     uint32_t              m_mat4Type        = 0u;
+    uint32_t              m_boolType        = 0u;
 
     uint32_t              m_entryPointId    = 0u;
 
@@ -842,6 +842,7 @@ namespace dxvk {
     m_vec2Type   = m_module.defVectorType(m_floatType, 2);
     m_mat3Type   = m_module.defMatrixType(m_vec3Type, 3);
     m_mat4Type   = m_module.defMatrixType(m_vec4Type, 4);
+    m_boolType   = m_module.defBoolType();
 
     m_entryPointId = m_module.allocateId();
 
@@ -977,7 +978,7 @@ namespace dxvk {
 
     const uint32_t wIndex = 3;
 
-    if (!m_vsKey.Data.Contents.HasPositionT) {
+    if (!m_vsKey.Data.Contents.VertexHasPositionT) {
       if (m_vsKey.Data.Contents.VertexBlendMode == D3D9FF_VertexBlendMode_Normal) {
         uint32_t blendWeightRemaining = m_module.constf32(1);
         uint32_t vtxSum               = 0;
@@ -1054,10 +1055,9 @@ namespace dxvk {
 
       // Some games rely no normals not being normal.
       if (m_vsKey.Data.Contents.NormalizeNormals) {
-        uint32_t bool_t = m_module.defBoolType();
-        uint32_t bool3_t = m_module.defVectorType(bool_t, 3);
+        uint32_t bool3_t = m_module.defVectorType(m_boolType, 3);
 
-        uint32_t isZeroNormal = m_module.opAll(bool_t, m_module.opFOrdEqual(bool3_t, normal, m_module.constvec3f32(0.0f, 0.0f, 0.0f)));
+        uint32_t isZeroNormal = m_module.opAll(m_boolType, m_module.opFOrdEqual(bool3_t, normal, m_module.constvec3f32(0.0f, 0.0f, 0.0f)));
 
         std::array<uint32_t, 3> members = { isZeroNormal, isZeroNormal, isZeroNormal };
         uint32_t isZeroNormal3 = m_module.opCompositeConstruct(bool3_t, members.size(), members.data());
@@ -1065,7 +1065,7 @@ namespace dxvk {
         normal = m_module.opNormalize(m_vec3Type, normal);
         normal = m_module.opSelect(m_vec3Type, isZeroNormal3, m_module.constvec3f32(0.0f, 0.0f, 0.0f), normal);
       }
-      
+
       gl_Position = emitVectorTimesMatrix(4, 4, vtx, m_vs.constants.proj);
     } else {
       gl_Position = m_module.opFMul(m_vec4Type, gl_Position, m_vs.constants.invExtent);
@@ -1076,10 +1076,8 @@ namespace dxvk {
       // gl_Position.w    = 1.0f / gl_Position.w
       // gl_Position.xyz *= gl_Position.w;
 
-      uint32_t bool_t  = m_module.defBoolType();
-
       uint32_t w   = m_module.opCompositeExtract (m_floatType, gl_Position, 1, &wIndex);      // w = gl_Position.w
-      uint32_t is0 = m_module.opFOrdEqual        (bool_t,      w, m_module.constf32(0));      // is0 = w == 0
+      uint32_t is0 = m_module.opFOrdEqual        (m_boolType,      w, m_module.constf32(0));      // is0 = w == 0
       uint32_t rhw = m_module.opFDiv             (m_floatType, m_module.constf32(1.0f), w);   // rhw = 1.0f / w
                rhw = m_module.opSelect           (m_floatType, is0, m_module.constf32(1.0), rhw); // rhw = w == 0 ? 1.0 : rhw
       gl_Position  = m_module.opVectorTimesScalar(m_vec4Type,  gl_Position, rhw);             // gl_Position.xyz *= rhw
@@ -1127,7 +1125,7 @@ namespace dxvk {
             transformed = m_module.opCompositeInsert(m_vec4Type, m_module.constf32(0), transformed, 1, &wIndex);
           }
 
-          if (applyTransform && !m_vsKey.Data.Contents.HasPositionT) {
+          if (applyTransform && !m_vsKey.Data.Contents.VertexHasPositionT) {
             /*This doesn't happen every time and I cannot figure out the difference between when it does and doesn't.
             Keep it disabled for now, it's more likely that games rely on the zero texcoord than the weird 1 here.
             if (texcoordCount <= 1) {
@@ -1208,7 +1206,7 @@ namespace dxvk {
         }
       }
 
-      if (applyTransform && !m_vsKey.Data.Contents.HasPositionT) {
+      if (applyTransform && !m_vsKey.Data.Contents.VertexHasPositionT) {
         transformed = m_module.opVectorTimesMatrix(m_vec4Type, transformed, m_vs.constants.texcoord[i]);
       }
 
@@ -1273,11 +1271,10 @@ namespace dxvk {
         uint32_t theta     = LoadLightItem(m_floatType, 11);
         uint32_t phi       = LoadLightItem(m_floatType, 12);
 
-        uint32_t bool_t  = m_module.defBoolType();
-        uint32_t bool3_t = m_module.defVectorType(bool_t, 3);
+        uint32_t bool3_t = m_module.defVectorType(m_boolType, 3);
 
-        uint32_t isSpot        = m_module.opIEqual(bool_t, type, m_module.constu32(D3DLIGHT_SPOT));
-        uint32_t isDirectional = m_module.opIEqual(bool_t, type, m_module.constu32(D3DLIGHT_DIRECTIONAL));
+        uint32_t isSpot        = m_module.opIEqual(m_boolType, type, m_module.constu32(D3DLIGHT_SPOT));
+        uint32_t isDirectional = m_module.opIEqual(m_boolType, type, m_module.constu32(D3DLIGHT_DIRECTIONAL));
 
         std::array<uint32_t, 3> members = { isDirectional, isDirectional, isDirectional };
 
@@ -1298,7 +1295,7 @@ namespace dxvk {
                  atten  = m_module.opFDiv  (m_floatType, m_module.constf32(1.0f), atten);
                  atten  = m_module.opNMin  (m_floatType, atten, m_module.constf32(std::numeric_limits<float>::max()));
 
-                 atten  = m_module.opSelect(m_floatType, m_module.opFOrdGreaterThan(bool_t, d, range), m_module.constf32(0.0f), atten);
+                 atten  = m_module.opSelect(m_floatType, m_module.opFOrdGreaterThan(m_boolType, d, range), m_module.constf32(0.0f), atten);
                  atten  = m_module.opSelect(m_floatType, isDirectional, m_module.constf32(1.0f), atten);
 
         // Spot Lighting
@@ -1308,8 +1305,8 @@ namespace dxvk {
                    spotAtten  = m_module.opFDiv(m_floatType, spotAtten, m_module.opFSub(m_floatType, theta, phi));
                    spotAtten  = m_module.opPow (m_floatType, spotAtten, falloff);
 
-          uint32_t insideThetaAndPhi = m_module.opFOrdLessThanEqual(bool_t, rho, theta);
-          uint32_t insidePhi         = m_module.opFOrdGreaterThan(bool_t, rho, phi);
+          uint32_t insideThetaAndPhi = m_module.opFOrdLessThanEqual(m_boolType, rho, theta);
+          uint32_t insidePhi         = m_module.opFOrdGreaterThan(m_boolType, rho, phi);
                    spotAtten  = m_module.opSelect(m_floatType, insidePhi,         spotAtten, m_module.constf32(0.0f));
                    spotAtten  = m_module.opSelect(m_floatType, insideThetaAndPhi, spotAtten, m_module.constf32(1.0f));
                    spotAtten  = m_module.opFClamp(m_floatType, spotAtten, m_module.constf32(0.0f), m_module.constf32(1.0f));
@@ -1336,8 +1333,8 @@ namespace dxvk {
 
         uint32_t midDot = m_module.opDot(m_floatType, normal, mid);
                  midDot = m_module.opFClamp(m_floatType, midDot, m_module.constf32(0.0f), m_module.constf32(1.0f));
-        uint32_t doSpec = m_module.opFOrdGreaterThan(bool_t, midDot, m_module.constf32(0.0f));
-                 doSpec = m_module.opLogicalAnd(bool_t, doSpec, m_module.opFOrdGreaterThan(bool_t, hitDot, m_module.constf32(0.0f)));
+        uint32_t doSpec = m_module.opFOrdGreaterThan(m_boolType, midDot, m_module.constf32(0.0f));
+                 doSpec = m_module.opLogicalAnd(m_boolType, doSpec, m_module.opFOrdGreaterThan(m_boolType, hitDot, m_module.constf32(0.0f)));
 
         uint32_t specularness = m_module.opPow(m_floatType, midDot, m_vs.constants.materialPower);
                  specularness = m_module.opFMul(m_floatType, specularness, atten);
@@ -1356,7 +1353,7 @@ namespace dxvk {
       uint32_t mat_ambient  = PickSource(m_vsKey.Data.Contents.AmbientSource,  m_vs.constants.materialAmbient);
       uint32_t mat_emissive = PickSource(m_vsKey.Data.Contents.EmissiveSource, m_vs.constants.materialEmissive);
       uint32_t mat_specular = PickSource(m_vsKey.Data.Contents.SpecularSource, m_vs.constants.materialSpecular);
-      
+
       std::array<uint32_t, 4> alphaSwizzle = {0, 1, 2, 7};
       uint32_t finalColor0 = m_module.opFFma(m_vec4Type, mat_ambient, m_vs.constants.globalAmbient, mat_emissive);
                finalColor0 = m_module.opFFma(m_vec4Type, mat_ambient, ambientValue, finalColor0);
@@ -1387,12 +1384,12 @@ namespace dxvk {
     fogCtx.RangeFog    = m_vsKey.Data.Contents.RangeFog;
     fogCtx.RenderState = m_rsBlock;
     fogCtx.vPos        = vtx;
-    fogCtx.HasFogInput = m_vsKey.Data.Contents.HasFog;
+    fogCtx.HasFogInput = m_vsKey.Data.Contents.VertexHasFog;
     fogCtx.vFog        = m_vs.in.FOG;
     fogCtx.oColor      = 0;
     fogCtx.IsFixedFunction = true;
-    fogCtx.IsPositionT = m_vsKey.Data.Contents.HasPositionT;
-    fogCtx.HasSpecular = m_vsKey.Data.Contents.HasColor1;
+    fogCtx.IsPositionT = m_vsKey.Data.Contents.VertexHasPositionT;
+    fogCtx.HasSpecular = m_vsKey.Data.Contents.VertexHasColor1;
     fogCtx.Specular    = m_vs.in.COLOR[1];
     fogCtx.SpecUBO     = m_specUbo;
     m_module.opStore(m_vs.out.FOG, DoFixedFunctionFog(m_spec, m_module, fogCtx));
@@ -1705,26 +1702,26 @@ namespace dxvk {
     for (uint32_t i = 0; i < caps::TextureStageCount; i++)
       m_vs.in.TEXCOORD[i] = declareIO(true, DxsoSemantic{ DxsoUsage::Texcoord, i });
 
-    if (m_vsKey.Data.Contents.HasColor0)
+    if (m_vsKey.Data.Contents.VertexHasColor0)
       m_vs.in.COLOR[0] = declareIO(true, DxsoSemantic{ DxsoUsage::Color, 0 });
     else {
       m_vs.in.COLOR[0] = m_module.constvec4f32(1.0f, 1.0f, 1.0f, 1.0f);
       m_isgn.elemCount++;
     }
 
-    if (m_vsKey.Data.Contents.HasColor1)
+    if (m_vsKey.Data.Contents.VertexHasColor1)
       m_vs.in.COLOR[1] = declareIO(true, DxsoSemantic{ DxsoUsage::Color, 1 });
     else {
       m_vs.in.COLOR[1] = m_module.constvec4f32(0.0f, 0.0f, 0.0f, 0.0f);
       m_isgn.elemCount++;
     }
 
-    if (m_vsKey.Data.Contents.HasFog)
+    if (m_vsKey.Data.Contents.VertexHasFog)
       m_vs.in.FOG = declareIO(true, DxsoSemantic{ DxsoUsage::Fog,   0 });
     else
       m_isgn.elemCount++;
 
-    if (m_vsKey.Data.Contents.HasPointSize)
+    if (m_vsKey.Data.Contents.VertexHasPointSize)
       m_vs.in.POINTSIZE = declareIO(true, DxsoSemantic{ DxsoUsage::PointSize, 0 });
     else
       m_isgn.elemCount++;
@@ -1855,10 +1852,16 @@ namespace dxvk {
             uint32_t reference = m_module.opCompositeExtract(m_floatType, texcoord, 1, &component);
 
             // [D3D8] Scale Dref to [0..(2^N - 1)] for D24S8 and D16 if Dref scaling is enabled
-            if (m_options.drefScaling) {
-              uint32_t maxDref = m_module.constf32(1.0f / (float(1 << m_options.drefScaling) - 1.0f));
-              reference        = m_module.opFMul(m_floatType, reference, maxDref);
-            }
+            uint32_t drefScaleShift = m_spec.get(m_module, m_specUbo, SpecDrefScaling);
+            uint32_t drefScale      = m_module.opShiftLeftLogical(m_uint32Type, m_module.constu32(1), drefScaleShift);
+            drefScale               = m_module.opConvertUtoF(m_floatType, drefScale);
+            drefScale               = m_module.opFSub(m_floatType, drefScale, m_module.constf32(1.0f));
+            drefScale               = m_module.opFDiv(m_floatType, m_module.constf32(1.0f), drefScale);
+            reference               = m_module.opSelect(m_floatType,
+              m_module.opINotEqual(m_boolType, drefScaleShift, m_module.constu32(0)),
+              m_module.opFMul(m_floatType, reference, drefScale),
+              reference
+            );
 
             texture = m_module.opImageSampleDrefImplicitLod(m_floatType, imageVarId, texcoord, reference, imageOperands);
             texture = ScalarReplicate(texture);
@@ -1878,7 +1881,7 @@ namespace dxvk {
             uint32_t lOffset = m_module.opAccessChain(m_module.defPointerType(m_floatType, spv::StorageClassUniform),
                                                      m_ps.sharedState, 1, &index);
                      lOffset = m_module.opLoad(m_floatType, lOffset);
-            
+
             uint32_t zIndex = 2;
             uint32_t scale = m_module.opCompositeExtract(m_floatType, texture, 1, &zIndex);
                      scale = m_module.opFMul(m_floatType, scale, lScale);
@@ -2368,20 +2371,20 @@ namespace dxvk {
     uint32_t worldPos = emitMatrixTimesVector(4, 4, m_vs.constants.inverseView, vtx);
 
     uint32_t clipPlaneCountId = m_module.constu32(caps::MaxClipPlanes);
-    
+
     uint32_t floatType = m_module.defFloatType(32);
     uint32_t vec4Type  = m_module.defVectorType(floatType, 4);
     uint32_t boolType  = m_module.defBoolType();
-    
+
     // Declare uniform buffer containing clip planes
     uint32_t clipPlaneArray  = m_module.defArrayTypeUnique(vec4Type, clipPlaneCountId);
     uint32_t clipPlaneStruct = m_module.defStructTypeUnique(1, &clipPlaneArray);
     uint32_t clipPlaneBlock  = m_module.newVar(
       m_module.defPointerType(clipPlaneStruct, spv::StorageClassUniform),
       spv::StorageClassUniform);
-    
+
     m_module.decorateArrayStride  (clipPlaneArray, 16);
-    
+
     m_module.setDebugName         (clipPlaneStruct, "clip_info_t");
     m_module.setDebugMemberName   (clipPlaneStruct, 0, "clip_planes");
     m_module.decorate             (clipPlaneStruct, spv::DecorationBlock);

--- a/src/d3d9/d3d9_fixed_function.h
+++ b/src/d3d9/d3d9_fixed_function.h
@@ -49,12 +49,7 @@ namespace dxvk {
 
     bool    invariantPosition;
     bool    forceSampleRateShading;
-    int32_t drefScaling;
   };
-
-  constexpr float GetDrefScaleFactor(int32_t bitDepth) {
-    return 1.0f / (float(1 << bitDepth) - 1.0f);
-  }
 
   // Returns new oFog if VS
   // Returns new oColor if PS
@@ -100,12 +95,12 @@ namespace dxvk {
       struct {
         uint32_t TexcoordIndices : 24;
 
-        uint32_t HasPositionT : 1;
+        uint32_t VertexHasPositionT : 1;
 
-        uint32_t HasColor0 : 1; // Diffuse
-        uint32_t HasColor1 : 1; // Specular
+        uint32_t VertexHasColor0 : 1; // Diffuse
+        uint32_t VertexHasColor1 : 1; // Specular
 
-        uint32_t HasPointSize : 1;
+        uint32_t VertexHasPointSize : 1;
 
         uint32_t UseLighting : 1;
 
@@ -125,11 +120,11 @@ namespace dxvk {
         uint32_t LightCount : 4;
 
         uint32_t TexcoordDeclMask : 24;
-        uint32_t HasFog : 1;
+        uint32_t VertexHasFog : 1;
 
         uint32_t VertexBlendMode    : 2;
         uint32_t VertexBlendIndexed : 1;
-        uint32_t VertexBlendCount   : 3;
+        uint32_t VertexBlendCount   : 2;
 
         uint32_t VertexClipping     : 1;
 

--- a/src/d3d9/d3d9_spec_constants.h
+++ b/src/d3d9/d3d9_spec_constants.h
@@ -15,22 +15,23 @@ namespace dxvk {
 
     SpecSamplerDepthMode,   // 1 bit for 21 VS + PS samplers  | Bits: 21
     SpecAlphaCompareOp,     // Range: 0 -> 7                  | Bits: 3
-    SpecPointMode,          // Range: 0 -> 3                  | Bits: 2
-    SpecVertexFogMode,      // Range: 0 -> 3                  | Bits: 2
-    SpecPixelFogMode,       // Range: 0 -> 3                  | Bits: 2
-    SpecFogEnabled,         // Range: 0 -> 1                  | Bits: 1
+    SpecSamplerProjected,   // 1 bit for 6 PS 1.x samplers    | Bits: 6
 
     SpecSamplerNull,        // 1 bit for 21 samplers          | Bits: 21
-    SpecProjectionType,     // 1 bit for 6 PS 1.x samplers    | Bits: 6
     SpecAlphaPrecisionBits, // Range: 0 -> 8 or 0xF           | Bits: 4
+    SpecFogEnabled,         // Range: 0 -> 1                  | Bits: 1
+    SpecVertexFogMode,      // Range: 0 -> 3                  | Bits: 2
+    SpecPixelFogMode,       // Range: 0 -> 3                  | Bits: 2
 
     SpecVertexShaderBools,  // 16 bools                       | Bits: 16
     SpecPixelShaderBools,   // 16 bools                       | Bits: 16
 
-    SpecFetch4,             // 1 bit for 16 PS samplers       | Bits: 16
+    SpecSamplerFetch4,      // 1 bit for 16 PS samplers       | Bits: 16
 
-    SpecDrefClamp,          // 1 bit for 21 VS + PS samplers  | Bits: 21
+    SpecSamplerDrefClamp,   // 1 bit for 21 VS + PS samplers  | Bits: 21
     SpecClipPlaneCount,     // 3 bits for 6 clip planes       | Bits : 3
+    SpecPointMode,          // Range: 0 -> 3                  | Bits: 2
+    SpecDrefScaling,        // Range: 0-31 | Bits: 5
 
     SpecConstantCount,
   };
@@ -46,6 +47,7 @@ namespace dxvk {
   };
 
   struct D3D9SpecializationInfo {
+    // Spec const word 0 determines whether the other spec constants are used rather than the spec const UBO
     static constexpr uint32_t MaxSpecDwords = 6;
 
     static constexpr uint32_t MaxUBODwords  = 5;
@@ -56,22 +58,23 @@ namespace dxvk {
 
       { 1, 0,  21 }, // SamplerDepthMode
       { 1, 21, 3 },  // AlphaCompareOp
-      { 1, 24, 2 },  // PointMode
-      { 1, 26, 2 },  // VertexFogMode
-      { 1, 28, 2 },  // PixelFogMode
-      { 1, 30, 1 },  // FogEnabled
+      { 1, 24, 6 },  // SamplerProjected
 
       { 2, 0,  21 }, // SamplerNull
-      { 2, 21, 6 },  // ProjectionType
-      { 2, 27, 4 },  // AlphaPrecisionBits
+      { 2, 21, 4 },  // AlphaPrecisionBits
+      { 2, 25, 1 },  // FogEnabled
+      { 2, 26, 2 },  // VertexFogMode
+      { 2, 28, 2 },  // PixelFogMode
 
       { 3, 0,  16 }, // VertexShaderBools
       { 3, 16, 16 }, // PixelShaderBools
 
-      { 4, 0,  16 }, // Fetch4
+      { 4, 0,  16 }, // SamplerFetch4
 
-      { 5, 0, 21 },  // DrefClamp
+      { 5, 0, 21 },  // SamplerDrefClamp
       { 5, 21, 3 },  // ClipPlaneCount
+      { 5, 24, 2 },  // PointMode
+      { 5, 26, 5 },  // DrefScaling
     }};
 
     template <D3D9SpecConstantId Id, typename T>

--- a/src/d3d9/d3d9_state.h
+++ b/src/d3d9/d3d9_state.h
@@ -164,6 +164,7 @@ namespace dxvk {
     Com<D3D9VertexBuffer, false> vertexBuffer;
 
     UINT              offset = 0;
+    UINT              length = 0;
     UINT              stride = 0;
   };
 

--- a/src/d3d9/d3d9_subresource.h
+++ b/src/d3d9/d3d9_subresource.h
@@ -84,8 +84,13 @@ namespace dxvk {
         // that have GENERAL (or FEEDBACK_LOOP) as their layout.
         // Because of that, we don't need to pay special attention here
         // to whether the image was transitioned because of a feedback loop.
+
+        VkImageUsageFlags usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+        if (m_texture->GetImage()->info().usage & VK_IMAGE_USAGE_ATTACHMENT_FEEDBACK_LOOP_BIT_EXT)
+          usage |= VK_IMAGE_USAGE_ATTACHMENT_FEEDBACK_LOOP_BIT_EXT | VK_IMAGE_USAGE_SAMPLED_BIT;
+
         view = m_texture->CreateView(m_face, m_mipLevel,
-          VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT,
+          usage,
           VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
           Srgb && m_isSrgbCompatible);
       }
@@ -103,12 +108,17 @@ namespace dxvk {
         // that have GENERAL (or FEEDBACK_LOOP) as their layout.
         // Because of that, we don't need to pay special attention here
         // to whether the image was transitioned because of a feedback loop.
+
+        VkImageUsageFlags usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
+        if (m_texture->GetImage()->info().usage & VK_IMAGE_USAGE_ATTACHMENT_FEEDBACK_LOOP_BIT_EXT)
+          usage |= VK_IMAGE_USAGE_ATTACHMENT_FEEDBACK_LOOP_BIT_EXT | VK_IMAGE_USAGE_SAMPLED_BIT;
+
         VkImageLayout layout = Writable
           ? VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL
           : VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL;
 
         view = m_texture->CreateView(m_face, m_mipLevel,
-          VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, layout, false);
+          usage, layout, false);
       }
 
       return view;

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -961,7 +961,7 @@ namespace dxvk {
     for (uint32_t i = 1; i < rotatingBufferCount; i++)
       m_backBuffers[i]->Swap(m_backBuffers[i - 1].ptr());
 
-    m_parent->m_flags.set(D3D9DeviceFlag::DirtyFramebuffer);
+    m_parent->m_dirty.set(D3D9DeviceDirtyFlag::Framebuffer);
   }
 
 

--- a/src/dxso/dxso_compiler.cpp
+++ b/src/dxso/dxso_compiler.cpp
@@ -2731,7 +2731,7 @@ void DxsoCompiler::emitControlFlowGenericLoop(
       uint32_t projResult = m_module.opVectorTimesScalar(texcoord_t, coord.id, projScalar);
 
       if (switchProjRes) {
-        uint32_t shouldProj = m_spec.get(m_module, m_specUbo, SpecProjectionType, samplerIdx, 1);
+        uint32_t shouldProj = m_spec.get(m_module, m_specUbo, SpecSamplerProjected, samplerIdx, 1);
         shouldProj = m_module.opINotEqual(bool_t, shouldProj, m_module.constu32(0));
 
         uint32_t bvec4_t = m_module.defVectorType(bool_t, 4);
@@ -2911,19 +2911,26 @@ void DxsoCompiler::emitControlFlowGenericLoop(
 
       uint32_t reference = 0;
       if (depth) {
+        uint32_t uiType = m_module.defIntType(32, false);
         uint32_t fType = m_module.defFloatType(32);
         uint32_t component = sampler.dimensions;
         reference = m_module.opCompositeExtract(
           fType, texcoordVar.id, 1, &component);
 
         // [D3D8] Scale Dref from [0..(2^N - 1)] for D24S8 and D16 if Dref scaling is enabled
-        if (m_moduleInfo.options.drefScaling) {
-          uint32_t drefScale       = m_module.constf32(GetDrefScaleFactor(m_moduleInfo.options.drefScaling));
-          reference                = m_module.opFMul(fType, reference, drefScale);
-        }
+        uint32_t drefScaleShift = m_spec.get(m_module, m_specUbo, SpecDrefScaling);
+        uint32_t drefScale      = m_module.opShiftLeftLogical(uiType, m_module.constu32(1), drefScaleShift);
+        drefScale               = m_module.opConvertUtoF(fType, drefScale);
+        drefScale               = m_module.opFSub(fType, drefScale, m_module.constf32(1.0f));
+        drefScale               = m_module.opFDiv(fType, m_module.constf32(1.0f), drefScale);
+        reference               = m_module.opSelect(fType,
+          m_module.opINotEqual(bool_t, drefScaleShift, m_module.constu32(0)),
+          m_module.opFMul(fType, reference, drefScale),
+          reference
+        );
 
         // Clamp Dref to [0..1] for D32F emulating UNORM textures 
-        uint32_t clampDref = m_spec.get(m_module, m_specUbo, SpecDrefClamp, samplerIdx, 1);
+        uint32_t clampDref = m_spec.get(m_module, m_specUbo, SpecSamplerDrefClamp, samplerIdx, 1);
         clampDref = m_module.opINotEqual(bool_t, clampDref, m_module.constu32(0));
         uint32_t clampedDref = m_module.opFClamp(fType, reference, m_module.constf32(0.0f), m_module.constf32(1.0f));
         reference = m_module.opSelect(fType, clampDref, clampedDref, reference);
@@ -2931,7 +2938,7 @@ void DxsoCompiler::emitControlFlowGenericLoop(
 
       uint32_t fetch4 = 0;
       if (m_programInfo.type() == DxsoProgramType::PixelShader && samplerType != SamplerTypeTexture3D) {
-        fetch4 = m_spec.get(m_module, m_specUbo, SpecFetch4, samplerIdx, 1);
+        fetch4 = m_spec.get(m_module, m_specUbo, SpecSamplerFetch4, samplerIdx, 1);
 
         fetch4 = m_module.opINotEqual(bool_t, fetch4, m_module.constu32(0));
 
@@ -3320,18 +3327,32 @@ void DxsoCompiler::emitControlFlowGenericLoop(
 
 
   void DxsoCompiler::emitLinkerOutputSetup() {
-    bool outputtedColor0 = false;
-    bool outputtedColor1 = false;
+    std::array<bool, 2> outputtedColor = {};
+    std::array<bool, 8> outputtedTexcoords = {};
+    bool outputtedNormals = false;
 
     for (uint32_t i = 0; i < m_osgn.elemCount; i++) {
       const auto& elem = m_osgn.elems[i];
       const uint32_t slot = elem.slot;
 
-      if (elem.semantic.usage == DxsoUsage::Color) {
-        if (elem.semantic.usageIndex == 0)
-          outputtedColor0 = true;
-        else
-          outputtedColor1 = true;
+      switch (elem.semantic.usage) {
+        case DxsoUsage::Color:
+          if (elem.semantic.usageIndex < outputtedColor.size()) {
+            outputtedColor[elem.semantic.usageIndex] = true;
+          }
+          break;
+
+        case DxsoUsage::Normal:
+          outputtedNormals = true;
+          break;
+
+
+        case DxsoUsage::Texcoord:
+          if (elem.semantic.usageIndex < outputtedTexcoords.size()) {
+            outputtedTexcoords[elem.semantic.usageIndex] = true;
+          }
+          break;
+        default: break; // Silence GCC warnings
       }
       
       DxsoRegisterInfo info;
@@ -3443,16 +3464,21 @@ void DxsoCompiler::emitControlFlowGenericLoop(
     auto OutputDefault = [&](DxsoSemantic semantic) {
       DxsoRegisterInfo info;
       info.type.ctype   = DxsoScalarType::Float32;
-      info.type.ccount  = 4;
+      info.type.ccount  = semantic.usage != DxsoUsage::Fog ? 4 : 1;
       info.type.alength = 1;
       info.sclass       = spv::StorageClassOutput;
 
       uint32_t slot = RegisterLinkerSlot(semantic);
 
-      uint32_t value = semantic == DxsoSemantic{ DxsoUsage::Color, 0 }
-        ? m_module.constvec4f32(1.0f, 1.0f, 1.0f, 1.0f)
-        : m_module.constvec4f32(0.0f, 0.0f, 0.0f, 0.0f);
+      uint32_t value;
 
+      if (semantic == DxsoSemantic{ DxsoUsage::Color, 0 }) {
+        value = m_module.constvec4f32(1.0f, 1.0f, 1.0f, 1.0f);
+      } else if (semantic == DxsoSemantic{ DxsoUsage::Fog, 0}) {
+        value = m_module.constf32(0.0);
+      } else {
+        value = m_module.constvec4f32(0.0f, 0.0f, 0.0f, 0.0f);
+      }
 
       uint32_t outputPtr = emitNewVariableDefault(info, value);
 
@@ -3466,11 +3492,30 @@ void DxsoCompiler::emitControlFlowGenericLoop(
       m_outputMask |= 1u << slot;
     };
 
-    if (!outputtedColor0)
-      OutputDefault(DxsoSemantic{ DxsoUsage::Color, 0 });
-
-    if (!outputtedColor1)
-      OutputDefault(DxsoSemantic{ DxsoUsage::Color, 1 });
+    if (m_programInfo.majorVersion() == 3) {
+      // Assume that shader model 3 vertex shaders hardly ever get mixed with fixed function pixel processing
+      // If they do, the backend handles it. Color 0 is the exception because that needs a different value.
+      if (!outputtedColor[0]) {
+        OutputDefault(DxsoSemantic{ DxsoUsage::Color, 0 });
+      }
+    } else {
+      // Emit the outputs that fixed function expects but the shader didn't emit itself.
+      // This avoids SPIR-V patching in the backend which would disable fast linked pipelines.
+      for (uint32_t i = 0; i < outputtedColor.size(); i++) {
+        if (outputtedColor[i]) continue;
+        OutputDefault(DxsoSemantic{ DxsoUsage::Color, i });
+      }
+      for (uint32_t i = 0; i < outputtedTexcoords.size(); i++) {
+        if (outputtedTexcoords[i]) continue;
+        OutputDefault(DxsoSemantic{ DxsoUsage::Texcoord, i });
+      }
+      if (!outputtedNormals) {
+        OutputDefault(DxsoSemantic{ DxsoUsage::Normal, 0 });
+      }
+      if (m_fog.id == 0) {
+        OutputDefault(DxsoSemantic{ DxsoUsage::Fog, 0 });
+      }
+    }
 
     auto pointInfo = GetPointSizeInfoVS(m_spec, m_module, m_vs.oPos.id, 0, 0, m_rsBlock, m_specUbo, false);
 

--- a/src/dxso/dxso_options.cpp
+++ b/src/dxso/dxso_options.cpp
@@ -30,7 +30,6 @@ namespace dxvk {
     robustness2Supported = devFeatures.extRobustness2.robustBufferAccess2;
 
     sincosEmulation     = options.sincosEmulation;
-    drefScaling         = options.drefScaling;
   }
 
 }

--- a/src/dxso/dxso_options.h
+++ b/src/dxso/dxso_options.h
@@ -44,12 +44,6 @@ namespace dxvk {
 
     /// Whether or not we need to use custom sincos
     bool sincosEmulation = false;
-
-    /// Whether runtime to apply Dref scaling for depth textures of specified bit depth
-    /// (24: D24S8, 16: D16, 0: Disabled). This allows compatability with games
-    /// that expect a different depth test range, which was typically a D3D8 quirk on
-    /// early NVIDIA hardware.
-    int32_t drefScaling = 0;
   };
 
 }

--- a/src/dxso/dxso_util.cpp
+++ b/src/dxso/dxso_util.cpp
@@ -5,15 +5,33 @@
 namespace dxvk {
 
   dxvk::mutex                  g_linkerSlotMutex;
-  uint32_t                     g_linkerSlotCount = 0;
-  std::array<DxsoSemantic, 32> g_linkerSlots;
+  uint32_t                     g_linkerSlotCount = 12;
+  std::array<DxsoSemantic, 32> g_linkerSlots = {
+    {
+      {DxsoUsage::Normal,   0},
+      {DxsoUsage::Texcoord,   0},
+      {DxsoUsage::Texcoord,   1},
+      {DxsoUsage::Texcoord,   2},
+      {DxsoUsage::Texcoord,   3},
+      {DxsoUsage::Texcoord,   4},
+      {DxsoUsage::Texcoord,   5},
+      {DxsoUsage::Texcoord,   6},
+      {DxsoUsage::Texcoord,   7},
+
+      {DxsoUsage::Color,      0},
+      {DxsoUsage::Color,      1},
+
+      {DxsoUsage::Fog,        0},
+    }};
+  // We set fixed locations for the outputs that fixed function vertex shaders
+  // can produce so the uber shader doesn't need to be patched at runtime.
 
   uint32_t RegisterLinkerSlot(DxsoSemantic semantic) {
     // Lock, because games could be trying
     // to make multiple shaders at a time.
     std::lock_guard<dxvk::mutex> lock(g_linkerSlotMutex);
 
-    // Need to chose a slot that maps nicely and similarly
+    // Need to choose a slot that maps nicely and similarly
     // between vertex and pixel shaders
 
     // Find or map a slot.

--- a/src/dxvk/dxvk_buffer.h
+++ b/src/dxvk/dxvk_buffer.h
@@ -705,12 +705,12 @@ namespace dxvk {
   }
 
 
-  inline void DxvkBufferView::incRef() {
+  force_inline void DxvkBufferView::incRef() {
     m_buffer->incRef();
   }
 
 
-  inline void DxvkBufferView::decRef() {
+  force_inline void DxvkBufferView::decRef() {
     m_buffer->decRef();
   }
 

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -263,12 +263,12 @@ namespace dxvk {
             VkShaderStageFlags    stages,
             uint32_t              slot,
             Rc<DxvkImageView>&&   view) {
-      if (m_resources[slot].bufferView)
+      if (likely(m_resources[slot].imageView != view)) {
         m_resources[slot].bufferView = nullptr;
+        m_resources[slot].imageView = std::move(view);
 
-      m_resources[slot].imageView = std::move(view);
-
-      m_descriptorState.dirtyViews(stages);
+        m_descriptorState.dirtyViews(stages);
+      }
     }
 
     /**
@@ -282,12 +282,12 @@ namespace dxvk {
             VkShaderStageFlags    stages,
             uint32_t              slot,
             Rc<DxvkBufferView>&&  view) {
-      if (m_resources[slot].imageView)
+      if (likely(m_resources[slot].bufferView != view)) {
         m_resources[slot].imageView = nullptr;
+        m_resources[slot].bufferView = std::move(view);
 
-      m_resources[slot].bufferView = std::move(view);
-
-      m_descriptorState.dirtyViews(stages);
+        m_descriptorState.dirtyViews(stages);
+      }
     }
 
     /**
@@ -303,9 +303,11 @@ namespace dxvk {
             VkShaderStageFlags    stages,
             uint32_t              slot,
             Rc<DxvkSampler>&&     sampler) {
-      m_samplers[slot] = std::move(sampler);
+      if (likely(m_samplers[slot] != sampler)) {
+        m_samplers[slot] = std::move(sampler);
 
-      m_descriptorState.dirtyViews(stages);
+        m_descriptorState.dirtyViews(stages);
+      }
     }
 
     /**

--- a/src/dxvk/dxvk_gpu_event.h
+++ b/src/dxvk/dxvk_gpu_event.h
@@ -42,7 +42,7 @@ namespace dxvk {
     /**
      * \brief Increments ref count
      */
-    void incRef() {
+    force_inline void incRef() {
       m_refs.fetch_add(1u, std::memory_order_acquire);
     }
 
@@ -52,7 +52,7 @@ namespace dxvk {
      * Returns event to the pool if no further
      * references exist for this event.
      */
-    void decRef() {
+    force_inline void decRef() {
       if (m_refs.fetch_sub(1u, std::memory_order_release) == 1u)
         free();
     }

--- a/src/dxvk/dxvk_image.cpp
+++ b/src/dxvk/dxvk_image.cpp
@@ -448,10 +448,10 @@ namespace dxvk {
   : m_image   (image),
     m_key     (key) {
     // If the view does not define a layout, figure out a suitable
-    // layout based on image view usage and image prperties. This
+    // layout based on image view usage and image properties. This
     // will be good enough in most situations.
     if (!m_key.layout) {
-      switch (m_key.usage) {
+      switch (m_key.usage & ~VK_IMAGE_USAGE_ATTACHMENT_FEEDBACK_LOOP_BIT_EXT) {
         case VK_IMAGE_USAGE_SAMPLED_BIT:
           m_key.layout = (m_image->formatInfo()->aspectMask & (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT))
             ? VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL
@@ -552,7 +552,7 @@ namespace dxvk {
 
     // We need to expose RT and UAV swizzles to the backend,
     // but cannot legally pass them down to Vulkan
-    if (key.usage != VK_IMAGE_USAGE_SAMPLED_BIT)
+    if ((key.usage & ~VK_IMAGE_USAGE_ATTACHMENT_FEEDBACK_LOOP_BIT_EXT) != VK_IMAGE_USAGE_SAMPLED_BIT)
       key.packedSwizzle = 0u;
 
     return m_image->m_storage->createImageView(key);

--- a/src/dxvk/dxvk_image.h
+++ b/src/dxvk/dxvk_image.h
@@ -801,12 +801,12 @@ namespace dxvk {
 
 
 
-  inline void DxvkImageView::incRef() {
+  force_inline void DxvkImageView::incRef() {
     m_image->incRef();
   }
 
 
-  inline void DxvkImageView::decRef() {
+  force_inline void DxvkImageView::decRef() {
     m_image->decRef();
   }
 

--- a/src/dxvk/dxvk_memory.cpp
+++ b/src/dxvk/dxvk_memory.cpp
@@ -123,8 +123,6 @@ namespace dxvk {
     auto& descriptor = m_views.emplace(std::piecewise_construct,
       std::tuple(key), std::tuple()).first->second;
 
-    VkImageUsageFlags shaderResourceUsage = key.usage & (VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_STORAGE_BIT);
-
     VkImageViewUsageCreateInfo usage = { VK_STRUCTURE_TYPE_IMAGE_VIEW_USAGE_CREATE_INFO };
     usage.usage = key.usage;
 

--- a/src/dxvk/dxvk_memory.cpp
+++ b/src/dxvk/dxvk_memory.cpp
@@ -123,7 +123,7 @@ namespace dxvk {
     auto& descriptor = m_views.emplace(std::piecewise_construct,
       std::tuple(key), std::tuple()).first->second;
 
-    bool isShaderResource = key.usage & (VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_STORAGE_BIT);
+    VkImageUsageFlags shaderResourceUsage = key.usage & (VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_STORAGE_BIT);
 
     VkImageViewUsageCreateInfo usage = { VK_STRUCTURE_TYPE_IMAGE_VIEW_USAGE_CREATE_INFO };
     usage.usage = key.usage;

--- a/src/dxvk/dxvk_memory.cpp
+++ b/src/dxvk/dxvk_memory.cpp
@@ -96,14 +96,16 @@ namespace dxvk {
   DxvkResourceImageViewMap::DxvkResourceImageViewMap(
           DxvkMemoryAllocator*        allocator,
           VkImage                     image)
-  : m_vkd(allocator->device()->vkd()), m_image(image) {
+   : m_device(allocator->device()), m_image(image) {
 
   }
 
 
   DxvkResourceImageViewMap::~DxvkResourceImageViewMap() {
+    auto vk = m_device->vkd();
+
     for (const auto& view : m_views)
-      m_vkd->vkDestroyImageView(m_vkd->device(), view.second.legacy.image.imageView, nullptr);
+      vk->vkDestroyImageView(vk->device(), view.second.legacy.image.imageView, nullptr);
   }
 
 
@@ -115,6 +117,13 @@ namespace dxvk {
 
     if (entry != m_views.end())
       return &entry->second;
+
+    auto vk = m_device->vkd();
+
+    auto& descriptor = m_views.emplace(std::piecewise_construct,
+      std::tuple(key), std::tuple()).first->second;
+
+    bool isShaderResource = key.usage & (VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_STORAGE_BIT);
 
     VkImageViewUsageCreateInfo usage = { VK_STRUCTURE_TYPE_IMAGE_VIEW_USAGE_CREATE_INFO };
     usage.usage = key.usage;
@@ -130,17 +139,15 @@ namespace dxvk {
     info.subresourceRange.baseArrayLayer = key.layerIndex;
     info.subresourceRange.layerCount = key.layerCount;
 
-    DxvkDescriptor descriptor = { };
     descriptor.legacy.image.imageLayout = key.layout;
 
-    VkResult vr = m_vkd->vkCreateImageView(
-      m_vkd->device(), &info, nullptr, &descriptor.legacy.image.imageView);
+    VkResult vr = vk->vkCreateImageView(
+      vk->device(), &info, nullptr, &descriptor.legacy.image.imageView);
 
     if (vr != VK_SUCCESS)
       throw DxvkError(str::format("Failed to create Vulkan image view: ", vr));
 
-    entry = m_views.insert({ key, descriptor }).first;
-    return &entry->second;
+    return &descriptor;
   }
 
 
@@ -1160,15 +1167,15 @@ namespace dxvk {
     VkMemoryPriorityAllocateInfoEXT priorityInfo = { VK_STRUCTURE_TYPE_MEMORY_PRIORITY_ALLOCATE_INFO_EXT };
 
     if (type.properties.propertyFlags & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT) {
-      if (type.properties.propertyFlags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) {
-        // BAR allocation. Give this a low priority since these are typically useful
-        // when when placed in system memory.
-        priorityInfo.priority = 0.0f;
-      } else if (next) {
+      if (next) {
         // Dedicated allocation, may or may not be a shared resource. Assign this the
         // highest priority since this is expected to be a high-bandwidth resource,
-        // such as a render target.
+        // such as a render target or a descriptor heap. The latter may be host-visible.
         priorityInfo.priority = 1.0f;
+      } else if (type.properties.propertyFlags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) {
+        // Regular HVV allocation. Give this a low priority since these are typically
+        // useful when when placed in system memory.
+        priorityInfo.priority = 0.0f;
       } else {
         // Standard priority for resource allocations
         priorityInfo.priority = 0.5f;

--- a/src/dxvk/dxvk_memory.h
+++ b/src/dxvk/dxvk_memory.h
@@ -417,7 +417,7 @@ namespace dxvk {
 
   private:
 
-    Rc<vk::DeviceFn>  m_vkd;
+    DxvkDevice*       m_device = nullptr;
     VkImage           m_image = VK_NULL_HANDLE;
 
     dxvk::mutex       m_mutex;

--- a/src/dxvk/dxvk_memory.h
+++ b/src/dxvk/dxvk_memory.h
@@ -332,7 +332,7 @@ namespace dxvk {
     /// View type
     VkImageViewType viewType = VK_IMAGE_VIEW_TYPE_MAX_ENUM;
     /// View usage flags
-    VkImageUsageFlagBits usage = VkImageUsageFlagBits(0u);
+    VkImageUsageFlags usage = VkImageUsageFlags(0u);
     /// View format
     VkFormat format = VK_FORMAT_UNDEFINED;
     /// Image layout that the view will be used as

--- a/src/util/sync/sync_signal.h
+++ b/src/util/sync/sync_signal.h
@@ -55,6 +55,34 @@ namespace dxvk::sync {
     
   };
 
+  /**
+   * \brief Sync point
+   *
+   * Convenience class that stores a sync
+   * object and a value to wait on.
+   */
+  class SyncPoint {
+
+  public:
+
+    SyncPoint() = default;
+    SyncPoint(Rc<Signal> signal, uint64_t value)
+    : m_signal(std::move(signal)), m_value(value) { }
+
+    void synchronize() {
+      if (m_signal) {
+        m_signal->wait(m_value);
+        m_signal = nullptr;
+      }
+    }
+
+  private:
+
+    Rc<Signal>  m_signal;
+    uint64_t    m_value = 0u;
+
+  };
+
 #ifdef _WIN32
   /**
    * \brief Fence


### PR DESCRIPTION
[841c499](https://github.com/doitsujin/dxvk/commit/841c499ed6230d48df64eff03b3b603358d555ad) - [dxvk] Get raw image view descriptors - [Implement descriptor buffers](https://github.com/doitsujin/dxvk/pull/4948)

[ff0f815](https://github.com/doitsujin/dxvk/commit/ff0f8157493181b3e3e2dca574f60246f4e601ee) - [util] Add convenience class for fence sync points - [Implement descriptor buffers](https://github.com/doitsujin/dxvk/pull/4948)

[0e78a8c](https://github.com/doitsujin/dxvk/commit/0e78a8c7c2f6dc2ecec3812bde70ba7da7a846b9) - [dxvk] Assign high memory priority to dedicated HVV allocations - [Implement descriptor buffers](https://github.com/doitsujin/dxvk/pull/4948)

[b327601](https://github.com/doitsujin/dxvk/commit/b327601362a5891164e4c81cea889530302dbbab) - [dxvk] Check whether views and samplers actually changed - [Implement descriptor buffers](https://github.com/doitsujin/dxvk/pull/4948)

[95001cd](https://github.com/doitsujin/dxvk/commit/95001cd64a1a0baad9464a927960c14c72359d70) - [dxvk] Use force_inline for some common refcounting methods - [Implement descriptor buffers](https://github.com/doitsujin/dxvk/pull/4948)

[833ee11](https://github.com/doitsujin/dxvk/commit/833ee1168c20c17fb43d3aff95a9ca96c2f46f9c) - [dxvk] Turn image view usage to flag type - [[d3d9] Add feedback loop usage to RT image view](https://github.com/doitsujin/dxvk/pull/5154)

[635dae6](https://github.com/doitsujin/dxvk/commit/635dae65d073e0d3e97bb233ebd1dd6ac1c6f443) - [d3d9] Add feedback loop usage to attachment image views - [[d3d9] Add feedback loop usage to RT image view](https://github.com/doitsujin/dxvk/pull/5154)

[cac185f](https://github.com/doitsujin/dxvk/commit/cac185f9b568eba4388e466c02997cf9c6aaa079) - [d3d9] Update the new texture type before checking diff

[b433d32](https://github.com/doitsujin/dxvk/commit/b433d3278035ddf2b883be7aa52f77dad7643acd) - [d3d9] Statically register all linker slots used by FF - [[d3d9] Preparation for the FF Ubershader](https://github.com/doitsujin/dxvk/pull/5203)

[ca749ed](https://github.com/doitsujin/dxvk/commit/ca749ed464ddfba46aab5e4b1342490508135270) - [dxso] Emit all outputs that fixed function fragment shaders expect - [[d3d9] Preparation for the FF Ubershader](https://github.com/doitsujin/dxvk/pull/5203)

[159f0c4](https://github.com/doitsujin/dxvk/commit/159f0c4da6734cac93dd1a5551a7b5462e65834d) - [d3d9] Reorganize spec constants - [[d3d9] Preparation for the FF Ubershader](https://github.com/doitsujin/dxvk/pull/5203)

[ed17382](https://github.com/doitsujin/dxvk/commit/ed17382bac0c3f53c61eda1ea020897fe484face) - [d3d9] Slightly improve spec const naming - [[d3d9] Preparation for the FF Ubershader](https://github.com/doitsujin/dxvk/pull/5203)

[2c3869a](https://github.com/doitsujin/dxvk/commit/2c3869ab2be5332c77f9846d9cc54274a30b98ee) - [d3d9] Turn drefScaling into spec constant - [[d3d9] Preparation for the FF Ubershader](https://github.com/doitsujin/dxvk/pull/5203)

[252891d](https://github.com/doitsujin/dxvk/commit/252891db8a4591d7b2b64c9067933cc19e4f74aa) - [d3d9] Reduce size of VertexBlendCount field - [[d3d9] Preparation for the FF Ubershader](https://github.com/doitsujin/dxvk/pull/5203)

[bb24f08](https://github.com/doitsujin/dxvk/commit/bb24f08cc80f25f648032e708a0a7b1d7ce4bd42) - [d3d9] Clean up parts of the fixed function generator - [[d3d9] Preparation for the FF Ubershader](https://github.com/doitsujin/dxvk/pull/5203)

[0e06635](https://github.com/doitsujin/dxvk/commit/0e06635e833b0b4c6836b3cfcdd3bc80ebe2b0ed) - [d3d9] Simplify vertex and index buffer binding - [Optimize D3D9 vertex buffer binding](https://github.com/doitsujin/dxvk/pull/5704)

[ea98788](https://github.com/doitsujin/dxvk/commit/ea987889efefa0839fdbb889c6a14b29ba470da8) - [d3d9] Only update buffer range when re-binding same vertex buffer - [Optimize D3D9 vertex buffer binding](https://github.com/doitsujin/dxvk/pull/5704)

[e4e43ed](https://github.com/doitsujin/dxvk/commit/e4e43edbcf57fa5e4859ed11b93f74887dc7a91f) - [d3d9] Move non-dirty flags out of D3D9DeviceFlag - [[d3d9] Move non-dirty flags out of D3D9DeviceFlag](https://github.com/doitsujin/dxvk/pull/5293)

[bd0dc07](https://github.com/doitsujin/dxvk/commit/bd0dc07ca93c40be2e8939a30baa7b4dcc0a3ba0) - [d3d9] Clean up SetRenderTargetInternal - [[d3d9] Move non-dirty flags out of D3D9DeviceFlag](https://github.com/doitsujin/dxvk/pull/5293)

[4bf7f3f](https://github.com/doitsujin/dxvk/commit/4bf7f3f156d727d8c107c39270a93eca6223ec9e) - [d3d9] Use D_READONLY_S_OPTIMAL layout for DS sampling views

[9e09adb](https://github.com/doitsujin/dxvk/commit/9e09adbef84be6aea3db2861b02f824acdad1cb1) - [d3d9] Reset texture projected bitmask