### PR TITLE
Backport upstream DXVK PR#5714, PR#5737, parts of PR#5390 and PR#5720, fix MSAA shader and Vulkan Extensions

### DIFF
--- a/VP_DXVK_requirements.json
+++ b/VP_DXVK_requirements.json
@@ -83,8 +83,8 @@
                 "VK_KHR_present_id2": 1,
                 "VK_KHR_present_wait2": 1,
                 "VK_KHR_swapchain_mutable_format": 1,
-                "VK_EXT_extended_dynamic_state3": 1,
                 "VK_EXT_border_color_swizzle": 1,
+                "VK_EXT_dynamic_rendering_unused_attachments": 1,
                 "VK_EXT_extended_dynamic_state3": 1,
                 "VK_EXT_line_rasterization": 1,
                 "VK_EXT_pageable_device_local_memory": 1,
@@ -140,6 +140,9 @@
                 },
                 "VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT": {
                     "pageableDeviceLocalMemory": true
+                },
+                "VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT": {
+                    "dynamicRenderingUnusedAttachments": true
                 },
             }
         },

--- a/src/d3d11/d3d11_device.cpp
+++ b/src/d3d11/d3d11_device.cpp
@@ -1911,8 +1911,12 @@ namespace dxvk {
 
     enabled.vk13.shaderDemoteToHelperInvocation                   = VK_TRUE;
 
+    // VK_EXT_custom_border_color - enable its features, if respective feature is supported
     enabled.extCustomBorderColor.customBorderColors               = supported.extCustomBorderColor.customBorderColorWithoutFormat;
     enabled.extCustomBorderColor.customBorderColorWithoutFormat   = supported.extCustomBorderColor.customBorderColorWithoutFormat;
+
+    // VK_EXT_dynamic_rendering_unused_attachments - enable its features, if respective feature is supported
+    enabled.extDynamicRenderingUnusedAttachments.dynamicRenderingUnusedAttachments = supported.extDynamicRenderingUnusedAttachments.dynamicRenderingUnusedAttachments;
 
     enabled.extTransformFeedback.transformFeedback                = VK_TRUE;
     enabled.extTransformFeedback.geometryStreams                  = VK_TRUE;

--- a/src/d3d8/d3d8_device.cpp
+++ b/src/d3d8/d3d8_device.cpp
@@ -116,7 +116,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::TestCooperativeLevel() {
-    // Equivalent of D3D11/DXGI present tests.
     return GetD3D9()->TestCooperativeLevel();
   }
 
@@ -139,16 +138,17 @@ namespace dxvk {
 
   HRESULT STDMETHODCALLTYPE D3D8Device::GetDeviceCaps(D3DCAPS8* pCaps) {
     d3d9::D3DCAPS9 caps9;
+
     HRESULT res = GetD3D9()->GetDeviceCaps(&caps9);
+    if (unlikely(FAILED(res)))
+      return res;
 
-    if (likely(SUCCEEDED(res)))
-      ConvertCaps8(caps9, pCaps);
+    ConvertCaps8(caps9, pCaps);
 
-    return res;
+    return D3D_OK;
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::GetDisplayMode(D3DDISPLAYMODE* pMode) {
-    // swap chain 0
     return GetD3D9()->GetDisplayMode(0, reinterpret_cast<d3d9::D3DDISPLAYMODE*>(pMode));
   }
 
@@ -191,18 +191,18 @@ namespace dxvk {
       &params,
       &pSwapChain9
     );
+    if (unlikely(FAILED(res)))
+      return res;
 
-    if (likely(SUCCEEDED(res)))
-      *ppSwapChain = ref(new D3D8SwapChain(this, pPresentationParameters, std::move(pSwapChain9)));
+    *ppSwapChain = ref(new D3D8SwapChain(this, pPresentationParameters, std::move(pSwapChain9)));
 
-    return res;
+    return D3D_OK;
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::Reset(D3DPRESENT_PARAMETERS* pPresentationParameters) {
     D3D8DeviceLock lock = LockDevice();
 
     HRESULT res = m_parent->ValidatePresentationParameters(pPresentationParameters);
-
     if (unlikely(FAILED(res)))
       return res;
 
@@ -213,11 +213,12 @@ namespace dxvk {
 
     d3d9::D3DPRESENT_PARAMETERS params = ConvertPresentParameters9(pPresentationParameters);
     res = GetD3D9()->Reset(&params);
+    if (unlikely(FAILED(res)))
+      return res;
 
-    if (likely(SUCCEEDED(res)))
-      RecreateBackBuffersAndAutoDepthStencil();
+    RecreateBackBuffersAndAutoDepthStencil();
 
-    return res;
+    return D3D_OK;
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::Present(
@@ -248,13 +249,10 @@ namespace dxvk {
     if (iBackBuffer >= m_backBuffers.size() || m_backBuffers[iBackBuffer] == nullptr) {
       Com<d3d9::IDirect3DSurface9> pSurface9;
       HRESULT res = GetD3D9()->GetBackBuffer(0, iBackBuffer, (d3d9::D3DBACKBUFFER_TYPE)Type, &pSurface9);
+      if (unlikely(FAILED(res)))
+        return res;
 
-      if (likely(SUCCEEDED(res))) {
-        m_backBuffers[iBackBuffer] = new D3D8Surface(this, D3DPOOL_DEFAULT, std::move(pSurface9));
-        *ppBackBuffer = m_backBuffers[iBackBuffer].ref();
-      }
-
-      return res;
+      m_backBuffers[iBackBuffer] = new D3D8Surface(this, D3DPOOL_DEFAULT, std::move(pSurface9));
     }
 
     *ppBackBuffer = m_backBuffers[iBackBuffer].ref();
@@ -268,12 +266,10 @@ namespace dxvk {
 
   void STDMETHODCALLTYPE D3D8Device::SetGammaRamp(DWORD Flags, const D3DGAMMARAMP* pRamp) {
     StateChange();
-    // For swap chain 0
     GetD3D9()->SetGammaRamp(0, Flags, reinterpret_cast<const d3d9::D3DGAMMARAMP*>(pRamp));
   }
 
   void STDMETHODCALLTYPE D3D8Device::GetGammaRamp(D3DGAMMARAMP* pRamp) {
-    // For swap chain 0
     GetD3D9()->GetGammaRamp(0, reinterpret_cast<d3d9::D3DGAMMARAMP*>(pRamp));
   }
 
@@ -312,11 +308,19 @@ namespace dxvk {
       d3d9::D3DPOOL(Pool),
       &pTex9,
       NULL);
+    if (unlikely(FAILED(res)))
+      return res;
 
-    if (likely(SUCCEEDED(res)))
-      *ppTexture = ref(new D3D8Texture2D(this, Pool, std::move(pTex9)));
+    IDirect3DTexture8* tex = new D3D8Texture2D(this, Pool, std::move(pTex9));
 
-    return res;
+    if (unlikely(m_d3d8Options.textureUAFGuard)) {
+      D3D8DeviceLock lock = LockDevice();
+      m_validTextures.insert(tex);
+    }
+
+    *ppTexture = ref(tex);
+
+    return D3D_OK;
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::CreateVolumeTexture(
@@ -349,11 +353,19 @@ namespace dxvk {
       d3d9::D3DPOOL(Pool),
       &pVolume9,
       NULL);
+    if (unlikely(FAILED(res)))
+      return res;
 
-    if (likely(SUCCEEDED(res)))
-      *ppVolumeTexture = ref(new D3D8Texture3D(this, Pool, std::move(pVolume9)));
+    IDirect3DVolumeTexture8* tex = new D3D8Texture3D(this, Pool, std::move(pVolume9));
 
-    return res;
+    if (unlikely(m_d3d8Options.textureUAFGuard)) {
+      D3D8DeviceLock lock = LockDevice();
+      m_validTextures.insert(tex);
+    }
+
+    *ppVolumeTexture = ref(tex);
+
+    return D3D_OK;
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::CreateCubeTexture(
@@ -385,11 +397,19 @@ namespace dxvk {
       d3d9::D3DPOOL(Pool),
       &pCube9,
       NULL);
+    if (unlikely(FAILED(res)))
+      return res;
 
-    if (likely(SUCCEEDED(res)))
-      *ppCubeTexture = ref(new D3D8TextureCube(this, Pool, std::move(pCube9)));
+    IDirect3DCubeTexture8* tex = new D3D8TextureCube(this, Pool, std::move(pCube9));
 
-    return res;
+    if (unlikely(m_d3d8Options.textureUAFGuard)) {
+      D3D8DeviceLock lock = LockDevice();
+      m_validTextures.insert(tex);
+    }
+
+    *ppCubeTexture = ref(tex);
+
+    return D3D_OK;
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::CreateVertexBuffer(
@@ -410,11 +430,12 @@ namespace dxvk {
 
     Com<d3d9::IDirect3DVertexBuffer9> pVertexBuffer9;
     HRESULT res = GetD3D9()->CreateVertexBuffer(Length, Usage, FVF, d3d9::D3DPOOL(Pool), &pVertexBuffer9, NULL);
+    if (unlikely(FAILED(res)))
+      return res;
 
-    if (likely(SUCCEEDED(res)))
-      *ppVertexBuffer = ref(new D3D8VertexBuffer(this, std::move(pVertexBuffer9), Pool, Usage));
+    *ppVertexBuffer = ref(new D3D8VertexBuffer(this, std::move(pVertexBuffer9), Pool, Usage));
 
-    return res;
+    return D3D_OK;
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::CreateIndexBuffer(
@@ -430,11 +451,12 @@ namespace dxvk {
 
     Com<d3d9::IDirect3DIndexBuffer9> pIndexBuffer9;
     HRESULT res = GetD3D9()->CreateIndexBuffer(Length, Usage, d3d9::D3DFORMAT(Format), d3d9::D3DPOOL(Pool), &pIndexBuffer9, NULL);
+    if (unlikely(FAILED(res)))
+      return res;
 
-    if (likely(SUCCEEDED(res)))
-      *ppIndexBuffer = ref(new D3D8IndexBuffer(this, std::move(pIndexBuffer9), Pool, Usage));
+    *ppIndexBuffer = ref(new D3D8IndexBuffer(this, std::move(pIndexBuffer9), Pool, Usage));
 
-    return res;
+    return D3D_OK;
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::CreateRenderTarget(
@@ -470,11 +492,12 @@ namespace dxvk {
       Lockable,
       &pSurf9,
       NULL);
+    if (unlikely(FAILED(res)))
+      return res;
 
-    if (likely(SUCCEEDED(res)))
-      *ppSurface = ref(new D3D8Surface(this, D3DPOOL_DEFAULT, std::move(pSurf9)));
+    *ppSurface = ref(new D3D8Surface(this, D3DPOOL_DEFAULT, std::move(pSurf9)));
 
-    return res;
+    return D3D_OK;
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::CreateDepthStencilSurface(
@@ -506,11 +529,12 @@ namespace dxvk {
       FALSE, // z-buffer discarding is not used in D3D8
       &pSurf9,
       NULL);
+    if (unlikely(FAILED(res)))
+      return res;
 
-    if (likely(SUCCEEDED(res)))
-      *ppSurface = ref(new D3D8Surface(this, D3DPOOL_DEFAULT, std::move(pSurf9)));
+    *ppSurface = ref(new D3D8Surface(this, D3DPOOL_DEFAULT, std::move(pSurf9)));
 
-    return res;
+    return D3D_OK;
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::CreateImageSurface(
@@ -544,11 +568,12 @@ namespace dxvk {
       d3d9::D3DPOOL(pool),
       &pSurf,
       NULL);
+    if (unlikely(FAILED(res)))
+      return res;
 
-    if (likely(SUCCEEDED(res)))
-      *ppSurface = ref(new D3D8Surface(this, pool, std::move(pSurf)));
+    *ppSurface = ref(new D3D8Surface(this, pool, std::move(pSurf)));
 
-    return res;
+    return D3D_OK;
   }
 
   // Copies texture rect in system mem using memcpy.
@@ -643,14 +668,14 @@ namespace dxvk {
    * The following table shows the possible combinations of source
    * and destination surface pools, and how we handle each of them.
    *
-   *     ┌────────────┬───────────────────────────┬───────────────────────┬───────────────────────┬──────────────────────┐
-   *     │ Src/Dst    │ DEFAULT                   │ MANAGED               │ SYSTEMMEM             │ SCRATCH              │
-   *     ├────────────┼───────────────────────────┼───────────────────────┼───────────────────────┼──────────────────────┤
-   *     │ DEFAULT    │  StretchRect              │  GetRenderTargetData  │  GetRenderTargetData  │ GetRenderTargetData  │
-   *     │ MANAGED    │  UpdateTextureFromBuffer  │  memcpy               │  memcpy               │ memcpy               │
-   *     │ SYSTEMMEM  │  UpdateSurface            │  memcpy               │  memcpy               │ memcpy               │
-   *     │ SCRATCH    │  memcpy + UpdateSurface   │  memcpy               │  memcpy               │ memcpy               │
-   *     └────────────┴───────────────────────────┴───────────────────────┴───────────────────────┴──────────────────────┘
+   *    ┌────────────┬───────────────────────────┬───────────────────────┬───────────────────────┬──────────────────────┐
+   *    │ Src/Dst    │ DEFAULT                   │ MANAGED               │ SYSTEMMEM             │ SCRATCH              │
+   *    ├────────────┼───────────────────────────┼───────────────────────┼───────────────────────┼──────────────────────┤
+   *    │ DEFAULT    │  StretchRect              │  GetRenderTargetData  │  GetRenderTargetData  │ GetRenderTargetData  │
+   *    │ MANAGED    │  UpdateTextureFromBuffer  │  memcpy               │  memcpy               │ memcpy               │
+   *    │ SYSTEMMEM  │  UpdateSurface            │  memcpy               │  memcpy               │ memcpy               │
+   *    │ SCRATCH    │  memcpy + UpdateSurface   │  memcpy               │  memcpy               │ memcpy               │
+   *    └────────────┴───────────────────────────┴───────────────────────┴───────────────────────┴──────────────────────┘
    */
   HRESULT STDMETHODCALLTYPE D3D8Device::CopyRects(
           IDirect3DSurface8*  pSourceSurface,
@@ -1003,8 +1028,8 @@ namespace dxvk {
       // needs to be readjusted and reset.
       StateChange();
       res = GetD3D9()->SetRenderTarget(0, D3D8Surface::GetD3D9Nullable(surf));
-
-      if (unlikely(FAILED(res))) return res;
+      if (unlikely(FAILED(res)))
+        return res;
 
       m_renderTarget = surf;
     }
@@ -1017,13 +1042,13 @@ namespace dxvk {
     if (m_renderTarget != nullptr && zStencil != nullptr) {
       D3DSURFACE_DESC rtDesc;
       res = m_renderTarget->GetDesc(&rtDesc);
-
-      if (unlikely(FAILED(res))) return res;
+      if (unlikely(FAILED(res)))
+        return res;
 
       D3DSURFACE_DESC dsDesc;
       res = zStencil->GetDesc(&dsDesc);
-
-      if (unlikely(FAILED(res))) return res;
+      if (unlikely(FAILED(res)))
+        return res;
 
       if (unlikely(dsDesc.Width  < rtDesc.Width
                 || dsDesc.Height < rtDesc.Height))
@@ -1050,17 +1075,15 @@ namespace dxvk {
 
     if (unlikely(m_renderTarget == nullptr)) {
       Com<d3d9::IDirect3DSurface9> pRT9;
-      HRESULT res = GetD3D9()->GetRenderTarget(0, &pRT9); // use RT index 0
+      HRESULT res = GetD3D9()->GetRenderTarget(0, &pRT9);
+      if (unlikely(FAILED(res)))
+        return res;
 
-      if (likely(SUCCEEDED(res))) {
-        m_renderTarget = new D3D8Surface(this, D3DPOOL_DEFAULT, std::move(pRT9));
-        *ppRenderTarget = m_renderTarget.ref();
-      }
-
-      return res;
+      m_renderTarget = new D3D8Surface(this, D3DPOOL_DEFAULT, std::move(pRT9));
     }
 
     *ppRenderTarget = m_renderTarget.ref();
+
     return D3D_OK;
   }
 
@@ -1075,22 +1098,25 @@ namespace dxvk {
     if (unlikely(m_depthStencil == nullptr)) {
       Com<d3d9::IDirect3DSurface9> pStencil9;
       HRESULT res = GetD3D9()->GetDepthStencilSurface(&pStencil9);
+      if (unlikely(FAILED(res)))
+        return res;
 
-      if (likely(SUCCEEDED(res))) {
-        m_depthStencil = new D3D8Surface(this, D3DPOOL_DEFAULT, std::move(pStencil9));
-        *ppZStencilSurface = m_depthStencil.ref();
-      }
-
-      return res;
+      m_depthStencil = new D3D8Surface(this, D3DPOOL_DEFAULT, std::move(pStencil9));
     }
 
     *ppZStencilSurface = m_depthStencil.ref();
+
     return D3D_OK;
   }
 
-  HRESULT STDMETHODCALLTYPE D3D8Device::BeginScene() { return GetD3D9()->BeginScene(); }
+  HRESULT STDMETHODCALLTYPE D3D8Device::BeginScene() {
+    return GetD3D9()->BeginScene();
+  }
 
-  HRESULT STDMETHODCALLTYPE D3D8Device::EndScene() { StateChange(); return GetD3D9()->EndScene(); }
+  HRESULT STDMETHODCALLTYPE D3D8Device::EndScene() {
+    StateChange();
+    return GetD3D9()->EndScene();
+  }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::Clear(
           DWORD    Count,
@@ -1217,16 +1243,16 @@ namespace dxvk {
 
     Com<d3d9::IDirect3DStateBlock9> pStateBlock9;
     HRESULT res = GetD3D9()->CreateStateBlock(d3d9::D3DSTATEBLOCKTYPE(Type), &pStateBlock9);
+    if (unlikely(FAILED(res)))
+      return res;
 
-    if (likely(SUCCEEDED(res))) {
-      m_token++;
-      m_stateBlocks.emplace(std::piecewise_construct,
-                            std::forward_as_tuple(m_token),
-                            std::forward_as_tuple(this, stateBlockType, pStateBlock9.ptr()));
-      *pToken = m_token;
-    }
+    m_token++;
+    m_stateBlocks.emplace(std::piecewise_construct,
+                          std::forward_as_tuple(m_token),
+                          std::forward_as_tuple(this, stateBlockType, pStateBlock9.ptr()));
+    *pToken = m_token;
 
-    return res;
+    return D3D_OK;
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::CaptureStateBlock(DWORD Token) {
@@ -1237,7 +1263,6 @@ namespace dxvk {
       return D3DERR_INVALIDCALL;
 
     auto stateBlockIter = m_stateBlocks.find(Token);
-
     if (unlikely(stateBlockIter == m_stateBlocks.end())) {
       Logger::warn(str::format("D3D8Device::CaptureStateBlock: Invalid token: ", std::hex, Token));
       return D3D_OK;
@@ -1256,7 +1281,6 @@ namespace dxvk {
     StateChange();
 
     auto stateBlockIter = m_stateBlocks.find(Token);
-
     if (unlikely(stateBlockIter == m_stateBlocks.end())) {
       Logger::warn(str::format("D3D8Device::ApplyStateBlock: Invalid token: ", std::hex, Token));
       return D3D_OK;
@@ -1273,7 +1297,6 @@ namespace dxvk {
       return D3DERR_INVALIDCALL;
 
     auto stateBlockIter = m_stateBlocks.find(Token);
-
     if (unlikely(stateBlockIter == m_stateBlocks.end())) {
       Logger::warn(str::format("D3D8Device::DeleteStateBlock: Invalid token: ", std::hex, Token));
       return D3D_OK;
@@ -1297,17 +1320,17 @@ namespace dxvk {
       return D3DERR_INVALIDCALL;
 
     HRESULT res = GetD3D9()->BeginStateBlock();
+    if (unlikely(FAILED(res)))
+      return res;
 
-    if (likely(SUCCEEDED(res))) {
-      m_token++;
-      auto stateBlockIterPair = m_stateBlocks.emplace(std::piecewise_construct,
-                                                      std::forward_as_tuple(m_token),
-                                                      std::forward_as_tuple(this));
-      m_recorder = &stateBlockIterPair.first->second;
-      m_recorderToken = m_token;
-    }
+    m_token++;
+    auto stateBlockIterPair = m_stateBlocks.emplace(std::piecewise_construct,
+                                                    std::forward_as_tuple(m_token),
+                                                    std::forward_as_tuple(this));
+    m_recorder = &stateBlockIterPair.first->second;
+    m_recorderToken = m_token;
 
-    return res;
+    return D3D_OK;
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::EndStateBlock(DWORD* pToken) {
@@ -1318,17 +1341,17 @@ namespace dxvk {
 
     Com<d3d9::IDirect3DStateBlock9> pStateBlock;
     HRESULT res = GetD3D9()->EndStateBlock(&pStateBlock);
+    if (unlikely(FAILED(res)))
+      return res;
 
-    if (likely(SUCCEEDED(res))) {
-      m_recorder->SetD3D9(std::move(pStateBlock));
+    m_recorder->SetD3D9(std::move(pStateBlock));
 
-      *pToken = m_recorderToken;
+    *pToken = m_recorderToken;
 
-      m_recorder = nullptr;
-      m_recorderToken = 0;
-    }
+    m_recorder = nullptr;
+    m_recorderToken = 0;
 
-    return res;
+    return D3D_OK;
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::SetClipStatus(const D3DCLIPSTATUS8* pClipStatus) {
@@ -1362,7 +1385,9 @@ namespace dxvk {
     if (unlikely(ShouldRecord()))
       return m_recorder->SetTexture(Stage, pTexture);
 
-    D3D8Texture2D* tex = static_cast<D3D8Texture2D*>(pTexture);
+    const bool isValidTexture = !m_d3d8Options.textureUAFGuard
+                              || m_validTextures.find(pTexture) != m_validTextures.end();
+    D3D8Texture2D* tex = isValidTexture ? static_cast<D3D8Texture2D*>(pTexture) : nullptr;
 
     // Splinter Cell: Force perspective divide when a shadow map is bound to slot 0
     if (unlikely(m_d3d8Options.shadowPerspectiveDivide && Stage == 0)) {
@@ -1390,11 +1415,12 @@ namespace dxvk {
 
     StateChange();
     HRESULT res = GetD3D9()->SetTexture(Stage, D3D8Texture2D::GetD3D9Nullable(tex));
+    if (unlikely(FAILED(res)))
+      return res;
 
-    if (likely(SUCCEEDED(res)))
-      m_textures[Stage] = tex;
+    m_textures[Stage] = tex;
 
-    return res;
+    return D3D_OK;
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::GetTextureStageState(
@@ -1476,7 +1502,8 @@ namespace dxvk {
 
     return GetD3D9()->DrawIndexedPrimitive(
       d3d9::D3DPRIMITIVETYPE(PrimitiveType),
-      static_cast<INT>(std::min(m_baseVertexIndex, static_cast<UINT>(std::numeric_limits<int32_t>::max()))), // set by SetIndices
+      static_cast<INT>(std::min(m_baseVertexIndex, // set by SetIndices()
+                                static_cast<UINT>(std::numeric_limits<int32_t>::max()))),
       MinVertexIndex,
       NumVertices,
       StartIndex,
@@ -1495,7 +1522,11 @@ namespace dxvk {
     // Stream 0 is set to null by this call
     m_streams[0] = D3D8VBO {nullptr, 0};
 
-    return GetD3D9()->DrawPrimitiveUP(d3d9::D3DPRIMITIVETYPE(PrimitiveType), PrimitiveCount, pVertexStreamZeroData, VertexStreamZeroStride);
+    return GetD3D9()->DrawPrimitiveUP(
+      d3d9::D3DPRIMITIVETYPE(PrimitiveType),
+      PrimitiveCount,
+      pVertexStreamZeroData,
+      VertexStreamZeroStride);
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::DrawIndexedPrimitiveUP(
@@ -1534,6 +1565,7 @@ namespace dxvk {
       IDirect3DVertexBuffer8*      pDestBuffer,
       DWORD                        Flags) {
     D3D8VertexBuffer* buffer = static_cast<D3D8VertexBuffer*>(pDestBuffer);
+
     return GetD3D9()->ProcessVertices(
       SrcStartIndex,
       DestIndex,
@@ -1571,18 +1603,18 @@ namespace dxvk {
 
     D3D8VertexBuffer* buffer = static_cast<D3D8VertexBuffer*>(pStreamData);
     HRESULT res = GetD3D9()->SetStreamSource(StreamNumber, D3D8VertexBuffer::GetD3D9Nullable(buffer), 0, Stride);
+    if (unlikely(FAILED(res)))
+      return res;
 
-    if (likely(SUCCEEDED(res))) {
-      if (unlikely(ShouldBatch()))
-        m_batcher->SetStream(StreamNumber, buffer, Stride);
+    if (unlikely(ShouldBatch()))
+      m_batcher->SetStream(StreamNumber, buffer, Stride);
 
-      m_streams[StreamNumber].buffer = buffer;
-      // The previous stride is preserved if pStreamData is NULL
-      if (likely(buffer != nullptr))
-        m_streams[StreamNumber].stride = Stride;
-    }
+    m_streams[StreamNumber].buffer = buffer;
+    // The previous stride is preserved if pStreamData is NULL
+    if (likely(buffer != nullptr))
+      m_streams[StreamNumber].stride = Stride;
 
-    return res;
+    return D3D_OK;
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::GetStreamSource(
@@ -1621,17 +1653,17 @@ namespace dxvk {
 
     D3D8IndexBuffer* buffer = static_cast<D3D8IndexBuffer*>(pIndexData);
     HRESULT res = GetD3D9()->SetIndices(D3D8IndexBuffer::GetD3D9Nullable(buffer));
+    if (unlikely(FAILED(res)))
+      return res;
 
-    if (likely(SUCCEEDED(res))) {
-      if (unlikely(ShouldBatch()))
-        m_batcher->SetIndices(buffer, BaseVertexIndex);
+    if (unlikely(ShouldBatch()))
+      m_batcher->SetIndices(buffer, BaseVertexIndex);
 
-      m_indices = buffer;
-      // used by DrawIndexedPrimitive
-      m_baseVertexIndex = BaseVertexIndex;
-    }
+    m_indices = buffer;
+    // used by DrawIndexedPrimitive
+    m_baseVertexIndex = BaseVertexIndex;
 
-    return res;
+    return D3D_OK;
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::GetIndices(
@@ -1824,46 +1856,43 @@ namespace dxvk {
     Com<d3d9::IDirect3DVertexShader9> pVertexShader;
     if (pFunction != nullptr) {
       res = GetD3D9()->CreateVertexShader(translatedVS.function.data(), &pVertexShader);
+      if (unlikely(FAILED(res)))
+        return res;
     } else {
       // pFunction is NULL: fixed function pipeline
       pVertexShader = nullptr;
     }
 
-    if (likely(SUCCEEDED(res))) {
-      D3D8VertexShaderInfo& info = m_vertexShaders.emplace_back();
+    D3D8VertexShaderInfo& info = m_vertexShaders.emplace_back();
 
-      info.pVertexDecl = std::move(pVertexDecl);
-      info.pVertexShader = std::move(pVertexShader);
+    info.pVertexDecl = std::move(pVertexDecl);
+    info.pVertexShader = std::move(pVertexShader);
 
-      // Store D3D8 bytecodes in the shader info
-      for (uint32_t i = 0; pDeclaration[i] != D3DVSD_END(); i++)
-        info.declaration.push_back(pDeclaration[i]);
-      info.declaration.push_back(D3DVSD_END());
+    // Store D3D8 bytecodes in the shader info
+    for (uint32_t i = 0; pDeclaration[i] != D3DVSD_END(); i++)
+      info.declaration.push_back(pDeclaration[i]);
+    info.declaration.push_back(D3DVSD_END());
 
-      if (pFunction != nullptr) {
-        for (uint32_t i = 0; pFunction[i] != D3DVS_END(); i++)
-          info.function.push_back(pFunction[i]);
-        info.function.push_back(D3DVS_END());
-      }
-
-      // Set bit to indicate this is not an FVF
-      *pHandle = getShaderHandle(m_vertexShaders.size());
+    if (pFunction != nullptr) {
+      for (uint32_t i = 0; pFunction[i] != D3DVS_END(); i++)
+        info.function.push_back(pFunction[i]);
+      info.function.push_back(D3DVS_END());
     }
 
-    return res;
+    // Set bit to indicate this is not an FVF
+    *pHandle = getShaderHandle(m_vertexShaders.size());
+
+    return D3D_OK;
   }
 
   inline D3D8VertexShaderInfo* getVertexShaderInfo(D3D8Device* device, DWORD Handle) {
-
     Handle = getShaderIndex(Handle);
-
     if (unlikely(Handle >= device->m_vertexShaders.size())) {
       Logger::debug(str::format("D3D8: Invalid vertex shader index ", std::hex, Handle));
       return nullptr;
     }
 
     D3D8VertexShaderInfo& info = device->m_vertexShaders[Handle];
-
     if (unlikely(info.pVertexDecl == nullptr && info.pVertexShader == nullptr)) {
       Logger::debug(str::format("D3D8: Application provided deleted vertex shader ", std::hex, Handle));
       return nullptr;
@@ -1883,7 +1912,6 @@ namespace dxvk {
 
     // Check for extra bit that indicates this is not an FVF
     if (!isFVF(Handle)) {
-
       D3D8VertexShaderInfo* info = getVertexShaderInfo(this, Handle);
 
       if (!info)
@@ -1893,27 +1921,21 @@ namespace dxvk {
 
       GetD3D9()->SetVertexDeclaration(info->pVertexDecl.ptr());
       res = GetD3D9()->SetVertexShader(info->pVertexShader.ptr());
+      if (unlikely(FAILED(res)))
+        return res;
 
-      if (likely(SUCCEEDED(res))) {
-        // Cache current shader
-        m_currentVertexShader = Handle;
-      }
-
-      return res;
-
+      m_currentVertexShader = Handle;
     } else if (m_currentVertexShader != Handle) {
       StateChange();
 
       //GetD3D9()->SetVertexDeclaration(nullptr);
       GetD3D9()->SetVertexShader(nullptr);
       res = GetD3D9()->SetFVF(Handle);
+      if (unlikely(FAILED(res)))
+        return res;
 
-      if (likely(SUCCEEDED(res))) {
-        // Cache current FVF
-        m_currentVertexShader = Handle;
-      }
-
-      return res;
+      // Cache current FVF
+      m_currentVertexShader = Handle;
     }
 
     return D3D_OK;
@@ -1935,7 +1957,6 @@ namespace dxvk {
 
     d3d9::IDirect3DVertexShader9* pVertexShader;
     HRESULT res = GetD3D9()->GetVertexShader(&pVertexShader);
-
     if (FAILED(res) || pVertexShader == nullptr) {
       return GetD3D9()->GetFVF(pHandle);
     }
@@ -1945,11 +1966,11 @@ namespace dxvk {
 
       if (info.pVertexShader == pVertexShader) {
         *pHandle = getShaderHandle(i);
-        return res;
+        return D3D_OK;
       }
     }
 
-    return res;
+    return D3D_OK;
     */
   }
 
@@ -2047,18 +2068,17 @@ namespace dxvk {
 
     Com<d3d9::IDirect3DPixelShader9> pPixelShader;
     HRESULT res = GetD3D9()->CreatePixelShader(pFunction, &pPixelShader);
+    if (unlikely(FAILED(res)))
+      return res;
 
-    if (likely(SUCCEEDED(res))) {
-      m_pixelShaders.push_back(std::move(pPixelShader));
-      // Still set the shader bit, to prevent conflicts with NULL.
-      *pHandle = getShaderHandle(m_pixelShaders.size());
-    }
+    m_pixelShaders.push_back(std::move(pPixelShader));
+    // Still set the shader bit, to prevent conflicts with NULL.
+    *pHandle = getShaderHandle(m_pixelShaders.size());
 
-    return res;
+    return D3D_OK;
   }
 
   inline d3d9::IDirect3DPixelShader9* getPixelShaderPtr(D3D8Device* device, DWORD Handle) {
-
     Handle = getShaderIndex(Handle);
 
     if (unlikely(Handle >= device->m_pixelShaders.size())) {
@@ -2097,13 +2117,13 @@ namespace dxvk {
 
     StateChange();
     HRESULT res = GetD3D9()->SetPixelShader(pPixelShader);
+    if (unlikely(FAILED(res)))
+      return res;
 
-    if (likely(SUCCEEDED(res))) {
-      // Cache current pixel shader
-      m_currentPixelShader = Handle;
-    }
+    // Cache current pixel shader
+    m_currentPixelShader = Handle;
 
-    return res;
+    return D3D_OK;
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::GetPixelShader(DWORD* pHandle) {

--- a/src/d3d8/d3d8_device.h
+++ b/src/d3d8/d3d8_device.h
@@ -15,6 +15,7 @@
 #include <array>
 #include <vector>
 #include <type_traits>
+#include <unordered_set>
 #include <unordered_map>
 
 namespace dxvk {
@@ -383,7 +384,7 @@ namespace dxvk {
       m_presentParams.BackBufferCount = std::max(m_presentParams.BackBufferCount, 1u);
 
       // Reset D3D8 exclusive render states
-      m_linePattern = {};
+      m_linePattern = { };
       m_zVisible    = 0;
 
       // Purge cached objects
@@ -418,6 +419,14 @@ namespace dxvk {
       m_depthStencil = m_autoDepthStencil;
     }
 
+    void RemoveValidTexture(IDirect3DBaseTexture8* tex) {
+      D3D8DeviceLock lock = LockDevice();
+
+      auto textureIter = m_validTextures.find(tex);
+      if (likely(textureIter != m_validTextures.end()))
+        m_validTextures.erase(textureIter);
+    }
+
     friend d3d9::IDirect3DPixelShader9* getPixelShaderPtr(D3D8Device* device, DWORD Handle);
     friend D3D8VertexShaderInfo*        getVertexShaderInfo(D3D8Device* device, DWORD Handle);
 
@@ -431,39 +440,41 @@ namespace dxvk {
     D3DPRESENT_PARAMETERS m_presentParams;
     
     // Value of D3DRS_LINEPATTERN
-    D3DLINEPATTERN        m_linePattern   = {};
+    D3DLINEPATTERN        m_linePattern = { };
     // Value of D3DRS_ZVISIBLE (although the RS is not supported, its value is stored)
-    DWORD                 m_zVisible      = 0;
+    DWORD                 m_zVisible    = 0;
 
     bool                  m_shadowPerspectiveDivide = false;
 
-    D3D8StateBlock*                            m_recorder = nullptr;
-    DWORD                                      m_recorderToken = 0;
-    DWORD                                      m_token    = 0;
-    std::unordered_map<DWORD, D3D8StateBlock>  m_stateBlocks;
-    D3D8Batcher*                               m_batcher  = nullptr;
+    D3D8StateBlock*                           m_recorder = nullptr;
+    DWORD                                     m_recorderToken = 0;
+    DWORD                                     m_token    = 0;
+    std::unordered_map<DWORD, D3D8StateBlock> m_stateBlocks;
+    D3D8Batcher*                              m_batcher  = nullptr;
 
     struct D3D8VBO {
       Com<D3D8VertexBuffer, false>   buffer = nullptr;
       UINT                           stride = 0;
     };
 
-    std::array<Com<D3D8Texture2D, false>, d8caps::MAX_TEXTURE_STAGES>  m_textures;
-    std::array<D3D8VBO, d8caps::MAX_STREAMS>                           m_streams;
+    std::array<Com<D3D8Texture2D, false>, d8caps::MAX_TEXTURE_STAGES> m_textures;
+    std::array<D3D8VBO, d8caps::MAX_STREAMS>                          m_streams;
 
-    Com<D3D8IndexBuffer, false>        m_indices;
-    UINT                               m_baseVertexIndex = 0;
+    std::unordered_set<IDirect3DBaseTexture8*> m_validTextures;
+
+    Com<D3D8IndexBuffer, false>          m_indices;
+    UINT                                 m_baseVertexIndex = 0;
 
     std::vector<Com<D3D8Surface, false>> m_backBuffers;
     Com<D3D8Surface, false>              m_autoDepthStencil;
 
-    Com<D3D8Surface, false>     m_renderTarget;
-    Com<D3D8Surface, false>     m_depthStencil;
+    Com<D3D8Surface, false>              m_renderTarget;
+    Com<D3D8Surface, false>              m_depthStencil;
 
-    std::vector<D3D8VertexShaderInfo>               m_vertexShaders;
-    std::vector<Com<d3d9::IDirect3DPixelShader9>>   m_pixelShaders;
-    DWORD                                           m_currentVertexShader  = 0; // can be FVF or vs index (marked by D3DFVF_RESERVED0)
-    DWORD                                           m_currentPixelShader   = 0;
+    std::vector<D3D8VertexShaderInfo>             m_vertexShaders;
+    std::vector<Com<d3d9::IDirect3DPixelShader9>> m_pixelShaders;
+    DWORD                                         m_currentVertexShader  = 0; // can be FVF or vs index (marked by D3DFVF_RESERVED0)
+    DWORD                                         m_currentPixelShader   = 0;
 
     D3DDEVTYPE            m_deviceType;
     HWND                  m_window;

--- a/src/d3d8/d3d8_device_child.h
+++ b/src/d3d8/d3d8_device_child.h
@@ -63,6 +63,7 @@ namespace dxvk {
         return D3DERR_INVALIDCALL;
 
       *ppDevice = ref(GetDevice());
+
       return D3D_OK;
     }
 

--- a/src/d3d8/d3d8_interface.cpp
+++ b/src/d3d8/d3d8_interface.cpp
@@ -27,7 +27,6 @@ namespace dxvk {
 
       // cache adapter modes and mode counts for each d3d9 format
       for (d3d9::D3DFORMAT fmt : ADAPTER_FORMATS) {
-
         const UINT modeCount = m_d3d9->GetAdapterModeCount(adapter, fmt);
         for (UINT mode = 0; mode < modeCount; mode++) {
 
@@ -74,7 +73,6 @@ namespace dxvk {
 
     d3d9::D3DADAPTER_IDENTIFIER9 identifier9;
     HRESULT res = m_d3d9->GetAdapterIdentifier(Adapter, Flags, &identifier9);
-
     if (unlikely(FAILED(res)))
       return res;
 
@@ -93,7 +91,7 @@ namespace dxvk {
     return D3D_OK;
   }
 
-  HRESULT __stdcall D3D8Interface::EnumAdapterModes(
+  HRESULT STDMETHODCALLTYPE D3D8Interface::EnumAdapterModes(
           UINT Adapter,
           UINT Mode,
           D3DDISPLAYMODE* pMode) {
@@ -109,7 +107,7 @@ namespace dxvk {
     return D3D_OK;
   }
 
-  HRESULT __stdcall D3D8Interface::CreateDevice(
+  HRESULT STDMETHODCALLTYPE D3D8Interface::CreateDevice(
         UINT Adapter,
         D3DDEVTYPE DeviceType,
         HWND hFocusWindow,
@@ -122,7 +120,6 @@ namespace dxvk {
       return D3DERR_INVALIDCALL;
 
     HRESULT res = ValidatePresentationParameters(pPresentationParameters);
-
     if (unlikely(FAILED(res)))
       return res;
 
@@ -136,7 +133,6 @@ namespace dxvk {
       &params,
       &pDevice9
     );
-
     if (unlikely(FAILED(res)))
       return res;
 

--- a/src/d3d8/d3d8_interface.h
+++ b/src/d3d8/d3d8_interface.h
@@ -151,11 +151,12 @@ namespace dxvk {
 
       d3d9::D3DCAPS9 caps9;
       HRESULT res = m_d3d9->GetDeviceCaps(Adapter, d3d9::D3DDEVTYPE(DeviceType), &caps9);
+      if (unlikely(FAILED(res)))
+        return res;
 
-      if (likely(SUCCEEDED(res)))
-        ConvertCaps8(caps9, pCaps);
+      ConvertCaps8(caps9, pCaps);
 
-      return res;
+      return D3D_OK;
     }
 
     HMONITOR STDMETHODCALLTYPE GetAdapterMonitor(UINT Adapter) {

--- a/src/d3d8/d3d8_options.cpp
+++ b/src/d3d8/d3d8_options.cpp
@@ -54,4 +54,16 @@ namespace dxvk {
     }
   }
 
+  D3D8Options::D3D8Options(const Config& config) {
+    auto forceVsDeclStr           = config.getOption<std::string>("d3d8.forceVsDecl",             "");
+
+    this->batching                = config.getOption<bool>       ("d3d8.batching",                false);
+    this->placeP8InScratch        = config.getOption<bool>       ("d3d8.placeP8InScratch",        false);
+    this->forceLegacyDiscard      = config.getOption<bool>       ("d3d8.forceLegacyDiscard",      false);
+    this->shadowPerspectiveDivide = config.getOption<bool>       ("d3d8.shadowPerspectiveDivide", false);
+    this->textureUAFGuard         = config.getOption<bool>       ("d3d8.textureUAFGuard",         false);
+
+    parseVsDecl(forceVsDeclStr);
+  }
+
 }

--- a/src/d3d8/d3d8_options.h
+++ b/src/d3d8/d3d8_options.h
@@ -4,9 +4,18 @@
 #include "../d3d9/d3d9_bridge.h"
 #include "../util/config/config.h"
 
+#include <vector>
+#include <utility>
+
 namespace dxvk {
 
   struct D3D8Options {
+
+    void parseVsDecl(const std::string& decl);
+
+    D3D8Options() {};
+
+    D3D8Options(const Config& config);
 
     /// Override application vertex shader declarations.
     std::vector<std::pair<D3DVSDE_REGISTER, D3DVSDT_TYPE>> forceVsDecl;
@@ -23,19 +32,9 @@ namespace dxvk {
     /// Force D3DTTFF_PROJECTED for the necessary stages when a depth texture is bound to slot 0.
     bool shadowPerspectiveDivide;
 
-    D3D8Options() {}
+    /// Keep track of live texture objects and validate them during SetTexture calls.
+    bool textureUAFGuard;
 
-    D3D8Options(const Config& config) {
-      auto forceVsDeclStr     = config.getOption<std::string>("d3d8.forceVsDecl",             "");
-      batching                = config.getOption<bool>       ("d3d8.batching",                false);
-      placeP8InScratch        = config.getOption<bool>       ("d3d8.placeP8InScratch",        false);
-      forceLegacyDiscard      = config.getOption<bool>       ("d3d8.forceLegacyDiscard",      false);
-      shadowPerspectiveDivide = config.getOption<bool>       ("d3d8.shadowPerspectiveDivide", false);
-
-      parseVsDecl(forceVsDeclStr);
-    }
-
-    void parseVsDecl(const std::string& decl);
   };
 
 }

--- a/src/d3d8/d3d8_resource.h
+++ b/src/d3d8/d3d8_resource.h
@@ -29,18 +29,16 @@ namespace dxvk {
             DWORD       SizeOfData,
             DWORD       Flags) final {
       HRESULT hr;
+
       if (Flags & D3DSPD_IUNKNOWN) {
         if(unlikely(SizeOfData != sizeof(IUnknown*)))
           return D3DERR_INVALIDCALL;
-        IUnknown* unknown =
-          const_cast<IUnknown*>(
-            reinterpret_cast<const IUnknown*>(pData));
-        hr = m_privateData.setInterface(
-          refguid, unknown);
+
+        IUnknown* unknown = const_cast<IUnknown*>(reinterpret_cast<const IUnknown*>(pData));
+        hr = m_privateData.setInterface(refguid, unknown);
+      } else {
+        hr = m_privateData.setData(refguid, SizeOfData, pData);
       }
-      else
-        hr = m_privateData.setData(
-          refguid, SizeOfData, pData);
 
       if (unlikely(FAILED(hr)))
         return D3DERR_INVALIDCALL;

--- a/src/d3d8/d3d8_surface.cpp
+++ b/src/d3d8/d3d8_surface.cpp
@@ -27,11 +27,12 @@ namespace dxvk {
 
     d3d9::D3DSURFACE_DESC desc;
     HRESULT res = GetD3D9()->GetDesc(&desc);
+    if (unlikely(FAILED(res)))
+      return res;
 
-    if (likely(SUCCEEDED(res)))
-      ConvertSurfaceDesc8(&desc, pDesc);
+    ConvertSurfaceDesc8(&desc, pDesc);
 
-    return res;
+    return D3D_OK;
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Surface::LockRect(
@@ -68,7 +69,6 @@ namespace dxvk {
       FALSE,
       &image,
       NULL);
-
     if (FAILED(res))
       throw DxvkError("D3D8: Failed to create blit image");
 

--- a/src/d3d8/d3d8_swapchain.cpp
+++ b/src/d3d8/d3d8_swapchain.cpp
@@ -25,16 +25,14 @@ namespace dxvk {
     if (BackBuffer >= m_backBuffers.size() || m_backBuffers[BackBuffer] == nullptr) {
       Com<d3d9::IDirect3DSurface9> pSurface9;
       HRESULT res = GetD3D9()->GetBackBuffer(BackBuffer, (d3d9::D3DBACKBUFFER_TYPE)Type, &pSurface9);
+      if (unlikely(FAILED(res)))
+        return res;
 
-      if (likely(SUCCEEDED(res))) {
-        m_backBuffers[BackBuffer] = new D3D8Surface(GetParent(), D3DPOOL_DEFAULT, std::move(pSurface9));
-        *ppBackBuffer = m_backBuffers[BackBuffer].ref();
-      }
-
-      return res;
+      m_backBuffers[BackBuffer] = new D3D8Surface(GetParent(), D3DPOOL_DEFAULT, std::move(pSurface9));
     }
 
     *ppBackBuffer = m_backBuffers[BackBuffer].ref();
+
     return D3D_OK;
   }
 

--- a/src/d3d8/d3d8_texture.cpp
+++ b/src/d3d8/d3d8_texture.cpp
@@ -1,5 +1,6 @@
 #include "d3d8_texture.h"
 
+#include "d3d8_device.h"
 #include "d3d8_util.h"
 
 namespace dxvk {
@@ -13,6 +14,11 @@ namespace dxvk {
     : D3D8Texture2DBase(pDevice, Pool, std::move(pTexture), pTexture->GetLevelCount()) {
   }
 
+  D3D8Texture2D::~D3D8Texture2D() {
+    if (unlikely(m_parent->GetOptions()->textureUAFGuard))
+      m_parent->RemoveValidTexture(this);
+  }
+
   D3DRESOURCETYPE STDMETHODCALLTYPE D3D8Texture2D::GetType() { return D3DRTYPE_TEXTURE; }
 
   HRESULT STDMETHODCALLTYPE D3D8Texture2D::GetLevelDesc(UINT Level, D3DSURFACE_DESC* pDesc) {
@@ -21,11 +27,12 @@ namespace dxvk {
 
     d3d9::D3DSURFACE_DESC surf;
     HRESULT res = GetD3D9()->GetLevelDesc(Level, &surf);
+    if (unlikely(FAILED(res)))
+      return res;
 
-    if (likely(SUCCEEDED(res)))
-      ConvertSurfaceDesc8(&surf, pDesc);
+    ConvertSurfaceDesc8(&surf, pDesc);
 
-    return res;
+    return D3D_OK;
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Texture2D::GetSurfaceLevel(UINT Level, IDirect3DSurface8** ppSurfaceLevel) {
@@ -56,6 +63,11 @@ namespace dxvk {
           Com<d3d9::IDirect3DVolumeTexture9>&&  pVolumeTexture)
     : D3D8Texture3DBase(pDevice, Pool, std::move(pVolumeTexture), pVolumeTexture->GetLevelCount()) {}
 
+  D3D8Texture3D::~D3D8Texture3D() {
+    if (unlikely(m_parent->GetOptions()->textureUAFGuard))
+      m_parent->RemoveValidTexture(this);
+  }
+
   D3DRESOURCETYPE STDMETHODCALLTYPE D3D8Texture3D::GetType() { return D3DRTYPE_VOLUMETEXTURE; }
 
   HRESULT STDMETHODCALLTYPE D3D8Texture3D::GetLevelDesc(UINT Level, D3DVOLUME_DESC *pDesc) {
@@ -64,11 +76,12 @@ namespace dxvk {
 
     d3d9::D3DVOLUME_DESC vol;
     HRESULT res = GetD3D9()->GetLevelDesc(Level, &vol);
+    if (unlikely(FAILED(res)))
+      return res;
 
-    if (likely(SUCCEEDED(res)))
-      ConvertVolumeDesc8(&vol, pDesc);
+    ConvertVolumeDesc8(&vol, pDesc);
 
-    return res;
+    return D3D_OK;
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Texture3D::GetVolumeLevel(UINT Level, IDirect3DVolume8** ppVolumeLevel) {
@@ -105,6 +118,11 @@ namespace dxvk {
     : D3D8TextureCubeBase(pDevice, Pool, std::move(pTexture), pTexture->GetLevelCount() * CUBE_FACES) {
   }
 
+  D3D8TextureCube::~D3D8TextureCube() {
+    if (unlikely(m_parent->GetOptions()->textureUAFGuard))
+      m_parent->RemoveValidTexture(this);
+  }
+
   D3DRESOURCETYPE STDMETHODCALLTYPE D3D8TextureCube::GetType() { return D3DRTYPE_CUBETEXTURE; }
 
   HRESULT STDMETHODCALLTYPE D3D8TextureCube::GetLevelDesc(UINT Level, D3DSURFACE_DESC* pDesc) {
@@ -113,11 +131,12 @@ namespace dxvk {
 
     d3d9::D3DSURFACE_DESC surf;
     HRESULT res = GetD3D9()->GetLevelDesc(Level, &surf);
+    if (unlikely(FAILED(res)))
+      return res;
 
-    if (likely(SUCCEEDED(res)))
-      ConvertSurfaceDesc8(&surf, pDesc);
+    ConvertSurfaceDesc8(&surf, pDesc);
 
-    return res;
+    return D3D_OK;
   }
 
   HRESULT STDMETHODCALLTYPE D3D8TextureCube::GetCubeMapSurface(

--- a/src/d3d8/d3d8_texture.h
+++ b/src/d3d8/d3d8_texture.h
@@ -118,6 +118,8 @@ namespace dxvk {
       const D3DPOOL                        Pool,
             Com<d3d9::IDirect3DTexture9>&& pTexture);
 
+    ~D3D8Texture2D();
+
     D3DRESOURCETYPE STDMETHODCALLTYPE GetType() final;
 
     HRESULT STDMETHODCALLTYPE GetLevelDesc(UINT Level, D3DSURFACE_DESC* pDesc);
@@ -146,6 +148,8 @@ namespace dxvk {
       const D3DPOOL                               Pool,
             Com<d3d9::IDirect3DVolumeTexture9>&&  pVolumeTexture);
 
+    ~D3D8Texture3D();
+
     D3DRESOURCETYPE STDMETHODCALLTYPE GetType() final;
 
     HRESULT STDMETHODCALLTYPE GetLevelDesc(UINT Level, D3DVOLUME_DESC *pDesc);
@@ -173,6 +177,8 @@ namespace dxvk {
             D3D8Device*                         pDevice,
       const D3DPOOL                             Pool,
             Com<d3d9::IDirect3DCubeTexture9>&&  pTexture);
+
+    ~D3D8TextureCube();
 
     D3DRESOURCETYPE STDMETHODCALLTYPE GetType() final;
 

--- a/src/d3d8/d3d8_volume.cpp
+++ b/src/d3d8/d3d8_volume.cpp
@@ -18,11 +18,12 @@ namespace dxvk {
 
     d3d9::D3DVOLUME_DESC desc;
     HRESULT res = GetD3D9()->GetDesc(&desc);
+    if (unlikely(FAILED(res)))
+      return res;
 
-    if (likely(SUCCEEDED(res)))
-      ConvertVolumeDesc8(&desc, pDesc);
+    ConvertVolumeDesc8(&desc, pDesc);
 
-    return res;
+    return D3D_OK;
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Volume::LockBox(D3DLOCKED_BOX* pLockedBox, CONST D3DBOX* pBox, DWORD Flags) {

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4555,18 +4555,9 @@ namespace dxvk {
 
     const uint32_t samplerBit = 1u << StateSampler;
 
-    if (Type == D3DSAMP_ADDRESSU
-     || Type == D3DSAMP_ADDRESSV
-     || Type == D3DSAMP_ADDRESSW
-     || Type == D3DSAMP_MAGFILTER
-     || Type == D3DSAMP_MINFILTER
-     || Type == D3DSAMP_MIPFILTER
-     || Type == D3DSAMP_MAXANISOTROPY
-     || Type == D3DSAMP_MIPMAPLODBIAS
-     || Type == D3DSAMP_MAXMIPLEVEL
-     || Type == D3DSAMP_BORDERCOLOR)
-      m_textureSlotTracking.samplerStateDirty |= samplerBit;
-    else if (Type == D3DSAMP_SRGBTEXTURE && (m_textureSlotTracking.bound & samplerBit))
+    m_textureSlotTracking.samplerStateDirty |= samplerBit;
+
+    if (Type == D3DSAMP_SRGBTEXTURE && (m_textureSlotTracking.bound & samplerBit))
       m_textureSlotTracking.textureDirty |= samplerBit;
 
     constexpr DWORD Fetch4Enabled  = MAKEFOURCC('G', 'E', 'T', '4');
@@ -4624,6 +4615,13 @@ namespace dxvk {
     TextureChangePrivate(m_state.textures[StateSampler], pTexture);
     m_textureSlotTracking.textureDirty |= 1u << StateSampler;
     UpdateTextureBitmasks(StateSampler, combinedUsage);
+
+    // If the texture format changes and the corresponding sampler uses
+    // border colors, we may need to update the border color swizzle
+    if (!oldTexture || !newTexture || oldTexture->Desc()->Format != newTexture->Desc()->Format) {
+      if (SamplerUsesBorderColor(StateSampler))
+        m_textureSlotTracking.samplerStateDirty |= 1u << StateSampler;
+    }
 
     return D3D_OK;
   }
@@ -7449,12 +7447,20 @@ namespace dxvk {
 
     const D3D9CommonTexture* tex = GetCommonTexture(m_state.textures[Sampler]);
 
+    const bool srgb = m_state.samplerStates[Sampler][D3DSAMP_SRGBTEXTURE] & 0x1;
+
+    Rc<DxvkImageView> imageView;
+
+    if (tex && SamplerUsesBorderColor(Sampler))
+      imageView = tex->GetSampleView(srgb);
+
     EmitCs([this,
       cSlot       = slot,
       cState      = D3D9SamplerInfo(m_state.samplerStates[Sampler]),
       cIsCube     = tex && tex->IsCube(),
       cIsMultiMip = tex && (tex->Desc()->MipLevels > 1u),
       cIsDepth    = bool(m_textureSlotTracking.depth & (1u << Sampler)),
+      cView       = std::move(imageView),
       cBindId     = m_samplerBindCount
     ] (DxvkContext* ctx) {
       DxvkSamplerKey key = { };
@@ -7502,8 +7508,12 @@ namespace dxvk {
         key.setLodRange(float(cState.maxMipLevel), 16.0f, lodBias);
       }
 
-      if (key.u.p.hasBorder)
+      if (key.u.p.hasBorder) {
         DecodeD3DCOLOR(cState.borderColor, key.borderColor.float32);
+
+        if (cView)
+          key.setViewProperties(cView->info().unpackSwizzle(), cView->info().format);
+      }
 
       VkShaderStageFlags stage = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
       ctx->bindResourceSampler(stage, cSlot, m_dxvkDevice->createSampler(key));
@@ -7586,6 +7596,14 @@ namespace dxvk {
       if (m_state.textures[i] == texture)
         m_textureSlotTracking.textureDirty |= 1u << i;
     }
+  }
+
+  bool D3D9DeviceEx::SamplerUsesBorderColor(DWORD Sampler) const {
+    const auto& sampler = m_state.samplerStates[Sampler];
+
+    return sampler[D3DSAMP_ADDRESSU] == D3DTADDRESS_BORDER
+        || sampler[D3DSAMP_ADDRESSV] == D3DTADDRESS_BORDER
+        || sampler[D3DSAMP_ADDRESSW] == D3DTADDRESS_BORDER;
   }
 
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4776,13 +4776,22 @@ namespace dxvk {
     // Enable depth bounds test if we support it.
     enabled.core.features.depthBounds = supported.core.features.depthBounds;
 
+    // VK_EXT_border_color_swizzle - enable its features, if respective feature is supported
+    enabled.extBorderColorSwizzle.borderColorSwizzle             = supported.extBorderColorSwizzle.borderColorSwizzle;
+    enabled.extBorderColorSwizzle.borderColorSwizzleFromImage    = supported.extBorderColorSwizzle.borderColorSwizzleFromImage;
+
+    // VK_EXT_custom_border_color - enable its features unconditionally, if customBorderColorWithoutFormat feature is supported
     if (supported.extCustomBorderColor.customBorderColorWithoutFormat) {
       enabled.extCustomBorderColor.customBorderColors             = VK_TRUE;
       enabled.extCustomBorderColor.customBorderColorWithoutFormat = VK_TRUE;
     }
 
+    // VK_EXT_attachment_feedback_loop_layout - enable its feature unconditionally, if attachmentFeedbackLoopLayout feature is supported
     if (supported.extAttachmentFeedbackLoopLayout.attachmentFeedbackLoopLayout)
       enabled.extAttachmentFeedbackLoopLayout.attachmentFeedbackLoopLayout = VK_TRUE;
+
+    // VK_EXT_dynamic_rendering_unused_attachments - enable its features, if respective feature is supported
+    enabled.extDynamicRenderingUnusedAttachments.dynamicRenderingUnusedAttachments = supported.extDynamicRenderingUnusedAttachments.dynamicRenderingUnusedAttachments;
 
     enabled.extNonSeamlessCubeMap.nonSeamlessCubeMap = supported.extNonSeamlessCubeMap.nonSeamlessCubeMap;
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -180,6 +180,7 @@ namespace dxvk {
 
     m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
     m_dirty.set(D3D9DeviceDirtyFlag::FFVertexBlend);
+    m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
     m_dirty.set(D3D9DeviceDirtyFlag::FFPixelShader);
     m_dirty.set(D3D9DeviceDirtyFlag::FFViewport);
     m_dirty.set(D3D9DeviceDirtyFlag::FFPixelData);
@@ -2234,7 +2235,8 @@ namespace dxvk {
     light.isValid = true;
     light.isEnabled = bool(Enable);
 
-    m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
+    m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData,
+                D3D9DeviceDirtyFlag::FFVertexShader);
     return D3D_OK;
   }
 
@@ -2444,7 +2446,7 @@ namespace dxvk {
 
         case D3DRS_CLIPPLANEENABLE:
           if (!Value != !oldValue)
-            m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
+            m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
 
           m_dirty.set(D3D9DeviceDirtyFlag::ClipPlanes);
           break;
@@ -2465,7 +2467,7 @@ namespace dxvk {
         case D3DRS_LIGHTING:
         case D3DRS_NORMALIZENORMALS:
         case D3DRS_LOCALVIEWER:
-          m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
+          m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
           break;
 
         case D3DRS_AMBIENT:
@@ -2483,7 +2485,7 @@ namespace dxvk {
           break;
 
         case D3DRS_RANGEFOGENABLE:
-          m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
+          m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
           break;
 
         case D3DRS_FOGCOLOR:
@@ -2581,14 +2583,14 @@ namespace dxvk {
           break;
 
         case D3DRS_VERTEXBLEND:
-          m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
+          m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
           break;
 
         case D3DRS_INDEXEDVERTEXBLENDENABLE:
           if (CanSWVP() && Value)
             m_dirty.set(D3D9DeviceDirtyFlag::FFVertexBlend);
 
-          m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
+          m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
           break;
 
         case D3DRS_ADAPTIVETESS_Y: {
@@ -3429,7 +3431,7 @@ namespace dxvk {
                     || decl->GetTexcoordMask() != m_state.vertexDecl->GetTexcoordMask();
 
     if (dirtyFFShader)
-      m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
+      m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
 
     m_state.vertexDecl = decl;
 
@@ -3554,7 +3556,7 @@ namespace dxvk {
 
     if (shader != nullptr) {
       m_dirty.clr(D3D9DeviceDirtyFlag::ProgVertexShader);
-      m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
+      m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
 
       BindShader<DxsoProgramTypes::VertexShader>(GetCommonShader(shader));
       UpdateTextureTypeMismatchesForShader(newShader, VSShaderMasks().samplerMask, FirstVSSamplerSlot);
@@ -4674,7 +4676,7 @@ namespace dxvk {
           break;
 
         case DXVK_TSS_TEXCOORDINDEX:
-          m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
+          m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
           break;
 
         case DXVK_TSS_TEXTURETRANSFORMFLAGS:
@@ -4682,7 +4684,7 @@ namespace dxvk {
           if (Value & D3DTTFF_PROJECTED)
             m_textureSlotTracking.projected |= 1 << Stage;
 
-          m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
+          m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
           m_dirty.set(D3D9DeviceDirtyFlag::FFPixelShader);
           break;
 
@@ -8220,12 +8222,12 @@ namespace dxvk {
 
     if (unlikely(hasPositionT && m_state.vertexShader != nullptr && !m_dirty.test(D3D9DeviceDirtyFlag::ProgVertexShader))) {
       m_dirty.set(D3D9DeviceDirtyFlag::InputLayout);
-      m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
+      m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
       m_dirty.set(D3D9DeviceDirtyFlag::ProgVertexShader);
     }
 
-    if (m_dirty.test(D3D9DeviceDirtyFlag::FFVertexData)) {
-      m_dirty.clr(D3D9DeviceDirtyFlag::FFVertexData);
+    if (m_dirty.test(D3D9DeviceDirtyFlag::FFVertexShader)) {
+      m_dirty.clr(D3D9DeviceDirtyFlag::FFVertexShader);
 
       D3D9FFShaderKeyVS key;
       key.Data.Contents.VertexHasPositionT = hasPositionT;
@@ -8715,7 +8717,7 @@ namespace dxvk {
     rs[D3DRS_LOCALVIEWER]            = TRUE;
     rs[D3DRS_RANGEFOGENABLE]         = FALSE;
     rs[D3DRS_NORMALIZENORMALS]       = FALSE;
-    m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
+    m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
 
     // PS
     rs[D3DRS_SPECULARENABLE] = FALSE;

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -180,7 +180,6 @@ namespace dxvk {
 
     m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
     m_dirty.set(D3D9DeviceDirtyFlag::FFVertexBlend);
-    m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
     m_dirty.set(D3D9DeviceDirtyFlag::FFPixelShader);
     m_dirty.set(D3D9DeviceDirtyFlag::FFViewport);
     m_dirty.set(D3D9DeviceDirtyFlag::FFPixelData);
@@ -2185,9 +2184,11 @@ namespace dxvk {
     if (Index >= m_state.lights.size())
       m_state.lights.resize(Index + 1);
 
-    m_state.lights[Index] = *pLight;
+    auto& light = m_state.lights[Index];
+    light.isValid = true;
+    light.light = *pLight;
 
-    if (m_state.IsLightEnabled(Index))
+    if (light.isEnabled)
       m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
 
     return D3D_OK;
@@ -2200,10 +2201,15 @@ namespace dxvk {
     if (unlikely(pLight == nullptr))
       return D3DERR_INVALIDCALL;
 
-    if (unlikely(Index >= m_state.lights.size() || !m_state.lights[Index]))
+    if (unlikely(Index >= m_state.lights.size()))
       return D3DERR_INVALIDCALL;
 
-    *pLight = m_state.lights[Index].value();
+    auto& light = m_state.lights[Index];
+
+    if (unlikely(!light.isValid))
+      return D3DERR_INVALIDCALL;
+
+    *pLight = m_state.lights[Index].light;
 
     return D3D_OK;
   }
@@ -2220,27 +2226,15 @@ namespace dxvk {
     if (unlikely(Index >= m_state.lights.size()))
       m_state.lights.resize(Index + 1);
 
-    if (unlikely(!m_state.lights[Index]))
-      m_state.lights[Index] = DefaultLight;
+    auto& light = m_state.lights[Index];
 
-    if (m_state.IsLightEnabled(Index) == !!Enable)
+    if (light.isEnabled == bool(Enable))
       return D3D_OK;
 
-    uint32_t searchIndex = std::numeric_limits<uint32_t>::max();
-    uint32_t setIndex    = Index;
+    light.isValid = true;
+    light.isEnabled = bool(Enable);
 
-    if (!Enable)
-      std::swap(searchIndex, setIndex);
-
-    for (auto& idx : m_state.enabledLightIndices) {
-      if (idx == searchIndex) {
-        idx = setIndex;
-        m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
-        m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
-        break;
-      }
-    }
-
+    m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
     return D3D_OK;
   }
 
@@ -2251,11 +2245,15 @@ namespace dxvk {
     if (unlikely(pEnable == nullptr))
       return D3DERR_INVALIDCALL;
 
-    if (unlikely(Index >= m_state.lights.size() || !m_state.lights[Index]))
+    if (unlikely(Index >= m_state.lights.size()))
       return D3DERR_INVALIDCALL;
 
-    *pEnable = m_state.IsLightEnabled(Index) ? 128 : 0; // Weird quirk but OK.
+    auto& light = m_state.lights[Index];
 
+    if (unlikely(!light.isValid))
+      return D3DERR_INVALIDCALL;
+
+    *pEnable = light.isEnabled ? 128 : 0; // Weird quirk but OK.
     return D3D_OK;
   }
 
@@ -2446,7 +2444,7 @@ namespace dxvk {
 
         case D3DRS_CLIPPLANEENABLE:
           if (!Value != !oldValue)
-            m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
+            m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
 
           m_dirty.set(D3D9DeviceDirtyFlag::ClipPlanes);
           break;
@@ -2467,7 +2465,7 @@ namespace dxvk {
         case D3DRS_LIGHTING:
         case D3DRS_NORMALIZENORMALS:
         case D3DRS_LOCALVIEWER:
-          m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
+          m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
           break;
 
         case D3DRS_AMBIENT:
@@ -2485,7 +2483,7 @@ namespace dxvk {
           break;
 
         case D3DRS_RANGEFOGENABLE:
-          m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
+          m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
           break;
 
         case D3DRS_FOGCOLOR:
@@ -2583,14 +2581,14 @@ namespace dxvk {
           break;
 
         case D3DRS_VERTEXBLEND:
-          m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
+          m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
           break;
 
         case D3DRS_INDEXEDVERTEXBLENDENABLE:
           if (CanSWVP() && Value)
             m_dirty.set(D3D9DeviceDirtyFlag::FFVertexBlend);
 
-          m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
+          m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
           break;
 
         case D3DRS_ADAPTIVETESS_Y: {
@@ -3431,7 +3429,7 @@ namespace dxvk {
                     || decl->GetTexcoordMask() != m_state.vertexDecl->GetTexcoordMask();
 
     if (dirtyFFShader)
-      m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
+      m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
 
     m_state.vertexDecl = decl;
 
@@ -3556,7 +3554,7 @@ namespace dxvk {
 
     if (shader != nullptr) {
       m_dirty.clr(D3D9DeviceDirtyFlag::ProgVertexShader);
-      m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
+      m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
 
       BindShader<DxsoProgramTypes::VertexShader>(GetCommonShader(shader));
       UpdateTextureTypeMismatchesForShader(newShader, VSShaderMasks().samplerMask, FirstVSSamplerSlot);
@@ -4676,7 +4674,7 @@ namespace dxvk {
           break;
 
         case DXVK_TSS_TEXCOORDINDEX:
-          m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
+          m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
           break;
 
         case DXVK_TSS_TEXTURETRANSFORMFLAGS:
@@ -4684,7 +4682,7 @@ namespace dxvk {
           if (Value & D3DTTFF_PROJECTED)
             m_textureSlotTracking.projected |= 1 << Stage;
 
-          m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
+          m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
           m_dirty.set(D3D9DeviceDirtyFlag::FFPixelShader);
           break;
 
@@ -8222,12 +8220,12 @@ namespace dxvk {
 
     if (unlikely(hasPositionT && m_state.vertexShader != nullptr && !m_dirty.test(D3D9DeviceDirtyFlag::ProgVertexShader))) {
       m_dirty.set(D3D9DeviceDirtyFlag::InputLayout);
-      m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
+      m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
       m_dirty.set(D3D9DeviceDirtyFlag::ProgVertexShader);
     }
 
-    if (m_dirty.test(D3D9DeviceDirtyFlag::FFVertexShader)) {
-      m_dirty.clr(D3D9DeviceDirtyFlag::FFVertexShader);
+    if (m_dirty.test(D3D9DeviceDirtyFlag::FFVertexData)) {
+      m_dirty.clr(D3D9DeviceDirtyFlag::FFVertexData);
 
       D3D9FFShaderKeyVS key;
       key.Data.Contents.VertexHasPositionT = hasPositionT;
@@ -8257,8 +8255,8 @@ namespace dxvk {
       uint32_t lightCount = 0;
 
       if (key.Data.Contents.UseLighting) {
-        for (uint32_t i = 0; i < caps::MaxEnabledLights; i++) {
-          if (m_state.enabledLightIndices[i] != std::numeric_limits<uint32_t>::max())
+        for (auto& light : m_state.lights) {
+          if (light.isEnabled)
             lightCount++;
         }
       }
@@ -8353,12 +8351,15 @@ namespace dxvk {
       DecodeD3DCOLOR(m_state.renderStates[D3DRS_AMBIENT], data->GlobalAmbient.data);
 
       uint32_t lightIdx = 0;
-      for (uint32_t i = 0; i < caps::MaxEnabledLights; i++) {
-        auto idx = m_state.enabledLightIndices[i];
-        if (idx == std::numeric_limits<uint32_t>::max())
+
+      for (auto& light : m_state.lights) {
+        if (!light.isEnabled)
           continue;
 
-        data->Lights[lightIdx++] = D3D9Light(m_state.lights[idx].value(), m_state.transforms[GetTransformIndex(D3DTS_VIEW)]);
+        data->Lights[lightIdx++] = D3D9Light(light.light, m_state.transforms[GetTransformIndex(D3DTS_VIEW)]);
+
+        if (lightIdx == caps::MaxEnabledLights)
+          break;
       }
 
       data->Material = m_state.material;
@@ -8714,7 +8715,7 @@ namespace dxvk {
     rs[D3DRS_LOCALVIEWER]            = TRUE;
     rs[D3DRS_RANGEFOGENABLE]         = FALSE;
     rs[D3DRS_NORMALIZENORMALS]       = FALSE;
-    m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
+    m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
 
     // PS
     rs[D3DRS_SPECULARENABLE] = FALSE;

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -76,7 +76,6 @@ namespace dxvk {
 
     FFVertexData,
     FFVertexBlend,
-    FFVertexShader,
     FFPixelShader,
     FFViewport,
     FFPixelData,

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -1073,6 +1073,8 @@ namespace dxvk {
 
     void MarkTextureBindingDirty(IDirect3DBaseTexture9* texture);
 
+    bool SamplerUsesBorderColor(DWORD Sampler) const;
+
     HRESULT STDMETHODCALLTYPE SetRenderTargetInternal(
             DWORD              RenderTargetIndex,
             IDirect3DSurface9* pRenderTarget);

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -76,6 +76,7 @@ namespace dxvk {
 
     FFVertexData,
     FFVertexBlend,
+    FFVertexShader,
     FFPixelShader,
     FFViewport,
     FFPixelData,

--- a/src/d3d9/d3d9_state.cpp
+++ b/src/d3d9/d3d9_state.cpp
@@ -8,9 +8,6 @@ namespace dxvk {
     D3D9State<ItemType>::D3D9State() {
       for (uint32_t i = 0; i < streamFreq.size(); i++)
         streamFreq[i] = 1;
-
-      for (uint32_t i = 0; i < enabledLightIndices.size(); i++)
-        enabledLightIndices[i] = std::numeric_limits<uint32_t>::max();
     }
 
 

--- a/src/d3d9/d3d9_state.h
+++ b/src/d3d9/d3d9_state.h
@@ -109,6 +109,25 @@ namespace dxvk {
     float Phi;
   };
 
+  constexpr D3DLIGHT9 DefaultLight = {
+    D3DLIGHT_DIRECTIONAL,     // Type
+    {1.0f, 1.0f, 1.0f, 0.0f}, // Diffuse
+    {0.0f, 0.0f, 0.0f, 0.0f}, // Specular
+    {0.0f, 0.0f, 0.0f, 0.0f}, // Ambient
+    {0.0f, 0.0f, 0.0f},       // Position
+    {0.0f, 0.0f, 1.0f},       // Direction
+    0.0f,                     // Range
+    0.0f,                     // Falloff
+    0.0f, 0.0f, 0.0f,         // Attenuations [constant, linear, quadratic]
+    0.0f,                     // Theta
+    0.0f                      // Phi
+  };
+
+  struct D3D9LightState {
+    bool isValid = false;
+    bool isEnabled = false;
+    D3DLIGHT9 light = DefaultLight;
+  };
 
   struct D3D9FixedFunctionVS {
     Matrix4 WorldView;
@@ -166,20 +185,6 @@ namespace dxvk {
     UINT              offset = 0;
     UINT              length = 0;
     UINT              stride = 0;
-  };
-
-  constexpr D3DLIGHT9 DefaultLight = {
-    D3DLIGHT_DIRECTIONAL,     // Type
-    {1.0f, 1.0f, 1.0f, 0.0f}, // Diffuse
-    {0.0f, 0.0f, 0.0f, 0.0f}, // Specular
-    {0.0f, 0.0f, 0.0f, 0.0f}, // Ambient
-    {0.0f, 0.0f, 0.0f},       // Position
-    {0.0f, 0.0f, 1.0f},       // Direction
-    0.0f,                     // Range
-    0.0f,                     // Falloff
-    0.0f, 0.0f, 0.0f,         // Attenuations [constant, linear, quadratic]
-    0.0f,                     // Theta
-    0.0f                      // Phi
   };
 
   template <typename T>
@@ -303,15 +308,10 @@ namespace dxvk {
 
     ItemType<D3DMATERIAL9>                              material = {};
 
-    std::vector<std::optional<D3DLIGHT9>>               lights;
-    std::array<DWORD, caps::MaxEnabledLights>           enabledLightIndices;
+    std::vector<D3D9LightState>                         lights;
 
     float                                               nPatchSegments = 0.0f;
 
-    bool IsLightEnabled(DWORD Index) const {
-      const auto& enabledIndices = enabledLightIndices;
-      return std::find(enabledIndices.begin(), enabledIndices.end(), Index) != enabledIndices.end();
-    }
   };
 
   using D3D9CapturableState = D3D9State<dynamic_item>;

--- a/src/d3d9/d3d9_stateblock.cpp
+++ b/src/d3d9/d3d9_stateblock.cpp
@@ -191,7 +191,9 @@ namespace dxvk {
     if (Index >= m_state.lights.size())
       m_state.lights.resize(Index + 1);
 
-    m_state.lights[Index] = *pLight;
+    auto& light = m_state.lights[Index];
+    light.isValid = true;
+    light.light = *pLight;
 
     m_captures.flags.set(D3D9CapturedStateFlag::Lights);
     return D3D_OK;
@@ -202,24 +204,13 @@ namespace dxvk {
     if (unlikely(Index >= m_state.lights.size()))
       m_state.lights.resize(Index + 1);
 
-    if (unlikely(!m_state.lights[Index]))
-      m_state.lights[Index] = DefaultLight;
+    // Apply default light on enable, but not disable.
+    // No idea if this is correct, but matches the old logic.
+    auto& light = m_state.lights[Index];
+    light.isEnabled = bool(Enable);
 
-    if (m_state.IsLightEnabled(Index) == !!Enable)
-      return D3D_OK;
-
-    uint32_t searchIndex = std::numeric_limits<uint32_t>::max();
-    uint32_t setIndex    = Index;
-
-    if (!Enable)
-      std::swap(searchIndex, setIndex);
-
-    for (auto& idx : m_state.enabledLightIndices) {
-      if (idx == searchIndex) {
-        idx = setIndex;
-        break;
-      }
-    }
+    if (Enable)
+      light.isValid = true;
 
     m_captures.lightEnabledChanges.set(Index, true);
     m_captures.flags.set(D3D9CapturedStateFlag::Lights);

--- a/src/d3d9/d3d9_stateblock.h
+++ b/src/d3d9/d3d9_stateblock.h
@@ -321,16 +321,18 @@ namespace dxvk {
 
       if (m_captures.flags.test(D3D9CapturedStateFlag::Lights)) {
         for (uint32_t i = 0; i < src->lights.size(); i++) {
-          if (!src->lights[i].has_value())
+          if (!src->lights[i].isValid)
             continue;
 
-          dst->SetLight(i, &src->lights[i].value());
+          dst->SetLight(i, &src->lights[i].light);
         }
+
         for (uint32_t i = 0; i < m_captures.lightEnabledChanges.dwordCount(); i++) {
           for (uint32_t consts : bit::BitMask(m_captures.lightEnabledChanges.dword(i))) {
             uint32_t idx = i * 32 + consts;
 
-            dst->LightEnable(idx, src->IsLightEnabled(idx));
+            if (idx < src->lights.size())
+              dst->LightEnable(idx, src->lights[idx].isEnabled);
           }
         }
       }

--- a/src/dxgi/dxgi_swapchain.cpp
+++ b/src/dxgi/dxgi_swapchain.cpp
@@ -40,7 +40,10 @@ namespace dxvk {
     
     // Apply initial window mode and fullscreen state
     if (!m_descFs.Windowed && FAILED(EnterFullscreenMode(nullptr)))
-      throw DxvkError("DXGI: Failed to set initial fullscreen state");
+    {
+      Logger::warn("DXGI: EnterFullscreenMode failed. Creating a windowed swapchain instead.");
+      m_descFs.Windowed = TRUE;
+    }
 
     // Ensure that RGBA16 swap chains are scRGB if supported
     UpdateColorSpace(m_desc.Format, m_colorSpace);
@@ -717,7 +720,21 @@ namespace dxvk {
 
     if (!wsi::isWindow(m_window))
       return DXGI_ERROR_NOT_CURRENTLY_AVAILABLE;
-    
+
+    if (!(m_descFs.ScanlineOrdering >= DXGI_MODE_SCANLINE_ORDER_UNSPECIFIED
+     && m_descFs.ScanlineOrdering <= DXGI_MODE_SCANLINE_ORDER_LOWER_FIELD_FIRST))
+    {
+      Logger::err(str::format("DXGI: EnterFullscreenMode: Invalid scanline order ", m_descFs.ScanlineOrdering));
+      return DXGI_ERROR_INVALID_CALL;
+    }
+
+    if (!(m_descFs.Scaling >= DXGI_MODE_SCALING_UNSPECIFIED
+     && m_descFs.Scaling <= DXGI_MODE_SCALING_STRETCHED))
+    {
+      Logger::err(str::format("DXGI: EnterFullscreenMode: Invalid scaling ", m_descFs.Scaling));
+      return DXGI_ERROR_INVALID_CALL;
+    }
+
     if (output == nullptr) {
       if (FAILED(GetOutputFromMonitor(wsi::getWindowMonitor(m_window), &output))) {
         Logger::err("DXGI: EnterFullscreenMode: Cannot query containing output");

--- a/src/dxvk/dxvk_adapter.cpp
+++ b/src/dxvk/dxvk_adapter.cpp
@@ -240,6 +240,7 @@ namespace dxvk {
         && CHECK_FEATURE_NEED(vk13.dynamicRendering)
         && CHECK_FEATURE_NEED(vk13.maintenance4)
         && CHECK_FEATURE_NEED(extAttachmentFeedbackLoopLayout.attachmentFeedbackLoopLayout)
+        && CHECK_FEATURE_NEED(extDynamicRenderingUnusedAttachments.dynamicRenderingUnusedAttachments)
         && CHECK_FEATURE_NEED(extBorderColorSwizzle.borderColorSwizzle)
         && CHECK_FEATURE_NEED(extBorderColorSwizzle.borderColorSwizzleFromImage)
         && CHECK_FEATURE_NEED(extConservativeRasterization)
@@ -599,6 +600,10 @@ namespace dxvk {
           enabledFeatures.extAttachmentFeedbackLoopLayout = *reinterpret_cast<const VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT*>(f);
           break;
 
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_UNUSED_ATTACHMENTS_FEATURES_EXT:
+          enabledFeatures.extDynamicRenderingUnusedAttachments = *reinterpret_cast<const VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT*>(f);
+          break;
+
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BORDER_COLOR_SWIZZLE_FEATURES_EXT:
           enabledFeatures.extBorderColorSwizzle = *reinterpret_cast<const VkPhysicalDeviceBorderColorSwizzleFeaturesEXT*>(f);
           break;
@@ -908,6 +913,11 @@ namespace dxvk {
       m_deviceFeatures.extAttachmentFeedbackLoopLayout.pNext = std::exchange(m_deviceFeatures.core.pNext, &m_deviceFeatures.extAttachmentFeedbackLoopLayout);
     }
 
+    if (m_deviceExtensions.supports(VK_EXT_DYNAMIC_RENDERING_UNUSED_ATTACHMENTS_EXTENSION_NAME)) {
+      m_deviceFeatures.extDynamicRenderingUnusedAttachments.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_UNUSED_ATTACHMENTS_FEATURES_EXT;
+      m_deviceFeatures.extDynamicRenderingUnusedAttachments.pNext = std::exchange(m_deviceFeatures.core.pNext, &m_deviceFeatures.extDynamicRenderingUnusedAttachments);
+    }
+
     if (m_deviceExtensions.supports(VK_EXT_BORDER_COLOR_SWIZZLE_EXTENSION_NAME)) {
       m_deviceFeatures.extBorderColorSwizzle.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BORDER_COLOR_SWIZZLE_FEATURES_EXT;
       m_deviceFeatures.extBorderColorSwizzle.pNext = std::exchange(m_deviceFeatures.core.pNext, &m_deviceFeatures.extBorderColorSwizzle);
@@ -1105,6 +1115,7 @@ namespace dxvk {
       &devExtensions.amdMemoryOverallocationBehaviour,
       &devExtensions.amdShaderFragmentMask,
       &devExtensions.extAttachmentFeedbackLoopLayout,
+      &devExtensions.extDynamicRenderingUnusedAttachments,
       &devExtensions.extBorderColorSwizzle,
       &devExtensions.extConservativeRasterization,
       &devExtensions.extCustomBorderColor,
@@ -1174,6 +1185,11 @@ namespace dxvk {
     if (devExtensions.extAttachmentFeedbackLoopLayout) {
       enabledFeatures.extAttachmentFeedbackLoopLayout.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ATTACHMENT_FEEDBACK_LOOP_LAYOUT_FEATURES_EXT;
       enabledFeatures.extAttachmentFeedbackLoopLayout.pNext = std::exchange(enabledFeatures.core.pNext, &enabledFeatures.extAttachmentFeedbackLoopLayout);
+    }
+
+    if (devExtensions.extDynamicRenderingUnusedAttachments) {
+      enabledFeatures.extDynamicRenderingUnusedAttachments.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_UNUSED_ATTACHMENTS_FEATURES_EXT;
+      enabledFeatures.extDynamicRenderingUnusedAttachments.pNext = std::exchange(enabledFeatures.core.pNext, &enabledFeatures.extDynamicRenderingUnusedAttachments);
     }
 
     if (devExtensions.extBorderColorSwizzle) {
@@ -1423,6 +1439,8 @@ namespace dxvk {
       "\n  extension supported                    : " << (features.amdShaderFragmentMask ? "1" : "0") <<
       "\n" << VK_EXT_ATTACHMENT_FEEDBACK_LOOP_LAYOUT_EXTENSION_NAME <<
       "\n  attachmentFeedbackLoopLayout           : " << (features.extAttachmentFeedbackLoopLayout.attachmentFeedbackLoopLayout ? "1" : "0") <<
+      "\n" << VK_EXT_DYNAMIC_RENDERING_UNUSED_ATTACHMENTS_EXTENSION_NAME <<
+      "\n  dynamicRenderingUnusedAttachments           : " << (features.extDynamicRenderingUnusedAttachments.dynamicRenderingUnusedAttachments ? "1" : "0") <<
       "\n" << VK_EXT_BORDER_COLOR_SWIZZLE_EXTENSION_NAME <<
       "\n  borderColorSwizzle                     : " << (features.extBorderColorSwizzle.borderColorSwizzle ? "1" : "0") <<
       "\n  borderColorSwizzleFromImage            : " << (features.extBorderColorSwizzle.borderColorSwizzleFromImage ? "1" : "0") <<

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -7625,7 +7625,7 @@ namespace dxvk {
       // need to rebind the pipeline, we need to end transform feedback and
       // potentially issue a barrier. Dirtying xfb buffers will do that.
       if (m_flags.any(DxvkContextFlag::GpDirtyPipelineState,
-                      DxvkContextFlag::GpDirtySpecConstants {
+                      DxvkContextFlag::GpDirtySpecConstants)) {
         m_flags.set(DxvkContextFlag::GpDirtyXfbBuffers);
         this->pauseTransformFeedback();
       }

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -6382,18 +6382,9 @@ namespace dxvk {
                 DxvkContextFlag::GpDynamicMultisampleState,
                 DxvkContextFlag::GpDynamicRasterizerState,
                 DxvkContextFlag::GpDynamicSampleLocations,
+                DxvkContextFlag::GpDynamicViewport,
                 DxvkContextFlag::GpHasPushConstants,
                 DxvkContextFlag::GpIndependentSets);
-    
-    m_flags.set(m_state.gp.state.useDynamicBlendConstants()
-      ? DxvkContextFlag::GpDynamicBlendConstants
-      : DxvkContextFlag::GpDirtyBlendConstants);
-    
-    m_flags.set((!m_state.gp.flags.test(DxvkGraphicsPipelineFlag::HasRasterizerDiscard))
-      ? DxvkContextFlags(DxvkContextFlag::GpDynamicRasterizerState,
-                         DxvkContextFlag::GpDynamicDepthBias)
-      : DxvkContextFlags(DxvkContextFlag::GpDirtyRasterizerState,
-                         DxvkContextFlag::GpDirtyDepthBias));
 
     // Retrieve and bind actual Vulkan pipeline handle
     auto pipelineInfo = m_state.gp.pipeline->getPipelineHandle(m_state.gp.state,
@@ -6414,62 +6405,89 @@ namespace dxvk {
       m_lastBoundGraphicsPipeline = pipelineInfo.handle;
     }
 
+    // Independent pipeline layout affects all resource updates
+    if (pipelineInfo.type == DxvkGraphicsPipelineType::BasePipeline)
+      m_flags.set(DxvkContextFlag::GpIndependentSets);
+
+    if (!m_state.gp.flags.test(DxvkGraphicsPipelineFlag::HasRasterizerDiscard)) {
+      // Some state is aways dynamic when used
+      m_flags.set(DxvkContextFlag::GpDynamicRasterizerState,
+                  DxvkContextFlag::GpDynamicDepthBias,
+                  DxvkContextFlag::GpDynamicViewport);
+
+      m_flags.set(m_state.gp.state.useDynamicBlendConstants()
+        ? DxvkContextFlag::GpDynamicBlendConstants
+        : DxvkContextFlag::GpDirtyBlendConstants);
+
+      if (pipelineInfo.type == DxvkGraphicsPipelineType::BasePipeline) {
+        // For pipelines created from graphics pipeline libraries, we need to
+        // apply a bunch of dynamic state that is otherwise static or unused
+        if (!m_state.gp.flags.test(DxvkGraphicsPipelineFlag::HasRasterizerDiscard)) {
+          m_flags.set(DxvkContextFlag::GpDynamicDepthBias,
+                      DxvkContextFlag::GpDynamicDepthTest,
+                      DxvkContextFlag::GpDynamicStencilTest);
+
+          if (m_device->features().extExtendedDynamicState3.extendedDynamicState3DepthClipEnable)
+            m_flags.set(DxvkContextFlag::GpDynamicDepthClip);
+
+          if (m_device->features().core.features.depthBounds)
+            m_flags.set(DxvkContextFlag::GpDynamicDepthBounds);
+
+          if (m_device->features().extExtendedDynamicState3.extendedDynamicState3RasterizationSamples
+          && m_device->features().extExtendedDynamicState3.extendedDynamicState3SampleMask
+          && m_state.gp.flags.test(DxvkGraphicsPipelineFlag::HasSampleRateShading))
+            m_flags.set(DxvkContextFlag::GpDynamicMultisampleState);
+
+          if (m_device->features().extSampleLocations)
+            m_flags.set(DxvkContextFlag::GpDynamicSampleLocations);
+        }
+      } else if (!m_state.gp.flags.test(DxvkGraphicsPipelineFlag::HasRasterizerDiscard)) {
+        // Conditionally set up dynamic state based on pipeline state.
+        // Must match DxvkGraphicsPipelineDynamicState behaviour exactly.
+        if (m_device->features().core.features.depthBounds) {
+          m_flags.set(m_state.gp.state.useDynamicDepthBounds()
+            ? DxvkContextFlag::GpDynamicDepthBounds
+            : DxvkContextFlag::GpDirtyDepthBounds);
+        }
+
+        if (m_device->features().extSampleLocations) {
+          m_flags.set(m_state.gp.state.useSampleLocations()
+            ? DxvkContextFlag::GpDynamicSampleLocations
+            : DxvkContextFlag::GpDirtySampleLocations);
+        }
+
+        m_flags.set(m_state.gp.state.useDynamicDepthTest()
+          ? DxvkContextFlag::GpDynamicDepthTest
+          : DxvkContextFlag::GpDirtyDepthTest);
+
+        m_flags.set(m_state.gp.state.useDynamicStencilTest()
+          ? DxvkContextFlags(DxvkContextFlag::GpDynamicStencilTest)
+          : DxvkContextFlags(DxvkContextFlag::GpDirtyStencilTest,
+                            DxvkContextFlag::GpDirtyStencilRef));
+
+        // Dirty state that is never dynamic for optimized pipelines
+        if (m_device->features().extExtendedDynamicState3.extendedDynamicState3DepthClipEnable)
+          m_flags.set(DxvkContextFlag::GpDirtyDepthClip);
+
+        m_flags.set(DxvkContextFlag::GpDirtyMultisampleState);
+      }
+    } else {
+      // If rasterization is disabled, none of the raster-related
+      // dynamic state is used either so mark all of that as dirty.
+      m_flags.set(DxvkContextFlag::GpDirtyDepthBias,
+                  DxvkContextFlag::GpDirtyDepthBounds,
+                  DxvkContextFlag::GpDirtyDepthClip,
+                  DxvkContextFlag::GpDirtyDepthTest,
+                  DxvkContextFlag::GpDirtyStencilTest,
+                  DxvkContextFlag::GpDirtyStencilRef,
+                  DxvkContextFlag::GpDirtyMultisampleState,
+                  DxvkContextFlag::GpDirtyRasterizerState,
+                  DxvkContextFlag::GpDirtySampleLocations,
+                  DxvkContextFlag::GpDirtyViewport);
+    }
+
     // Update attachment usage info based on the pipeline state
     m_state.om.attachmentMask.merge(pipelineInfo.attachments);
-
-    // For pipelines created from graphics pipeline libraries, we need to
-    // apply a bunch of dynamic state that is otherwise static or unused
-    if (pipelineInfo.type == DxvkGraphicsPipelineType::BasePipeline) {
-      m_flags.set(DxvkContextFlag::GpDynamicDepthBias,
-                  DxvkContextFlag::GpDynamicDepthTest,
-                  DxvkContextFlag::GpDynamicStencilTest,
-                  DxvkContextFlag::GpIndependentSets);
-
-      if (m_device->features().extExtendedDynamicState3.extendedDynamicState3DepthClipEnable)
-        m_flags.set(DxvkContextFlag::GpDynamicDepthClip);
-
-      if (m_device->features().core.features.depthBounds)
-        m_flags.set(DxvkContextFlag::GpDynamicDepthBounds);
-
-      if (m_device->features().extExtendedDynamicState3.extendedDynamicState3RasterizationSamples
-       && m_device->features().extExtendedDynamicState3.extendedDynamicState3SampleMask) {
-        m_flags.set(m_state.gp.flags.test(DxvkGraphicsPipelineFlag::HasSampleRateShading)
-          ? DxvkContextFlag::GpDynamicMultisampleState
-          : DxvkContextFlag::GpDirtyMultisampleState);
-      }
-
-      if (m_device->features().extSampleLocations
-       && m_device->features().extExtendedDynamicState3.extendedDynamicState3SampleLocationsEnable)
-        m_flags.set(DxvkContextFlag::GpDynamicSampleLocations);
-    } else {
-      if (m_device->features().extExtendedDynamicState3.extendedDynamicState3DepthClipEnable)
-        m_flags.set(DxvkContextFlag::GpDirtyDepthClip);
-
-      if (m_device->features().core.features.depthBounds) {
-        m_flags.set(m_state.gp.state.useDynamicDepthBounds()
-          ? DxvkContextFlag::GpDynamicDepthBounds
-          : DxvkContextFlag::GpDirtyDepthBounds);
-      }
-
-      if (m_device->features().extSampleLocations
-       && m_device->features().extExtendedDynamicState3.extendedDynamicState3SampleLocationsEnable) {
-        m_flags.set(m_state.gp.state.useSampleLocations()
-          ? DxvkContextFlag::GpDynamicSampleLocations
-          : DxvkContextFlag::GpDirtySampleLocations);
-      }
-
-      m_flags.set(m_state.gp.state.useDynamicDepthTest()
-        ? DxvkContextFlag::GpDynamicDepthTest
-        : DxvkContextFlag::GpDirtyDepthTest);
-
-      m_flags.set(m_state.gp.state.useDynamicStencilTest()
-        ? DxvkContextFlags(DxvkContextFlag::GpDynamicStencilTest)
-        : DxvkContextFlags(DxvkContextFlag::GpDirtyStencilTest,
-                           DxvkContextFlag::GpDirtyStencilRef));
-
-      m_flags.set(
-        DxvkContextFlag::GpDirtyMultisampleState);
-    }
 
     // If necessary, dirty descriptor sets due to layout incompatibilities
     bool newIndependentSets = m_flags.test(DxvkContextFlag::GpIndependentSets);
@@ -7282,7 +7300,8 @@ namespace dxvk {
 
   
   void DxvkContext::updateDynamicState() {
-    if (unlikely(m_flags.test(DxvkContextFlag::GpDirtyViewport))) {
+    if (unlikely(m_flags.all(DxvkContextFlag::GpDirtyViewport,
+                             DxvkContextFlag::GpDynamicViewport))) {
       m_flags.clr(DxvkContextFlag::GpDirtyViewport);
 
       // Clamp scissor against rendering area. Not doing so is technically
@@ -7604,13 +7623,12 @@ namespace dxvk {
     if (m_flags.test(DxvkContextFlag::GpXfbActive)) {
       // If transform feedback is active and there is a chance that we might
       // need to rebind the pipeline, we need to end transform feedback and
-      // issue a barrier. End the render pass to do that. Ignore dirty vertex
-      // buffers here since non-dynamic vertex strides are such an extreme
-      // edge case that it's likely irrelevant in practice.
+      // potentially issue a barrier. Dirtying xfb buffers will do that.
       if (m_flags.any(DxvkContextFlag::GpDirtyPipelineState,
-                      DxvkContextFlag::GpDirtySpecConstants,
-                      DxvkContextFlag::GpDirtyXfbBuffers))
-        this->spillRenderPass(true);
+                      DxvkContextFlag::GpDirtySpecConstants {
+        m_flags.set(DxvkContextFlag::GpDirtyXfbBuffers);
+        this->pauseTransformFeedback();
+      }
     }
 
     // If a depth-stencil image is bound used with non-default sample locations,
@@ -7853,7 +7871,7 @@ namespace dxvk {
      && m_state.gp.flags.test(DxvkGraphicsPipelineFlag::HasTransformFeedback)) {
       for (uint32_t i = 0; i < MaxNumXfbBuffers; i++) {
         const auto& xfbBufferSlice = m_state.xfb.buffers[i];
-        const auto& xfbCounterSlice = m_state.xfb.activeCounters[i];
+        const auto& xfbCounterSlice = m_state.xfb.counters[i];
 
         if (xfbBufferSlice.length()) {
           requiresBarrier |= !xfbBufferSlice.buffer()->trackGfxStores();

--- a/src/dxvk/dxvk_context_state.h
+++ b/src/dxvk/dxvk_context_state.h
@@ -55,6 +55,7 @@ namespace dxvk {
     GpDynamicRasterizerState,   ///< Cull mode and front face are dynamic
     GpDynamicSampleLocations,   ///< Sample locations are dynamic
     GpDynamicVertexStrides,     ///< Vertex buffer strides are dynamic
+    GpDynamicViewport,          ///< Viewport state is dynamic. Disabled for rasterizer discard.
     GpHasPushConstants,         ///< Graphics pipeline uses push constants
     GpIndependentSets,          ///< Graphics pipeline layout was created with independent sets
 

--- a/src/dxvk/dxvk_device_info.h
+++ b/src/dxvk/dxvk_device_info.h
@@ -49,6 +49,7 @@ namespace dxvk {
     VkPhysicalDeviceVulkan13Features                          vk13;
     VkBool32                                                  amdShaderFragmentMask;
     VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT   extAttachmentFeedbackLoopLayout;
+    VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT   extDynamicRenderingUnusedAttachments;
     VkPhysicalDeviceBorderColorSwizzleFeaturesEXT             extBorderColorSwizzle;
     VkBool32                                                  extConservativeRasterization;
     VkPhysicalDeviceCustomBorderColorFeaturesEXT              extCustomBorderColor;

--- a/src/dxvk/dxvk_extensions.h
+++ b/src/dxvk/dxvk_extensions.h
@@ -297,6 +297,7 @@ namespace dxvk {
     DxvkExt amdMemoryOverallocationBehaviour  = { VK_AMD_MEMORY_OVERALLOCATION_BEHAVIOR_EXTENSION_NAME,     DxvkExtMode::Disabled };
     DxvkExt amdShaderFragmentMask             = { VK_AMD_SHADER_FRAGMENT_MASK_EXTENSION_NAME,               DxvkExtMode::Optional };
     DxvkExt extAttachmentFeedbackLoopLayout   = { VK_EXT_ATTACHMENT_FEEDBACK_LOOP_LAYOUT_EXTENSION_NAME,    DxvkExtMode::Optional };
+    DxvkExt extDynamicRenderingUnusedAttachments   = { VK_EXT_DYNAMIC_RENDERING_UNUSED_ATTACHMENTS_EXTENSION_NAME,    DxvkExtMode::Optional };
     DxvkExt extBorderColorSwizzle             = { VK_EXT_BORDER_COLOR_SWIZZLE_EXTENSION_NAME,               DxvkExtMode::Optional };
     DxvkExt extConservativeRasterization      = { VK_EXT_CONSERVATIVE_RASTERIZATION_EXTENSION_NAME,         DxvkExtMode::Optional };
     DxvkExt extCustomBorderColor              = { VK_EXT_CUSTOM_BORDER_COLOR_EXTENSION_NAME,                DxvkExtMode::Optional };

--- a/src/dxvk/dxvk_graphics.cpp
+++ b/src/dxvk/dxvk_graphics.cpp
@@ -551,11 +551,6 @@ namespace dxvk {
     const DxvkGraphicsPipelineShaders&    shaders) {
     // Set up tessellation state
     tsInfo.patchControlPoints = state.ia.patchVertexCount();
-    
-    // Set up basic rasterization state
-    rsInfo.depthClampEnable         = VK_TRUE;
-    rsInfo.polygonMode              = state.rs.polygonMode();
-    rsInfo.lineWidth                = 1.0f;
 
     // Set up rasterized stream depending on geometry shader state.
     // Rasterizing stream 0 is default behaviour in all situations.
@@ -567,6 +562,19 @@ namespace dxvk {
     } else if (streamIndex < 0) {
       rsInfo.rasterizerDiscardEnable = VK_TRUE;
     }
+
+    if (shaders.gs && !shaders.gs->info().flags.test(DxvkShaderFlag::ExportsPosition))
+      rsInfo.rasterizerDiscardEnable = VK_TRUE;
+
+    // Nothing more to do if rasterizer discard is enabled.
+    // Avoid creating extra permutations in this case.
+    if (rsInfo.rasterizerDiscardEnable)
+      return;
+
+    // Set up basic rasterization state
+    rsInfo.depthClampEnable         = VK_TRUE;
+    rsInfo.polygonMode              = state.rs.polygonMode();
+    rsInfo.lineWidth                = 1.0f;
 
     // Set up depth clip state. If the extension is not supported,
     // use depth clamp instead, even though this is not accurate.
@@ -758,44 +766,43 @@ namespace dxvk {
     bool hasDynamicSampleLocations = device->features().extSampleLocations
       && device->features().extExtendedDynamicState3.extendedDynamicState3SampleLocationsEnable;
 
-    dyStates[dyInfo.dynamicStateCount++] = VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT;
-    dyStates[dyInfo.dynamicStateCount++] = VK_DYNAMIC_STATE_SCISSOR_WITH_COUNT;
+    if (state.useDynamicVertexStrides())
+      dyStates[dyInfo.dynamicStateCount++] = VK_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE;
 
     if (!flags.test(DxvkGraphicsPipelineFlag::HasRasterizerDiscard)) {
+      dyStates[dyInfo.dynamicStateCount++] = VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT;
+      dyStates[dyInfo.dynamicStateCount++] = VK_DYNAMIC_STATE_SCISSOR_WITH_COUNT;
       dyStates[dyInfo.dynamicStateCount++] = VK_DYNAMIC_STATE_DEPTH_BIAS;
       dyStates[dyInfo.dynamicStateCount++] = VK_DYNAMIC_STATE_DEPTH_BIAS_ENABLE;
       dyStates[dyInfo.dynamicStateCount++] = VK_DYNAMIC_STATE_CULL_MODE;
       dyStates[dyInfo.dynamicStateCount++] = VK_DYNAMIC_STATE_FRONT_FACE;
-    }
 
-    if (state.useDynamicVertexStrides())
-      dyStates[dyInfo.dynamicStateCount++] = VK_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE;
+      if (state.useDynamicDepthBounds() && device->features().core.features.depthBounds) {
+        dyStates[dyInfo.dynamicStateCount++] = VK_DYNAMIC_STATE_DEPTH_BOUNDS;
+        dyStates[dyInfo.dynamicStateCount++] = VK_DYNAMIC_STATE_DEPTH_BOUNDS_TEST_ENABLE;
+      }
 
-    if (state.useDynamicDepthBounds() && device->features().core.features.depthBounds) {
-      dyStates[dyInfo.dynamicStateCount++] = VK_DYNAMIC_STATE_DEPTH_BOUNDS;
-      dyStates[dyInfo.dynamicStateCount++] = VK_DYNAMIC_STATE_DEPTH_BOUNDS_TEST_ENABLE;
-    }
+      if (state.useDynamicBlendConstants())
+        dyStates[dyInfo.dynamicStateCount++] = VK_DYNAMIC_STATE_BLEND_CONSTANTS;
 
-    if (state.useDynamicBlendConstants())
-      dyStates[dyInfo.dynamicStateCount++] = VK_DYNAMIC_STATE_BLEND_CONSTANTS;
+      if (state.useDynamicDepthTest()) {
+        dyStates[dyInfo.dynamicStateCount++] = VK_DYNAMIC_STATE_DEPTH_TEST_ENABLE;
+        dyStates[dyInfo.dynamicStateCount++] = VK_DYNAMIC_STATE_DEPTH_COMPARE_OP;
+        dyStates[dyInfo.dynamicStateCount++] = VK_DYNAMIC_STATE_DEPTH_WRITE_ENABLE;
+      }
 
-    if (state.useDynamicDepthTest()) {
-      dyStates[dyInfo.dynamicStateCount++] = VK_DYNAMIC_STATE_DEPTH_TEST_ENABLE;
-      dyStates[dyInfo.dynamicStateCount++] = VK_DYNAMIC_STATE_DEPTH_COMPARE_OP;
-      dyStates[dyInfo.dynamicStateCount++] = VK_DYNAMIC_STATE_DEPTH_WRITE_ENABLE;
-    }
+      if (state.useDynamicStencilTest()) {
+        dyStates[dyInfo.dynamicStateCount++] = VK_DYNAMIC_STATE_STENCIL_TEST_ENABLE;
+        dyStates[dyInfo.dynamicStateCount++] = VK_DYNAMIC_STATE_STENCIL_OP;
+        dyStates[dyInfo.dynamicStateCount++] = VK_DYNAMIC_STATE_STENCIL_COMPARE_MASK;
+        dyStates[dyInfo.dynamicStateCount++] = VK_DYNAMIC_STATE_STENCIL_REFERENCE;
+        dyStates[dyInfo.dynamicStateCount++] = VK_DYNAMIC_STATE_STENCIL_WRITE_MASK;
+      }
 
-    if (state.useDynamicStencilTest()) {
-      dyStates[dyInfo.dynamicStateCount++] = VK_DYNAMIC_STATE_STENCIL_TEST_ENABLE;
-      dyStates[dyInfo.dynamicStateCount++] = VK_DYNAMIC_STATE_STENCIL_OP;
-      dyStates[dyInfo.dynamicStateCount++] = VK_DYNAMIC_STATE_STENCIL_COMPARE_MASK;
-      dyStates[dyInfo.dynamicStateCount++] = VK_DYNAMIC_STATE_STENCIL_REFERENCE;
-      dyStates[dyInfo.dynamicStateCount++] = VK_DYNAMIC_STATE_STENCIL_WRITE_MASK;
-    }
-
-    if (state.useSampleLocations() && hasDynamicSampleLocations) {
-      dyStates[dyInfo.dynamicStateCount++] = VK_DYNAMIC_STATE_SAMPLE_LOCATIONS_ENABLE_EXT;
-      dyStates[dyInfo.dynamicStateCount++] = VK_DYNAMIC_STATE_SAMPLE_LOCATIONS_EXT;
+      if (state.useSampleLocations() && hasDynamicSampleLocations) {
+        dyStates[dyInfo.dynamicStateCount++] = VK_DYNAMIC_STATE_SAMPLE_LOCATIONS_ENABLE_EXT;
+        dyStates[dyInfo.dynamicStateCount++] = VK_DYNAMIC_STATE_SAMPLE_LOCATIONS_EXT;
+      }
     }
 
     if (dyInfo.dynamicStateCount)
@@ -1017,12 +1024,12 @@ namespace dxvk {
     m_vsLibrary     (vsLibrary),
     m_fsLibrary     (fsLibrary),
     m_debugName     (createDebugName()) {
-    m_vsIn  = m_shaders.vs != nullptr ? m_shaders.vs->info().inputMask  : 0;
-    m_fsOut = m_shaders.fs != nullptr ? m_shaders.fs->info().outputMask : 0;
+    m_vsIn  = m_shaders.vs ? m_shaders.vs->info().inputMask  : 0;
+    m_fsOut = m_shaders.fs ? m_shaders.fs->info().outputMask : 0;
     m_specConstantMask = this->computeSpecConstantMask();
     gplAsyncCache = m_device->config().gplAsyncCache;
 
-    if (m_shaders.gs != nullptr) {
+    if (m_shaders.gs) {
       if (m_shaders.gs->flags().test(DxvkShaderFlag::HasTransformFeedback)) {
         m_flags.set(DxvkGraphicsPipelineFlag::HasTransformFeedback);
 
@@ -1032,10 +1039,11 @@ namespace dxvk {
                          |  VK_ACCESS_TRANSFORM_FEEDBACK_WRITE_BIT_EXT;
       }
 
-      if (m_shaders.gs->info().xfbRasterizedStream < 0)
+      if (m_shaders.gs->info().xfbrasterizedStream < 0
+       || !m_shaders.gs->info().flags.test(DxvkShaderFlag::ExportsPosition))
         m_flags.set(DxvkGraphicsPipelineFlag::HasRasterizerDiscard);
     }
-    
+
     if (m_barrier.access & VK_ACCESS_SHADER_WRITE_BIT) {
       m_flags.set(DxvkGraphicsPipelineFlag::HasStorageDescriptors);
 
@@ -1043,7 +1051,7 @@ namespace dxvk {
         m_flags.set(DxvkGraphicsPipelineFlag::UnrollMergedDraws);
     }
 
-    if (m_shaders.fs != nullptr) {
+    if (m_shaders.fs) {
       if (m_shaders.fs->flags().test(DxvkShaderFlag::HasSampleRateShading))
         m_flags.set(DxvkGraphicsPipelineFlag::HasSampleRateShading);
       if (m_shaders.fs->flags().test(DxvkShaderFlag::ExportsSampleMask))
@@ -1438,38 +1446,43 @@ namespace dxvk {
     DxvkShaderStageInfo stageInfo(m_device);
     stageInfo.addStage(VK_SHADER_STAGE_VERTEX_BIT, getShaderCode(m_shaders.vs, key.shState.vsInfo), &key.scState.scInfo);
 
-    if (m_shaders.tcs != nullptr)
+    if (m_shaders.tcs)
       stageInfo.addStage(VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT, getShaderCode(m_shaders.tcs, key.shState.tcsInfo), &key.scState.scInfo);
-    if (m_shaders.tes != nullptr)
+    if (m_shaders.tes)
       stageInfo.addStage(VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT, getShaderCode(m_shaders.tes, key.shState.tesInfo), &key.scState.scInfo);
-    if (m_shaders.gs != nullptr)
+    if (m_shaders.gs)
       stageInfo.addStage(VK_SHADER_STAGE_GEOMETRY_BIT, getShaderCode(m_shaders.gs, key.shState.gsInfo), &key.scState.scInfo);
-    if (m_shaders.fs != nullptr)
+    if (m_shaders.fs)
       stageInfo.addStage(VK_SHADER_STAGE_FRAGMENT_BIT, getShaderCode(m_shaders.fs, key.shState.fsInfo), &key.scState.scInfo);
 
-    VkGraphicsPipelineCreateInfo info = { VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO, &key.foState.rtInfo };
+    VkGraphicsPipelineCreateInfo info = { VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO };
     info.stageCount               = stageInfo.getStageCount();
     info.pStages                  = stageInfo.getStageInfos();
     info.pVertexInputState        = &key.viState.viInfo;
     info.pInputAssemblyState      = &key.viState.iaInfo;
-    info.pTessellationState       = &key.prState.tsInfo;
-    info.pViewportState           = &key.prState.vpInfo;
     info.pRasterizationState      = &key.prState.rsInfo;
-    info.pMultisampleState        = &key.foState.msInfo;
-    info.pDepthStencilState       = &key.fsState.dsInfo;
-    info.pColorBlendState         = &key.foState.cbInfo;
     info.pDynamicState            = &key.dyState.dyInfo;
     info.layout                   = m_layout.getLayout()->getPipelineLayout(false);
     info.basePipelineIndex        = -1;
-    
-    if (!key.prState.tsInfo.patchControlPoints)
-      info.pTessellationState = nullptr;
-    
-    if (key.foState.feedbackLoop & VK_IMAGE_ASPECT_COLOR_BIT)
+
+    if (key.prState.tsInfo.patchControlPoints)
+      info.pTessellationState     = &key.prState.tsInfo;
+
+    if (!m_flags.test(DxvkGraphicsPipelineFlag::HasRasterizerDiscard)) {
+      info.pNext                  = &key.foState.rtInfo;
+      info.pViewportState         = &key.prState.vpInfo;
+      info.pMultisampleState      = &key.foState.msInfo;
+      info.pDepthStencilState     = &key.fsState.dsInfo;
+      info.pColorBlendState       = &key.foState.cbInfo;
+    }
+
+    if (!m_flags.test(DxvkGraphicsPipelineFlag::HasRasterizerDiscard)) {
+      if (key.foState.feedbackLoop & VK_IMAGE_ASPECT_COLOR_BIT)
       info.flags |= VK_PIPELINE_CREATE_COLOR_ATTACHMENT_FEEDBACK_LOOP_BIT_EXT;
 
     if (key.foState.feedbackLoop & VK_IMAGE_ASPECT_DEPTH_BIT)
       info.flags |= VK_PIPELINE_CREATE_DEPTH_STENCIL_ATTACHMENT_FEEDBACK_LOOP_BIT_EXT;
+    }
 
     VkPipeline pipeline = VK_NULL_HANDLE;
     VkResult vr = vk->vkCreateGraphicsPipelines(vk->device(), VK_NULL_HANDLE, 1, &info, nullptr, &pipeline);

--- a/src/dxvk/dxvk_graphics.cpp
+++ b/src/dxvk/dxvk_graphics.cpp
@@ -563,7 +563,7 @@ namespace dxvk {
       rsInfo.rasterizerDiscardEnable = VK_TRUE;
     }
 
-    if (shaders.gs && !shaders.gs->info().flags.test(DxvkShaderFlag::ExportsPosition))
+    if (shaders.gs && !shaders.gs->flags().test(DxvkShaderFlag::ExportsPosition))
       rsInfo.rasterizerDiscardEnable = VK_TRUE;
 
     // Nothing more to do if rasterizer discard is enabled.
@@ -1039,8 +1039,8 @@ namespace dxvk {
                          |  VK_ACCESS_TRANSFORM_FEEDBACK_WRITE_BIT_EXT;
       }
 
-      if (m_shaders.gs->info().xfbrasterizedStream < 0
-       || !m_shaders.gs->info().flags.test(DxvkShaderFlag::ExportsPosition))
+      if (m_shaders.gs->info().xfbRasterizedStream < 0
+       || !m_shaders.gs->flags().test(DxvkShaderFlag::ExportsPosition))
         m_flags.set(DxvkGraphicsPipelineFlag::HasRasterizerDiscard);
     }
 

--- a/src/dxvk/dxvk_memory.cpp
+++ b/src/dxvk/dxvk_memory.cpp
@@ -1981,8 +1981,14 @@ namespace dxvk {
       VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
       VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
 
+    // Handle obscure setups where cached memory is unavailable.
     if (!m_memTypesByPropertyFlags[hostCachedIndex])
       m_memTypesByPropertyFlags[hostCachedIndex] = m_memTypesByPropertyFlags[hostCoherentIndex];
+
+    // If we zero mapped memory, we need good CPU memory bandwidth.
+    // Prefer uncached system memory over HVV in that case.
+    if (m_device->config().zeroMappedMemory)
+      m_memTypesByPropertyFlags[hostVisibleVramIndex] = m_memTypesByPropertyFlags[hostCoherentIndex];
 
     // On tilers, we are likely running on an ARM system where uncached
     // stores are expected to be very slow. Always use cached memory

--- a/src/dxvk/dxvk_meta_blit.cpp
+++ b/src/dxvk/dxvk_meta_blit.cpp
@@ -63,48 +63,69 @@ namespace dxvk {
   }
 
 
-  DxvkMetaBlitPipeline DxvkMetaBlitObjects::createPipeline(
-    const DxvkMetaBlitPipelineKey&    key) const {
-    util::DxvkBuiltInGraphicsState state = { };
+// Helper utility to convert Vulkan sample flags to pure loop scalar counts
+static uint32_t getSampleCountInteger(VkSampleCountFlagBits flags) {
+  if (flags & VK_SAMPLE_COUNT_16_BIT) return 16u;
+  if (flags & VK_SAMPLE_COUNT_8_BIT)  return 8u;
+  if (flags & VK_SAMPLE_COUNT_4_BIT)  return 4u;
+  if (flags & VK_SAMPLE_COUNT_2_BIT)  return 2u;
+  return 1u;
+}
 
-    std::array<VkSpecializationMapEntry, 3u> specMap = {{
-      { 0u, offsetof(DxvkMetaBlitPipelineKey, srcSamples),  sizeof(VkSampleCountFlagBits) },
-      { 1u, offsetof(DxvkMetaBlitPipelineKey, dstSamples),  sizeof(VkSampleCountFlagBits) },
-      { 2u, offsetof(DxvkMetaBlitPipelineKey, resolveMode), sizeof(DxvkMetaBlitResolveMode) },
-    }};
 
-    VkSpecializationInfo specInfo = { };
-    specInfo.mapEntryCount = specMap.size();
-    specInfo.pMapEntries = specMap.data();
-    specInfo.dataSize = sizeof(key);
-    specInfo.pData = &key;
+DxvkMetaBlitPipeline DxvkMetaBlitObjects::createPipeline(
+  const DxvkMetaBlitPipelineKey&    key) const {
+  util::DxvkBuiltInGraphicsState state = { };
 
-    if (m_device->features().vk12.shaderOutputLayer) {
-      state.vs = util::DxvkBuiltInShaderStage(dxvk_fullscreen_layer_vert, nullptr);
-    } else {
-      state.vs = util::DxvkBuiltInShaderStage(dxvk_fullscreen_vert, nullptr);
-      state.gs = util::DxvkBuiltInShaderStage(dxvk_fullscreen_geom, nullptr);
-    }
+  // Explicitly pack pure scalar counts for the unrolled GLSL shader loops
+  struct ShaderSpecData {
+    uint32_t srcSamples;  // Will be exactly 1, 2, 4, 8, or 16
+    uint32_t dstSamples;  // Will be exactly 1, 2, 4, 8, or 16
+    uint32_t resolveMode;
+  } specData;
 
-    if (key.srcSamples != VK_SAMPLE_COUNT_1_BIT) {
-      if (key.viewType == VK_IMAGE_VIEW_TYPE_2D_ARRAY) {
-        state.fs = util::DxvkBuiltInShaderStage(dxvk_blit_frag_2d_ms, &specInfo);
-      } else {
-        throw DxvkError("DxvkMetaBlitObjects: Invalid view type for multisampled image");
-      }
-    } else {
-      switch (key.viewType) {
-        case VK_IMAGE_VIEW_TYPE_1D_ARRAY: state.fs = util::DxvkBuiltInShaderStage(dxvk_blit_frag_1d, nullptr); break;
-        case VK_IMAGE_VIEW_TYPE_2D_ARRAY: state.fs = util::DxvkBuiltInShaderStage(dxvk_blit_frag_2d, nullptr); break;
-        case VK_IMAGE_VIEW_TYPE_3D:       state.fs = util::DxvkBuiltInShaderStage(dxvk_blit_frag_3d, nullptr); break;
-        default: throw DxvkError("DxvkMetaBlitObjects: Invalid view type");
-      }
-    }
+  specData.srcSamples  = getSampleCountInteger(key.srcSamples);  
+  specData.dstSamples  = getSampleCountInteger(key.dstSamples);  
+  specData.resolveMode = static_cast<uint32_t>(key.resolveMode); 
 
-    state.colorFormat = key.viewFormat;
-    state.sampleCount = key.dstSamples;
+  std::array<VkSpecializationMapEntry, 3u> specMap = {{
+    { 0u, offsetof(ShaderSpecData, srcSamples),  sizeof(uint32_t) },
+    { 1u, offsetof(ShaderSpecData, dstSamples),  sizeof(uint32_t) },
+    { 2u, offsetof(ShaderSpecData, resolveMode), sizeof(uint32_t) },
+  }};
 
-    return { m_layout, m_device->createBuiltInGraphicsPipeline(m_layout, state) };
+  VkSpecializationInfo specInfo = { };
+  specInfo.mapEntryCount = specMap.size();
+  specInfo.pMapEntries   = specMap.data();
+  specInfo.dataSize      = sizeof(ShaderSpecData);
+  specInfo.pData         = &specData;
+
+  if (m_device->features().vk12.shaderOutputLayer) {
+    state.vs = util::DxvkBuiltInShaderStage(dxvk_fullscreen_layer_vert, nullptr);
+  } else {
+    state.vs = util::DxvkBuiltInShaderStage(dxvk_fullscreen_vert, nullptr);
+    state.gs = util::DxvkBuiltInShaderStage(dxvk_fullscreen_geom, nullptr);
   }
+
+  if (key.srcSamples != VK_SAMPLE_COUNT_1_BIT) {
+    if (key.viewType == VK_IMAGE_VIEW_TYPE_2D_ARRAY) {
+      state.fs = util::DxvkBuiltInShaderStage(dxvk_blit_frag_2d_ms, &specInfo);
+    } else {
+      throw DxvkError("DxvkMetaBlitObjects: Invalid view type for multisampled image");
+    }
+  } else {
+    switch (key.viewType) {
+      case VK_IMAGE_VIEW_TYPE_1D_ARRAY: state.fs = util::DxvkBuiltInShaderStage(dxvk_blit_frag_1d, nullptr); break;
+      case VK_IMAGE_VIEW_TYPE_2D_ARRAY: state.fs = util::DxvkBuiltInShaderStage(dxvk_blit_frag_2d, nullptr); break;
+      case VK_IMAGE_VIEW_TYPE_3D:       state.fs = util::DxvkBuiltInShaderStage(dxvk_blit_frag_3d, nullptr); break;
+      default: throw DxvkError("DxvkMetaBlitObjects: Invalid view type");
+    }
+  }
+
+  state.colorFormat = key.viewFormat;
+  state.sampleCount = key.dstSamples;
+
+  return { m_layout, m_device->createBuiltInGraphicsPipeline(m_layout, state) };
+}
 
 }

--- a/src/dxvk/shaders/dxvk_blit_frag_2d_ms.frag
+++ b/src/dxvk/shaders/dxvk_blit_frag_2d_ms.frag
@@ -11,8 +11,9 @@ layout(location = 0) out vec4 o_color;
 layout(push_constant)
 uniform push_block {
   float p_src_coord0_x, p_src_coord0_y, p_src_coord0_z;
+  uint  p_pad1;
   float p_src_coord1_x, p_src_coord1_y, p_src_coord1_z;
-  uint p_layer_count;
+  uint  p_layer_count;
 };
 
 #define FILTER_NEAREST  (0u)

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1394,6 +1394,20 @@ namespace dxvk {
     { R"(\\Smash up Derby\\cars\.exe$)", {{
       { "d3d9.allowDirectBufferMapping",   "False" },
     }} },
+    /* Age of Pirates: Caribbean Tales            *
+     * Crashes due to a texture UAF otherwise     */
+    { R"(\\(Age of Pirates|Sea Dogs).*Caribbean Tales\\ENGINE\.exe$)", {{
+      { "d3d8.textureUAFGuard",             "True" },
+    }} },
+    /* Age of Pirates 2: City of Abandoned Ships  *
+     * Crashes due to a texture UAF otherwise     */
+    { R"(\\(Age of Pirates|Sea Dogs).*City of Abandoned Ships\\START\.exe$)", {{
+      { "d3d8.textureUAFGuard",             "True" },
+    }} },
+    /* Mafia - Improves poor texture filtering    */
+    { R"(\\Mafia\\Game\.exe$)", {{
+      { "d3d9.samplerAnisotropy",             "16" },
+    }} },
   };
 
 


### PR DESCRIPTION
Also backport additional commits.

[ba4c7e0](https://github.com/doitsujin/dxvk/commit/ba4c7e07fb788feb32a62a276a3f21614fe308a0) - [d3d8] Always quick return on failure - [[d3d8] Handle odd cases of texture UAF](https://github.com/doitsujin/dxvk/pull/5714)

[f1fa1a5](https://github.com/doitsujin/dxvk/commit/f1fa1a53ffcab8f2ae215642594ca541cc5efab2) - [d3d8] Add a UAF texture guard config option - [[d3d8] Handle odd cases of texture UAF](https://github.com/doitsujin/dxvk/pull/5714)

[ec44064](https://github.com/doitsujin/dxvk/commit/ec440643861a94b46562338f0f502edfd9a72fb3) - [util] Force sampler anisotropy for Mafia

[d435948](https://github.com/doitsujin/dxvk/commit/d43594895e1c3036abbe323d1d33f373bcdddb85) - [dxvk] Disable HVV usage if zeroMappedMemory option is set

[5c45928](https://github.com/doitsujin/dxvk/commit/5c45928bdd7162a0094302cdbde513c955f872f3) - [d3d9] Pass view format and swizzle to samplers - [Implement border color swizzle](https://github.com/doitsujin/dxvk/pull/5390) - Previously UnImplemented part of PR#5390

[5000fb1](https://github.com/doitsujin/dxvk/commit/5000fb1d825bc38ad9878febc276b3ad2e4945a0) - [d3d9] Simplify and fix light enablement - [Simplify D3D9 fixed-function lighting](https://github.com/doitsujin/dxvk/pull/5720)

[67dba69](https://github.com/doitsujin/dxvk/commit/67dba691fc01a0ae1b8821daafe97fbc53c5ceda) - [dxgi] Create a windowed swapchain instead when the fullscreen mode scanline order or scaling is invalid.

[68dbde1](https://github.com/doitsujin/dxvk/commit/68dbde1c600f65994e59f031c9a3009a4aac815b) - [dxvk] Enable VK_EXT_dynamic_rendering_unused_attachments - [Some rasterizer discard optimizations](https://github.com/doitsujin/dxvk/pull/5737)

[0566ef7](https://github.com/doitsujin/dxvk/commit/0566ef78b2d8d9cf64fa758f6b57f870f46828db) - [dxvk] Enable rasterizer discard if GS does not export position - [Some rasterizer discard optimizations](https://github.com/doitsujin/dxvk/pull/5737)

[9e293e7](https://github.com/doitsujin/dxvk/commit/9e293e776d68c1e2507b30c8686e4544ae243bec) - [dxvk] Do not pass unnecessary state for pipelines with rasterizer discard - [Some rasterizer discard optimizations](https://github.com/doitsujin/dxvk/pull/5737)

[3fcacb8](https://github.com/doitsujin/dxvk/commit/3fcacb8b5b9bc546f8283baeaed0296694132626) - [dxvk] Disable raster-related dynamic state if raster is disabled - [Some rasterizer discard optimizations](https://github.com/doitsujin/dxvk/pull/5737)

[5ab213f](https://github.com/doitsujin/dxvk/commit/5ab213f95d8707f7dd0f62391f1793bb7f2c548f) - [dxvk] Fix transform feedback synchronization - [Some rasterizer discard optimizations](https://github.com/doitsujin/dxvk/pull/5737)

