### PR TITLE
Backport upstream DXVK commits and PR#5817, DXVK Low Latency commits, Reduce Logs - Part 1

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('dxvk', ['c', 'cpp'], version : '2.6.8', meson_version : '>= 0.58', default_options : [ 'cpp_std=c++17', 'b_vscrt=static_from_buildtype', 'warning_level=2' ])
+project('dxvk', ['c', 'cpp'], version : '2.6.9', meson_version : '>= 0.58', default_options : [ 'cpp_std=c++17', 'b_vscrt=static_from_buildtype', 'warning_level=2' ])
 
 pkg = import('pkgconfig')
 cpu_family = target_machine.cpu_family()
@@ -23,6 +23,7 @@ compiler_args = [
   '-flto=auto', # Enables FullLTO for Clang and GCC
   '-Wimplicit-fallthrough',
   '-Wno-deprecated', # Silences warnings about use of -mtune=x86-64
+  '-Wno-switch', # Silences warnings about an enum value missing in a switch statement; used due to commenting out default sections that are used only for logging.
   # gcc
   '-fuse-linker-plugin', # Enabled by default in newer GCC toolchains
   '-Wno-missing-field-initializers',

--- a/src/d3d10/d3d10_device.cpp
+++ b/src/d3d10/d3d10_device.cpp
@@ -654,7 +654,9 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D10Device::CreateCounter(
     const D3D10_COUNTER_DESC*               pCounterDesc,
           ID3D10Counter**                   ppCounter) {
+/*
     Logger::err("D3D10Device::CreateCounter: Not implemented");
+*/
     return E_NOTIMPL;
   }
 
@@ -677,7 +679,9 @@ namespace dxvk {
 
   void STDMETHODCALLTYPE D3D10Device::CheckCounterInfo(
           D3D10_COUNTER_INFO*               pCounterInfo) {
+/*
     Logger::err("D3D10Device::CheckCounterInfo: Not implemented");
+*/
   }
 
 
@@ -691,7 +695,9 @@ namespace dxvk {
           UINT*                             pUnitsLength,
           char*                             description,
           UINT*                             pDescriptionLength) {
+/*
     Logger::err("D3D10Device::CheckCounter: Not implemented");
+*/
     return E_NOTIMPL;
   }
 

--- a/src/d3d11/d3d11_annotation.cpp
+++ b/src/d3d11/d3d11_annotation.cpp
@@ -16,7 +16,9 @@ namespace dxvk {
 
     HMODULE d3d9Module = ::LoadLibraryA("d3d9.dll");
     if (!d3d9Module) {
+/*
       Logger::info("Unable to find d3d9, some annotations may be missed.");
+*/
       return;
     }
 
@@ -25,7 +27,9 @@ namespace dxvk {
       reinterpret_cast<const char*>(static_cast<uintptr_t>(ordinal))));
 
     if (!registrationFunction) {
+/*
       Logger::info("Unable to find DXVK_RegisterAnnotation, some annotations may be missed.");
+*/
       return;
     }
 

--- a/src/d3d11/d3d11_blend.cpp
+++ b/src/d3d11/d3d11_blend.cpp
@@ -18,23 +18,25 @@ namespace dxvk {
           ? desc.RenderTarget[i]
           : desc.RenderTarget[0]);
     }
-    
+
     // Multisample state is part of the blend state in D3D11
     m_msState.setSampleMask(0u); // Set during bind
     m_msState.setAlphaToCoverage(desc.AlphaToCoverageEnable);
-    
+
+/*
     // Vulkan only supports a global logic op for the blend
     // state, which might be problematic in some cases.
     if (desc.IndependentBlendEnable && desc.RenderTarget[0].LogicOpEnable)
       Logger::warn("D3D11: Per-target logic ops not supported");
-    
+*/
+
     m_loState.setLogicOp(desc.RenderTarget[0].LogicOpEnable,
       DecodeLogicOp(desc.RenderTarget[0].LogicOp));
   }
-  
-  
+
+
   D3D11BlendState::~D3D11BlendState() {
-    
+
   }
 
 
@@ -43,7 +45,7 @@ namespace dxvk {
       return E_POINTER;
 
     *ppvObject = nullptr;
-    
+
     if (riid == __uuidof(IUnknown)
      || riid == __uuidof(ID3D11DeviceChild)
      || riid == __uuidof(ID3D11BlendState)
@@ -64,10 +66,12 @@ namespace dxvk {
       return S_OK;
     }
 
+/*
     if (logQueryInterfaceError(__uuidof(ID3D11BlendState), riid)) {
       Logger::warn("D3D11BlendState::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));
     }
+*/
 
     return E_NOINTERFACE;
   }

--- a/src/d3d11/d3d11_buffer.cpp
+++ b/src/d3d11/d3d11_buffer.cpp
@@ -166,15 +166,17 @@ namespace dxvk {
       return S_OK;
     }
 
+/*
     if (logQueryInterfaceError(__uuidof(ID3D11Buffer), riid)) {
       Logger::warn("D3D11Buffer::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));
     }
+*/
 
     return E_NOINTERFACE;
   }
-  
-  
+
+
   UINT STDMETHODCALLTYPE D3D11Buffer::GetEvictionPriority() {
     return DXGI_RESOURCE_PRIORITY_NORMAL;
   }
@@ -186,18 +188,18 @@ namespace dxvk {
     if (!std::exchange(s_errorShown, true))
       Logger::warn("D3D11Buffer::SetEvictionPriority: Stub");
   }
-  
-  
+
+
   void STDMETHODCALLTYPE D3D11Buffer::GetType(D3D11_RESOURCE_DIMENSION* pResourceDimension) {
     *pResourceDimension = D3D11_RESOURCE_DIMENSION_BUFFER;
   }
-  
-  
+
+
   void STDMETHODCALLTYPE D3D11Buffer::GetDesc(D3D11_BUFFER_DESC* pDesc) {
     *pDesc = m_desc;
   }
-  
-  
+
+
   bool D3D11Buffer::CheckViewCompatibility(
           UINT                BindFlags,
           DXGI_FORMAT         Format) const {

--- a/src/d3d11/d3d11_class_linkage.cpp
+++ b/src/d3d11/d3d11_class_linkage.cpp
@@ -34,15 +34,17 @@ namespace dxvk {
       return S_OK;
     }
 
+/*
     if (logQueryInterfaceError(__uuidof(ID3D11ClassLinkage), riid)) {
       Logger::warn("D3D11ClassLinkage::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));
     }
+*/
 
     return E_NOINTERFACE;
   }
-  
-  
+
+
   HRESULT STDMETHODCALLTYPE D3D11ClassLinkage::CreateClassInstance(
           LPCSTR              pClassTypeName,
           UINT                ConstantBufferOffset,
@@ -51,8 +53,11 @@ namespace dxvk {
           UINT                SamplerOffset,
           ID3D11ClassInstance **ppInstance) {
     InitReturnPtr(ppInstance);
-    
+
+/*
     Logger::err("D3D11ClassLinkage::CreateClassInstance: Not implemented yet");
+*/
+
     return E_NOTIMPL;
   }
   
@@ -61,8 +66,11 @@ namespace dxvk {
           LPCSTR              pClassInstanceName,
           UINT                InstanceIndex,
           ID3D11ClassInstance **ppInstance) {
+/*
     Logger::err("D3D11ClassLinkage::GetClassInstance: Not implemented yet");
+*/
+
     return E_NOTIMPL;
   }
-  
+
 }

--- a/src/d3d11/d3d11_cmdlist.cpp
+++ b/src/d3d11/d3d11_cmdlist.cpp
@@ -35,10 +35,12 @@ namespace dxvk {
       return S_OK;
     }
 
+/*
     if (logQueryInterfaceError(__uuidof(ID3D11CommandList), riid)) {
       Logger::warn("D3D11CommandList::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));
     }
+*/
 
     return E_NOINTERFACE;
   }

--- a/src/d3d11/d3d11_context.cpp
+++ b/src/d3d11/d3d11_context.cpp
@@ -87,10 +87,12 @@ namespace dxvk {
       return S_OK;
     }
 
+/*
     if (logQueryInterfaceError(__uuidof(ID3D11DeviceContext), riid)) {
       Logger::warn("D3D11DeviceContext::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));
     }
+*/
 
     return E_NOINTERFACE;
   }
@@ -465,7 +467,9 @@ namespace dxvk {
       rawFormat = uavFormat;
 
     if (uavFormat && !rawFormat) {
+/*
       Logger::err(str::format("D3D11: ClearUnorderedAccessViewUint: No raw format found for ", uavFormat));
+*/
       return;
     }
 
@@ -1485,8 +1489,10 @@ namespace dxvk {
 
     auto shader = static_cast<D3D11HullShader*>(pHullShader);
 
+/*
     if (NumClassInstances)
       Logger::err("D3D11: Class instances not supported");
+*/
 
     if (m_state.hs != shader) {
       m_state.hs = shader;
@@ -1623,8 +1629,10 @@ namespace dxvk {
 
     auto shader = static_cast<D3D11DomainShader*>(pDomainShader);
 
+/*
     if (NumClassInstances)
       Logger::err("D3D11: Class instances not supported");
+*/
 
     if (m_state.ds != shader) {
       m_state.ds = shader;
@@ -1761,8 +1769,10 @@ namespace dxvk {
 
     auto shader = static_cast<D3D11GeometryShader*>(pShader);
 
+/*
     if (NumClassInstances)
       Logger::err("D3D11: Class instances not supported");
+*/
 
     if (m_state.gs != shader) {
       m_state.gs = shader;
@@ -1899,8 +1909,10 @@ namespace dxvk {
 
     auto shader = static_cast<D3D11PixelShader*>(pPixelShader);
 
+/*
     if (NumClassInstances)
       Logger::err("D3D11: Class instances not supported");
+*/
 
     if (m_state.ps != shader) {
       m_state.ps = shader;
@@ -2037,8 +2049,10 @@ namespace dxvk {
 
     auto shader = static_cast<D3D11ComputeShader*>(pComputeShader);
 
+/*
     if (NumClassInstances)
       Logger::err("D3D11: Class instances not supported");
+*/
 
     if (m_state.cs != shader) {
       m_state.cs = shader;

--- a/src/d3d11/d3d11_cuda.cpp
+++ b/src/d3d11/d3d11_cuda.cpp
@@ -19,8 +19,11 @@ namespace dxvk {
       return S_OK;
     }
 
+/*
     Logger::warn("CubinShaderWrapper::QueryInterface: Unknown interface query");
     Logger::warn(str::format(riid));
+*/
+
     return E_NOINTERFACE;
   }
 

--- a/src/d3d11/d3d11_depth_stencil.cpp
+++ b/src/d3d11/d3d11_depth_stencil.cpp
@@ -49,10 +49,12 @@ namespace dxvk {
       return S_OK;
     }
 
+/*
     if (logQueryInterfaceError(__uuidof(ID3D11DepthStencilState), riid)) {
       Logger::warn("D3D11DepthStencilState::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));
     }
+*/
 
     return E_NOINTERFACE;
   }

--- a/src/d3d11/d3d11_device.cpp
+++ b/src/d3d11/d3d11_device.cpp
@@ -564,10 +564,12 @@ namespace dxvk {
     GetCommonResourceDesc(pResource, &resourceDesc);
     
     if (resourceDesc.Dim == D3D11_RESOURCE_DIMENSION_BUFFER) {
+/*
       Logger::warn("D3D11: Cannot create render target view for a buffer");
+*/
       return S_OK; // It is required to run Battlefield 3 and Battlefield 4.
     }
-    
+
     // The view description is optional. If not defined, it
     // will use the resource's format and all array layers.
     D3D11_RENDER_TARGET_VIEW_DESC1 desc;
@@ -885,9 +887,11 @@ namespace dxvk {
 
     // Set stream to rasterize, if any
     xfb.rasterizedStream = -1;
-    
+
+/*
     if (RasterizedStream != D3D11_SO_NO_RASTERIZED_STREAM)
       Logger::err("D3D11: CreateGeometryShaderWithStreamOutput: Rasterized stream not supported");
+*/
 
     // Create the actual shader module
     DxbcModuleInfo moduleInfo;
@@ -1280,8 +1284,9 @@ namespace dxvk {
     const D3D11_COUNTER_DESC*         pCounterDesc,
           ID3D11Counter**             ppCounter) {
     InitReturnPtr(ppCounter);
-    
+/*
     Logger::err(str::format("D3D11: Unsupported counter: ", pCounterDesc->Counter));
+*/
     return E_INVALIDARG;
   }
   
@@ -1468,8 +1473,9 @@ namespace dxvk {
           REFIID      returnedInterface, 
           void**      ppResource) {
     InitReturnPtr(ppResource);
-    
+/*
     Logger::err("D3D11Device::OpenSharedResourceByName: Not implemented");
+*/
     return E_NOTIMPL;
   }
 
@@ -1594,7 +1600,9 @@ namespace dxvk {
           UINT*               pUnitsLength,
           LPSTR               szDescription,
           UINT*               pDescriptionLength) {
+/*
     Logger::err("D3D11: Counters not supported");
+*/
     return E_INVALIDARG;
   }
   
@@ -1691,13 +1699,17 @@ namespace dxvk {
   
   
   HRESULT STDMETHODCALLTYPE D3D11Device::SetExceptionMode(UINT RaiseFlags) {
+/*
     Logger::err("D3D11Device::SetExceptionMode: Not implemented");
+*/
     return E_NOTIMPL;
   }
   
   
   UINT STDMETHODCALLTYPE D3D11Device::GetExceptionMode() {
+/*
     Logger::err("D3D11Device::GetExceptionMode: Not implemented");
+*/
     return 0;
   }
 
@@ -3390,8 +3402,6 @@ namespace dxvk {
     return m_apiVersion;
   }
 
-  
-
 
   D3D11DXGIDevice::D3D11DXGIDevice(
           IDXGIAdapter*       pAdapter,
@@ -3415,15 +3425,14 @@ namespace dxvk {
     m_metaDevice    (this),
     m_dxvkFactory   (this, &m_d3d11Device),
     m_destructionNotifier(this) {
-
   }
-  
-  
+
+
   D3D11DXGIDevice::~D3D11DXGIDevice() {
 
   }
-  
-  
+
+
   HRESULT STDMETHODCALLTYPE D3D11DXGIDevice::QueryInterface(REFIID riid, void** ppvObject) {
     if (ppvObject == nullptr)
       return E_POINTER;
@@ -3515,10 +3524,12 @@ namespace dxvk {
     if (riid == GUID{0xd56e2a4c,0x5127,0x8437,{0x65,0x8a,0x98,0xc5,0xbb,0x78,0x94,0x98}})
       return E_NOINTERFACE;
 
+/*
     if (logQueryInterfaceError(__uuidof(IDXGIDXVKDevice), riid)) {
       Logger::warn("D3D11DXGIDevice::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));
     }
+*/
 
     return E_NOINTERFACE;
   }
@@ -3589,9 +3600,11 @@ namespace dxvk {
     if (FAILED(hr))
       return hr;
 
+/*
     // We don't support shared resources
     if (NumSurfaces && pSharedResource)
       Logger::err("D3D11: CreateSurface: Shared surfaces not supported");
+*/
 
     // Try to create the given number of surfaces
     uint32_t surfacesCreated = 0;
@@ -3662,8 +3675,10 @@ namespace dxvk {
           INT                   Priority) {
     if (Priority < -7 || Priority > 7)
       return E_INVALIDARG;
-    
+
+/*
     Logger::err("DXGI: SetGPUThreadPriority: Ignoring");
+*/
     return S_OK;
   }
   

--- a/src/d3d11/d3d11_features.cpp
+++ b/src/d3d11/d3d11_features.cpp
@@ -174,7 +174,9 @@ namespace dxvk {
       case D3D11_FEATURE_THREADING:
         return GetTypedFeatureData(FeatureDataSize, pFeatureData, &m_threading);
       default:
+/*
         Logger::err(str::format("D3D11: Unknown feature: ", Feature));
+*/
         return E_INVALIDARG;
     }
   }

--- a/src/d3d11/d3d11_fence.cpp
+++ b/src/d3d11/d3d11_fence.cpp
@@ -23,8 +23,10 @@ namespace dxvk {
       fenceInfo.sharedHandle = hFence;
     }
 
+/*
     if (Flags & ~D3D11_FENCE_FLAG_SHARED)
       Logger::err(str::format("Fence flags 0x", std::hex, Flags, " not supported"));
+*/
 
     m_fence = pDevice->GetDXVKDevice()->createFence(fenceInfo);
   }
@@ -55,10 +57,12 @@ namespace dxvk {
       return S_OK;
     }
 
+/*
     if (logQueryInterfaceError(__uuidof(ID3D11Fence), riid)) {
       Logger::warn("D3D11Fence: Unknown interface query");
       Logger::warn(str::format(riid));
     }
+*/
 
     return E_NOINTERFACE;
   }
@@ -72,12 +76,14 @@ namespace dxvk {
     if (!(m_flags & D3D11_FENCE_FLAG_SHARED))
       return E_INVALIDARG;
 
+/*
     if (pAttributes)
       Logger::warn(str::format("CreateSharedHandle: attributes ", pAttributes, " not handled"));
     if (dwAccess)
       Logger::warn(str::format("CreateSharedHandle: access ", dwAccess, " not handled"));
     if (lpName)
       Logger::warn(str::format("CreateSharedHandle: name ", dxvk::str::fromws(lpName), " not handled"));
+*/
 
     HANDLE sharedHandle = m_fence->sharedHandle();
     if (sharedHandle == INVALID_HANDLE_VALUE)

--- a/src/d3d11/d3d11_input_layout.cpp
+++ b/src/d3d11/d3d11_input_layout.cpp
@@ -51,10 +51,12 @@ namespace dxvk {
       return S_OK;
     }
 
+/*
     if (logQueryInterfaceError(__uuidof(ID3D11InputLayout), riid)) {
       Logger::warn("D3D11InputLayout::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));
     }
+*/
 
     return E_NOINTERFACE;
   }

--- a/src/d3d11/d3d11_main.cpp
+++ b/src/d3d11/d3d11_main.cpp
@@ -316,10 +316,12 @@ extern "C" {
       return E_INVALIDARG;
     }
 
+/*
     if (NumQueues > 1) {
       // Not sure what to do with more than one graphics queue
       Logger::warn("D3D11On12CreateDevice: Only one queue supported");
     }
+*/
 
     if (FAILED(ppCommandQueues[0]->QueryInterface(__uuidof(ID3D12CommandQueue), reinterpret_cast<void**>(&d3d12Queue)))) {
       Logger::err("D3D11On12CreateDevice: Queue is not a valid D3D12 command queue");

--- a/src/d3d11/d3d11_query.cpp
+++ b/src/d3d11/d3d11_query.cpp
@@ -126,10 +126,12 @@ namespace dxvk {
       return S_OK;
     }
 
+/*
     if (logQueryInterfaceError(__uuidof(ID3D11Query), riid)) {
       Logger::warn("D3D11Query: Unknown interface query");
       Logger::warn(str::format(riid));
     }
+*/
 
     return E_NOINTERFACE;
   }
@@ -169,7 +171,7 @@ namespace dxvk {
       case D3D11_QUERY_SO_OVERFLOW_PREDICATE_STREAM3:
         return sizeof(BOOL);
     }
-    
+
     Logger::err("D3D11Query: Failed to query data size");
     return 0;
   }

--- a/src/d3d11/d3d11_rasterizer.cpp
+++ b/src/d3d11/d3d11_rasterizer.cpp
@@ -88,10 +88,12 @@ namespace dxvk {
       return S_OK;
     }
 
+/*
     if (logQueryInterfaceError(__uuidof(ID3D11RasterizerState), riid)) {
       Logger::warn("D3D11RasterizerState::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));
     }
+*/
 
     return E_NOINTERFACE;
   }

--- a/src/d3d11/d3d11_resource.cpp
+++ b/src/d3d11/d3d11_resource.cpp
@@ -87,7 +87,9 @@ namespace dxvk {
     if (!m_supported) {
       if (!m_warned) {
         m_warned = true;
+/*
         Logger::err("D3D11DXGIKeyedMutex::AcquireSync: Not supported");
+*/
       }
       return S_OK;
     }
@@ -281,8 +283,10 @@ namespace dxvk {
         !(texture->Desc()->MiscFlags & D3D11_RESOURCE_MISC_SHARED_NTHANDLE))
       return E_INVALIDARG;
 
+/*
     if (lpName)
       Logger::warn("Naming shared resources not supported");
+*/
 
     HANDLE handle = texture->GetImage()->sharedHandle();
 

--- a/src/d3d11/d3d11_sampler.cpp
+++ b/src/d3d11/d3d11_sampler.cpp
@@ -91,10 +91,12 @@ namespace dxvk {
       return S_OK;
     }
 
+/*
     if (logQueryInterfaceError(__uuidof(ID3D11SamplerState), riid)) {
       Logger::warn("D3D11SamplerState::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));
     }
+*/
 
     return E_NOINTERFACE;
   }

--- a/src/d3d11/d3d11_shader.cpp
+++ b/src/d3d11/d3d11_shader.cpp
@@ -14,8 +14,11 @@ namespace dxvk {
     const void*           pShaderBytecode,
           size_t          BytecodeLength) {
     const std::string name = pShaderKey->toString();
+
+/*
     Logger::debug(str::format("Compiling shader ", name));
-    
+*/
+
     DxbcReader reader(
       reinterpret_cast<const char*>(pShaderBytecode),
       BytecodeLength);

--- a/src/d3d11/d3d11_shader.h
+++ b/src/d3d11/d3d11_shader.h
@@ -146,10 +146,12 @@ namespace dxvk {
         return S_OK;
       }
 
+/*
       if (logQueryInterfaceError(__uuidof(D3D11Interface), riid)) {
         Logger::warn("D3D11Shader::QueryInterface: Unknown interface query");
         Logger::warn(str::format(riid));
       }
+*/
 
       return E_NOINTERFACE;
     }

--- a/src/d3d11/d3d11_state_object.cpp
+++ b/src/d3d11/d3d11_state_object.cpp
@@ -35,10 +35,12 @@ namespace dxvk {
       return S_OK;
     }
 
+/*
     if (logQueryInterfaceError(__uuidof(ID3DDeviceContextState), riid)) {
       Logger::warn("D3D11DeviceContextState::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));
     }
+*/
 
     return E_NOINTERFACE;
   }

--- a/src/d3d11/d3d11_swapchain.cpp
+++ b/src/d3d11/d3d11_swapchain.cpp
@@ -103,10 +103,12 @@ namespace dxvk {
       return S_OK;
     }
 
+/*
     if (logQueryInterfaceError(__uuidof(IDXGIVkSwapChain), riid)) {
       Logger::warn("D3D11SwapChain::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));
     }
+*/
 
     return E_NOINTERFACE;
   }

--- a/src/d3d11/d3d11_texture.cpp
+++ b/src/d3d11/d3d11_texture.cpp
@@ -1272,10 +1272,12 @@ namespace dxvk {
       return S_OK;
     }
 
+/*
     if (logQueryInterfaceError(__uuidof(ID3D10Texture1D), riid)) {
       Logger::warn("D3D11Texture1D::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));
     }
+*/
 
     return E_NOINTERFACE;
   }
@@ -1449,10 +1451,12 @@ namespace dxvk {
       return S_OK;
     }
 
+/*
     if (logQueryInterfaceError(__uuidof(ID3D10Texture2D), riid)) {
       Logger::warn("D3D11Texture2D::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));
     }
+*/
 
     return E_NOINTERFACE;
   }
@@ -1574,10 +1578,12 @@ namespace dxvk {
       return S_OK;
     }
 
+/*
     if (logQueryInterfaceError(__uuidof(ID3D10Texture3D), riid)) {
       Logger::warn("D3D11Texture3D::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));
     }
+*/
 
     return E_NOINTERFACE;
   }

--- a/src/d3d11/d3d11_video.cpp
+++ b/src/d3d11/d3d11_video.cpp
@@ -37,10 +37,12 @@ namespace dxvk {
       return S_OK;
     }
 
+/*
     if (logQueryInterfaceError(__uuidof(ID3D11VideoProcessorEnumerator), riid)) {
       Logger::warn("D3D11VideoProcessorEnumerator::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));
     }
+*/
 
     return E_NOINTERFACE;
   }
@@ -56,7 +58,9 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D11VideoProcessorEnumerator::CheckVideoProcessorFormat(
           DXGI_FORMAT             Format,
           UINT*                   pFlags) {
+/*
     Logger::warn(str::format("D3D11VideoProcessorEnumerator::CheckVideoProcessorFormat: stub, format ", Format));
+*/
 
     if (!pFlags)
       return E_INVALIDARG;
@@ -165,10 +169,12 @@ namespace dxvk {
       return S_OK;
     }
 
+/*
     if (logQueryInterfaceError(__uuidof(ID3D11VideoProcessor), riid)) {
       Logger::warn("D3D11VideoProcessor::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));
     }
+*/
 
     return E_NOINTERFACE;
   }
@@ -317,10 +323,12 @@ namespace dxvk {
       return S_OK;
     }
 
+/*
     if (logQueryInterfaceError(__uuidof(ID3D11VideoProcessorInputView), riid)) {
       Logger::warn("D3D11VideoProcessorInputView::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));
     }
+*/
 
     return E_NOINTERFACE;
   }
@@ -392,10 +400,12 @@ namespace dxvk {
       return S_OK;
     }
 
+/*
     if (logQueryInterfaceError(__uuidof(ID3D11VideoProcessorOutputView), riid)) {
       Logger::warn("D3D11VideoProcessorOutputView::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));
     }
+*/
 
     return E_NOINTERFACE;
   }
@@ -1276,7 +1286,9 @@ namespace dxvk {
           ID3D11CryptoSession*            pSession,
           UINT                            DataSize,
           void*                           pData) {
+/*
     Logger::warn("D3D11VideoContext::NegotiateCryptoSessionKeyExchange: Stub");
+*/
     return E_NOTIMPL;
   }
 
@@ -1287,7 +1299,9 @@ namespace dxvk {
           ID3D11Texture2D*                pDstSurface,
           UINT                            IVSize,
           void*                           pIV) {
+/*
     Logger::warn("D3D11VideoContext::EncryptionBlt: Stub");
+*/
   }
 
 
@@ -1300,7 +1314,10 @@ namespace dxvk {
     const void*                           pKey,
           UINT                            IVSize,
           void*                           pIV) {
+/*
     Logger::warn("D3D11VideoContext::DecryptionBlt: Stub");
+*/
+
   }
 
 
@@ -1308,13 +1325,17 @@ namespace dxvk {
           ID3D11CryptoSession*            pSession,
           UINT                            RandomNumberSize,
           void*                           pRandomNumber) {
+/*
     Logger::warn("D3D11VideoContext::StartSessionKeyRefresh: Stub");
+*/
   }
 
 
   void STDMETHODCALLTYPE D3D11VideoContext::FinishSessionKeyRefresh(
           ID3D11CryptoSession*            pSession) {
+/*
     Logger::warn("D3D11VideoContext::FinishSessionKeyRefresh: Stub");
+*/
   }
 
 
@@ -1322,7 +1343,9 @@ namespace dxvk {
           ID3D11CryptoSession*            pSession,
           UINT                            KeySize,
           void*                           pKey) {
+/*
     Logger::warn("D3D11VideoContext::GetEncryptionBltKey: Stub");
+*/
     return E_NOTIMPL;
   }
 
@@ -1331,7 +1354,9 @@ namespace dxvk {
           ID3D11AuthenticatedChannel*     pChannel,
           UINT                            DataSize,
           void*                           pData) {
+/*
     Logger::warn("D3D11VideoContext::NegotiateAuthenticatedChannelKeyExchange: Stub");
+*/
     return E_NOTIMPL;
   }
 
@@ -1342,7 +1367,9 @@ namespace dxvk {
     const void*                           pInput,
           UINT                            OutputSize,
           void*                           pOutput) {
+/*
     Logger::warn("D3D11VideoContext::QueryAuthenticatedChannel: Stub");
+*/
     return E_NOTIMPL;
   }
 
@@ -1352,7 +1379,9 @@ namespace dxvk {
           UINT                            InputSize,
     const void*                           pInput,
           D3D11_AUTHENTICATED_CONFIGURE_OUTPUT* pOutput) {
+/*
     Logger::warn("D3D11VideoContext::ConfigureAuthenticatedChannel: Stub");
+*/
     return E_NOTIMPL;
   }
 
@@ -1433,6 +1462,7 @@ namespace dxvk {
     const D3D11_VIDEO_PROCESSOR_STREAM*   pStream) {
     CreateResources();
 
+/*
     if (pStream->PastFrames || pStream->FutureFrames)
       Logger::err("D3D11VideoContext: Ignoring non-zero PastFrames and FutureFrames");
 
@@ -1441,6 +1471,7 @@ namespace dxvk {
 
     if (pStream->InputFrameOrField)
       Logger::err("D3D11VideoContext: Ignoring non-zero InputFrameOrField");
+*/
 
     auto& view = static_cast<D3D11VideoProcessorInputView*>(pStream->pInputSurface)->GetCommon();
 

--- a/src/d3d11/d3d11_view_dsv.cpp
+++ b/src/d3d11/d3d11_view_dsv.cpp
@@ -143,10 +143,12 @@ namespace dxvk {
       return S_OK;
     }
 
+/*
     if (logQueryInterfaceError(__uuidof(ID3D11DepthStencilView), riid)) {
       Logger::warn("D3D11DepthStencilView::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));
     }
+*/
 
     return E_NOINTERFACE;
   }

--- a/src/d3d11/d3d11_view_rtv.cpp
+++ b/src/d3d11/d3d11_view_rtv.cpp
@@ -155,10 +155,12 @@ namespace dxvk {
       return S_OK;
     }
 
+/*
     if (logQueryInterfaceError(__uuidof(ID3D11RenderTargetView), riid)) {
       Logger::warn("D3D11RenderTargetView::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));
     }
+*/
 
     return E_NOINTERFACE;
   }

--- a/src/d3d11/d3d11_view_srv.cpp
+++ b/src/d3d11/d3d11_view_srv.cpp
@@ -221,10 +221,12 @@ namespace dxvk {
       return S_OK;
     }
 
+/*
     if (logQueryInterfaceError(__uuidof(ID3D11ShaderResourceView), riid)) {
       Logger::warn("D3D11ShaderResourceView::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));
     }
+*/
 
     return E_NOINTERFACE;
   }

--- a/src/d3d11/d3d11_view_uav.cpp
+++ b/src/d3d11/d3d11_view_uav.cpp
@@ -63,8 +63,10 @@ namespace dxvk {
       viewInfo.aspects = formatInfo.Aspect;
       viewInfo.usage = VK_IMAGE_USAGE_STORAGE_BIT;
 
+/*
       if (!util::isIdentityMapping(formatInfo.Swizzle))
         Logger::warn(str::format("UAV format ", pDesc->Format, " has non-identity swizzle, but UAV swizzles are not supported"));
+*/
 
       switch (pDesc->ViewDimension) {
         case D3D11_UAV_DIMENSION_TEXTURE1D:
@@ -160,10 +162,12 @@ namespace dxvk {
       return S_OK;
     }
 
+/*
     if (logQueryInterfaceError(__uuidof(ID3D11UnorderedAccessView), riid)) {
       Logger::warn("D3D11UnorderedAccessView::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));
     }
+*/
 
     return E_NOINTERFACE;
   }

--- a/src/d3d8/d3d8_device.cpp
+++ b/src/d3d8/d3d8_device.cpp
@@ -1162,10 +1162,10 @@ namespace dxvk {
       // to skip the validation, in order to prevent issues.
       const bool isOnePixelWider  = pViewport->X + pViewport->Width  == rtDesc.Width  + 1;
       const bool isOnePixelTaller = pViewport->Y + pViewport->Height == rtDesc.Height + 1;
-/*
+
       if (unlikely(m_presentParams.Windowed && (isOnePixelWider || isOnePixelTaller))) {
         Logger::debug("D3D8Device::SetViewport: Viewport exceeds render target dimensions by one pixel");
-      } */ else {
+      }  else {
         return D3DERR_INVALIDCALL;
       }
 

--- a/src/d3d8/d3d8_device.cpp
+++ b/src/d3d8/d3d8_device.cpp
@@ -24,7 +24,7 @@ namespace dxvk {
     , m_behaviorFlags(BehaviorFlags)
     , m_multithread(BehaviorFlags & D3DCREATE_MULTITHREADED) {
     // Get the bridge interface to D3D9.
-    if (unlikely(FAILED(GetD3D9()->QueryInterface(__uuidof(IDxvkD3D8Bridge), reinterpret_cast<void**>(&m_bridge))))) {
+    if (unlikely(FAILED(GetD3D9()->QueryInterface(__uuidof(IDxvkLegacyD3DDeviceBridge), reinterpret_cast<void**>(&m_bridge))))) {
       throw DxvkError("D3D8Device: ERROR! Failed to get D3D9 Bridge. d3d9.dll might not be DXVK!");
     }
 
@@ -41,7 +41,9 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::GetInfo(DWORD DevInfoID, void* pDevInfoStruct, DWORD DevInfoStructSize) {
+/*
     Logger::debug(str::format("D3D8Device::GetInfo: ", DevInfoID));
+*/
 
     if (unlikely(pDevInfoStruct == nullptr || DevInfoStructSize == 0))
       return D3DERR_INVALIDCALL;
@@ -752,19 +754,23 @@ namespace dxvk {
 
       POINT dstPt = { dstRect.left, dstRect.top };
 
+/*
       auto unsupported = [&] {
         Logger::err(str::format("D3D8Device::CopyRects: Unsupported case from src pool ", srcDesc.Pool, " to dst pool ", dstDesc.Pool));
         return D3DERR_INVALIDCALL;
       };
 
       auto logError = [&] (HRESULT res) {
+
         if (FAILED(res)) {
           // Only a debug message because some games mess up CopyRects every frame in a way
           // that fails on native too but are perfectly fine with it.
           Logger::debug(str::format("D3D8Device::CopyRects: Failed to copy from src pool ", srcDesc.Pool, " to dst pool ", dstDesc.Pool));
         }
+
         return res;
       };
+*/
 
       switch (dstDesc.Pool) {
 
@@ -773,31 +779,31 @@ namespace dxvk {
           switch (srcDesc.Pool) {
             case d3d9::D3DPOOL_DEFAULT: {
               // DEFAULT -> DEFAULT: use StretchRect
-              return logError(GetD3D9()->StretchRect(
+              return GetD3D9()->StretchRect(
                 src->GetD3D9(),
                 &srcRect,
                 dst->GetD3D9(),
                 &dstRect,
                 d3d9::D3DTEXF_NONE
-              ));
+              );
             }
             case d3d9::D3DPOOL_MANAGED: {
               // MANAGED -> DEFAULT: UpdateTextureFromBuffer
-              return logError(m_bridge->UpdateTextureFromBuffer(
+              return m_bridge->UpdateTextureFromBuffer(
                 src->GetD3D9(),
                 dst->GetD3D9(),
                 &srcRect,
                 &dstPt
-              ));
+              );
             }
             case d3d9::D3DPOOL_SYSTEMMEM: {
               // SYSTEMMEM -> DEFAULT: use UpdateSurface
-              return logError(GetD3D9()->UpdateSurface(
+              return GetD3D9()->UpdateSurface(
                 src->GetD3D9(),
                 &srcRect,
                 dst->GetD3D9(),
                 &dstPt
-              ));
+              );
             }
             case d3d9::D3DPOOL_SCRATCH: {
               // SCRATCH -> DEFAULT: memcpy to a SYSTEMMEM temporary buffer and use UpdateSurface
@@ -805,7 +811,7 @@ namespace dxvk {
               const bool isSupportedSurfaceFormat = m_bridge->IsSupportedSurfaceFormat(srcDesc.Format);
               // UpdateSurface will not work on surface formats unsupported by D3DPOOL_DEFAULT
               if (unlikely(!isSupportedSurfaceFormat))
-                return logError(D3DERR_INVALIDCALL);
+                return D3DERR_INVALIDCALL;
 
               Com<IDirect3DSurface8> pTempImageSurface;
               // The temporary image surface is guaranteed to end up in SYSTEMMEM for supported formats
@@ -815,28 +821,24 @@ namespace dxvk {
                 D3DFORMAT(srcDesc.Format),
                 &pTempImageSurface
               );
-
-              if (FAILED(res)) {
-                return logError(res);
-              }
+              if (unlikely(FAILED(res)))
+                return res;
 
               Com<D3D8Surface> pBlitImage = static_cast<D3D8Surface*>(pTempImageSurface.ptr());
               // Temporary image surface dimensions are identical, so we can reuse srcDesc/Rect
               res = copyTextureBuffers(src.ptr(), pBlitImage.ptr(), srcDesc, srcDesc, srcRect, srcRect);
+              if (unlikely(FAILED(res)))
+                return res;
 
-              if (FAILED(res)) {
-                return logError(res);
-              }
-
-              return logError(GetD3D9()->UpdateSurface(
+              return GetD3D9()->UpdateSurface(
                 pBlitImage->GetD3D9(),
                 &srcRect,
                 dst->GetD3D9(),
                 &dstPt
-              ));
+              );
             }
             default: {
-              return unsupported();
+              return D3DERR_INVALIDCALL;
             }
           } break;
 
@@ -855,27 +857,24 @@ namespace dxvk {
                 pBlitImage.ptr(),
                 &dstRect,
                 d3d9::D3DTEXF_NONE);
-
-              if (FAILED(res)) {
-                return logError(res);
-              }
+              if (unlikely(FAILED(res)))
+                return res;
 
               // Now sync the rendertarget data into main memory.
-              return logError(GetD3D9()->GetRenderTargetData(pBlitImage.ptr(), dst->GetD3D9()));
+              return GetD3D9()->GetRenderTargetData(pBlitImage.ptr(), dst->GetD3D9());
             }
             case d3d9::D3DPOOL_MANAGED:
             case d3d9::D3DPOOL_SYSTEMMEM:
             case d3d9::D3DPOOL_SCRATCH: {
               // MANAGED/SYSMEM/SCRATCH -> MANAGED: LockRect / memcpy
 
-              if (stretch) {
-                return logError(D3DERR_INVALIDCALL);
-              }
+              if (unlikely(stretch))
+                return D3DERR_INVALIDCALL;
 
-              return logError(copyTextureBuffers(src.ptr(), dst.ptr(), srcDesc, dstDesc, srcRect, dstRect));
+              return copyTextureBuffers(src.ptr(), dst.ptr(), srcDesc, dstDesc, srcRect, dstRect);
             }
             default: {
-              return unsupported();
+              return D3DERR_INVALIDCALL;
             }
           } break;
 
@@ -891,7 +890,7 @@ namespace dxvk {
                 && srcDesc.Height == dstDesc.Height
                 && srcDesc.Format == dstDesc.Format
                 && !asymmetric) {
-              return logError(GetD3D9()->GetRenderTargetData(src->GetD3D9(), dst->GetD3D9()));
+              return GetD3D9()->GetRenderTargetData(src->GetD3D9(), dst->GetD3D9());
             }
           }
 
@@ -907,26 +906,23 @@ namespace dxvk {
                 pBlitImage.ptr(),
                 &dstRect,
                 d3d9::D3DTEXF_NONE);
-
-              if (FAILED(res)) {
-                return logError(res);
-              }
+              if (unlikely(FAILED(res)))
+                return res;
 
               // Now sync the rendertarget data into main memory.
-              return logError(GetD3D9()->GetRenderTargetData(pBlitImage.ptr(), dst->GetD3D9()));
+              return GetD3D9()->GetRenderTargetData(pBlitImage.ptr(), dst->GetD3D9());
             }
             // MANAGED/SYSMEM/SCRATCH -> SYSMEM: LockRect / memcpy
             case d3d9::D3DPOOL_MANAGED:
             case d3d9::D3DPOOL_SYSTEMMEM:
             case d3d9::D3DPOOL_SCRATCH: {
-              if (stretch) {
-                return logError(D3DERR_INVALIDCALL);
-              }
+              if (unlikely(stretch))
+                return D3DERR_INVALIDCALL;
 
-              return logError(copyTextureBuffers(src.ptr(), dst.ptr(), srcDesc, dstDesc, srcRect, dstRect));
+              return copyTextureBuffers(src.ptr(), dst.ptr(), srcDesc, dstDesc, srcRect, dstRect);
             }
             default: {
-              return unsupported();
+              return D3DERR_INVALIDCALL;
             }
           } break;
         }
@@ -943,7 +939,7 @@ namespace dxvk {
                 && srcDesc.Height == dstDesc.Height
                 && srcDesc.Format == dstDesc.Format
                 && !asymmetric) {
-              return logError(GetD3D9()->GetRenderTargetData(src->GetD3D9(), dst->GetD3D9()));
+              return GetD3D9()->GetRenderTargetData(src->GetD3D9(), dst->GetD3D9());
             }
           }
 
@@ -959,31 +955,28 @@ namespace dxvk {
                 pBlitImage.ptr(),
                 &dstRect,
                 d3d9::D3DTEXF_NONE);
-
-              if (FAILED(res)) {
-                return logError(res);
-              }
+              if (unlikely(FAILED(res)))
+                return res;
 
               // Now sync the rendertarget data into main memory.
-              return logError(GetD3D9()->GetRenderTargetData(pBlitImage.ptr(), dst->GetD3D9()));
+              return GetD3D9()->GetRenderTargetData(pBlitImage.ptr(), dst->GetD3D9());
             }
             // MANAGED/SYSMEM/SCRATCH -> SCRATCH: LockRect / memcpy
             case d3d9::D3DPOOL_MANAGED:
             case d3d9::D3DPOOL_SYSTEMMEM:
             case d3d9::D3DPOOL_SCRATCH: {
-              if (stretch) {
-                return logError(D3DERR_INVALIDCALL);
-              }
+              if (unlikely(stretch))
+                return D3DERR_INVALIDCALL;
 
-              return logError(copyTextureBuffers(src.ptr(), dst.ptr(), srcDesc, dstDesc, srcRect, dstRect));
+              return copyTextureBuffers(src.ptr(), dst.ptr(), srcDesc, dstDesc, srcRect, dstRect);
             }
             default: {
-              return unsupported();
+              return D3DERR_INVALIDCALL;
             }
           } break;
         }
         default: {
-          return unsupported();
+          return D3DERR_INVALIDCALL;
         }
       }
     }
@@ -1169,12 +1162,13 @@ namespace dxvk {
       // to skip the validation, in order to prevent issues.
       const bool isOnePixelWider  = pViewport->X + pViewport->Width  == rtDesc.Width  + 1;
       const bool isOnePixelTaller = pViewport->Y + pViewport->Height == rtDesc.Height + 1;
-
+/*
       if (unlikely(m_presentParams.Windowed && (isOnePixelWider || isOnePixelTaller))) {
         Logger::debug("D3D8Device::SetViewport: Viewport exceeds render target dimensions by one pixel");
-      } else {
+      } */ else {
         return D3DERR_INVALIDCALL;
       }
+
     }
 
     StateChange();
@@ -1237,7 +1231,9 @@ namespace dxvk {
     D3D8StateBlockType stateBlockType = ConvertStateBlockType(Type);
 
     if (unlikely(stateBlockType == D3D8StateBlockType::Unknown)) {
+/*
       Logger::warn(str::format("D3D8Device::CreateStateBlock: Invalid state block type: ", Type));
+*/
       return D3DERR_INVALIDCALL;
     }
 
@@ -1264,7 +1260,9 @@ namespace dxvk {
 
     auto stateBlockIter = m_stateBlocks.find(Token);
     if (unlikely(stateBlockIter == m_stateBlocks.end())) {
+/*
       Logger::warn(str::format("D3D8Device::CaptureStateBlock: Invalid token: ", std::hex, Token));
+*/
       return D3D_OK;
     }
 
@@ -1282,7 +1280,9 @@ namespace dxvk {
 
     auto stateBlockIter = m_stateBlocks.find(Token);
     if (unlikely(stateBlockIter == m_stateBlocks.end())) {
+/*
       Logger::warn(str::format("D3D8Device::ApplyStateBlock: Invalid token: ", std::hex, Token));
+*/
       return D3D_OK;
     }
 
@@ -1298,7 +1298,9 @@ namespace dxvk {
 
     auto stateBlockIter = m_stateBlocks.find(Token);
     if (unlikely(stateBlockIter == m_stateBlocks.end())) {
+/*
       Logger::warn(str::format("D3D8Device::DeleteStateBlock: Invalid token: ", std::hex, Token));
+*/
       return D3D_OK;
     }
 
@@ -1648,8 +1650,10 @@ namespace dxvk {
     if (unlikely(ShouldRecord()))
       return m_recorder->SetIndices(pIndexData, BaseVertexIndex);
 
+/*
     if (unlikely(BaseVertexIndex > std::numeric_limits<int32_t>::max()))
       Logger::warn("D3D8Device::SetIndices: BaseVertexIndex exceeds INT_MAX");
+*/
 
     D3D8IndexBuffer* buffer = static_cast<D3D8IndexBuffer*>(pIndexData);
     HRESULT res = GetD3D9()->SetIndices(D3D8IndexBuffer::GetD3D9Nullable(buffer));
@@ -1888,13 +1892,17 @@ namespace dxvk {
   inline D3D8VertexShaderInfo* getVertexShaderInfo(D3D8Device* device, DWORD Handle) {
     Handle = getShaderIndex(Handle);
     if (unlikely(Handle >= device->m_vertexShaders.size())) {
-      Logger::debug(str::format("D3D8: Invalid vertex shader index ", std::hex, Handle));
+/*
+      Logger::warn(str::format("D3D8Device: Invalid vertex shader handle ", std::hex, Handle));
+*/
       return nullptr;
     }
 
     D3D8VertexShaderInfo& info = device->m_vertexShaders[Handle];
     if (unlikely(info.pVertexDecl == nullptr && info.pVertexShader == nullptr)) {
-      Logger::debug(str::format("D3D8: Application provided deleted vertex shader ", std::hex, Handle));
+/*
+      Logger::warn(str::format("D3D8Device: Application provided deleted vertex shader ", std::hex, Handle));
+*/
       return nullptr;
     }
 
@@ -1914,7 +1922,7 @@ namespace dxvk {
     if (!isFVF(Handle)) {
       D3D8VertexShaderInfo* info = getVertexShaderInfo(this, Handle);
 
-      if (!info)
+      if (unlikely(!info))
         return D3DERR_INVALIDCALL;
 
       StateChange();
@@ -1980,7 +1988,7 @@ namespace dxvk {
     if (!isFVF(Handle)) {
       D3D8VertexShaderInfo* info = getVertexShaderInfo(this, Handle);
 
-      if (!info)
+      if (unlikely(!info))
         return D3DERR_INVALIDCALL;
 
       info->pVertexDecl = nullptr;
@@ -2082,14 +2090,18 @@ namespace dxvk {
     Handle = getShaderIndex(Handle);
 
     if (unlikely(Handle >= device->m_pixelShaders.size())) {
-      Logger::debug(str::format("D3D8: Invalid pixel shader index ", std::hex, Handle));
+/*
+      Logger::warn(str::format("D3D8Device: Invalid pixel shader handle ", std::hex, Handle));
+*/
       return nullptr;
     }
 
     d3d9::IDirect3DPixelShader9* pPixelShader = device->m_pixelShaders[Handle].ptr();
 
     if (unlikely(pPixelShader == nullptr)) {
-      Logger::debug(str::format("D3D8: Application provided deleted pixel shader ", std::hex, Handle));
+/*
+      Logger::warn(str::format("D3D8Device: Application provided deleted pixel shader ", std::hex, Handle));
+*/
       return nullptr;
     }
 
@@ -2103,17 +2115,16 @@ namespace dxvk {
       return m_recorder->SetPixelShader(Handle);
     }
 
-    if (Handle == DWORD(NULL)) {
+    if (!Handle) {
       StateChange();
-      m_currentPixelShader = DWORD(NULL);
+      m_currentPixelShader = 0;
       return GetD3D9()->SetPixelShader(nullptr);
     }
 
     d3d9::IDirect3DPixelShader9* pPixelShader = getPixelShaderPtr(this, Handle);
 
-    if (unlikely(!pPixelShader)) {
+    if (unlikely(!pPixelShader))
       return D3DERR_INVALIDCALL;
-    }
 
     StateChange();
     HRESULT res = GetD3D9()->SetPixelShader(pPixelShader);
@@ -2143,9 +2154,8 @@ namespace dxvk {
 
     d3d9::IDirect3DPixelShader9* pPixelShader = getPixelShaderPtr(this, Handle);
 
-    if (unlikely(!pPixelShader)) {
+    if (unlikely(!pPixelShader))
       return D3DERR_INVALIDCALL;
-    }
 
     m_pixelShaders[getShaderIndex(Handle)] = nullptr;
 

--- a/src/d3d8/d3d8_device.h
+++ b/src/d3d8/d3d8_device.h
@@ -432,19 +432,19 @@ namespace dxvk {
 
   private:
 
-    Com<IDxvkD3D8Bridge>  m_bridge;
-    const D3D8Options&    m_d3d8Options;
+    Com<IDxvkLegacyD3DDeviceBridge> m_bridge;
+    const D3D8Options&              m_d3d8Options;
 
-    Com<D3D8Interface>    m_parent;
+    Com<D3D8Interface>              m_parent;
 
-    D3DPRESENT_PARAMETERS m_presentParams;
-    
+    D3DPRESENT_PARAMETERS           m_presentParams;
+
     // Value of D3DRS_LINEPATTERN
-    D3DLINEPATTERN        m_linePattern = { };
+    D3DLINEPATTERN                  m_linePattern = { };
     // Value of D3DRS_ZVISIBLE (although the RS is not supported, its value is stored)
-    DWORD                 m_zVisible    = 0;
+    DWORD                           m_zVisible    = 0;
 
-    bool                  m_shadowPerspectiveDivide = false;
+    bool                            m_shadowPerspectiveDivide = false;
 
     D3D8StateBlock*                           m_recorder = nullptr;
     DWORD                                     m_recorderToken = 0;
@@ -453,8 +453,8 @@ namespace dxvk {
     D3D8Batcher*                              m_batcher  = nullptr;
 
     struct D3D8VBO {
-      Com<D3D8VertexBuffer, false>   buffer = nullptr;
-      UINT                           stride = 0;
+      Com<D3D8VertexBuffer, false>  buffer = nullptr;
+      UINT                          stride = 0;
     };
 
     std::array<Com<D3D8Texture2D, false>, d8caps::MAX_TEXTURE_STAGES> m_textures;

--- a/src/d3d8/d3d8_interface.cpp
+++ b/src/d3d8/d3d8_interface.cpp
@@ -10,11 +10,11 @@ namespace dxvk {
   D3D8Interface::D3D8Interface()
     : m_d3d9(d3d9::Direct3DCreate9(D3D_SDK_VERSION)) {
     // Get the bridge interface to D3D9.
-    if (unlikely(FAILED(m_d3d9->QueryInterface(__uuidof(IDxvkD3D8InterfaceBridge), reinterpret_cast<void**>(&m_bridge))))) {
+    if (unlikely(FAILED(m_d3d9->QueryInterface(__uuidof(IDxvkLegacyD3DInterfaceBridge), reinterpret_cast<void**>(&m_bridge))))) {
       throw DxvkError("D3D8Interface: ERROR! Failed to get D3D9 Bridge. d3d9.dll might not be DXVK!");
     }
 
-    m_bridge->EnableD3D8CompatibilityMode();
+    m_bridge->SetD3DCompatibility(D3DCompatibility::D3D8);
 
     m_d3d8Options = D3D8Options(*m_bridge->GetConfig());
 
@@ -51,9 +51,10 @@ namespace dxvk {
       *ppvObject = ref(this);
       return S_OK;
     }
-
+/*
     Logger::warn("D3D8Interface::QueryInterface: Unknown interface query");
     Logger::warn(str::format(riid));
+*/
     return E_NOINTERFACE;
   }
 

--- a/src/d3d8/d3d8_interface.h
+++ b/src/d3d8/d3d8_interface.h
@@ -183,7 +183,7 @@ namespace dxvk {
     std::vector<std::vector<d3d9::D3DDISPLAYMODE>>  m_adapterModes;
 
     Com<d3d9::IDirect3D9>                           m_d3d9;
-    Com<IDxvkD3D8InterfaceBridge>                   m_bridge;
+    Com<IDxvkLegacyD3DInterfaceBridge>              m_bridge;
     D3D8Options                                     m_d3d8Options;
   };
 

--- a/src/d3d8/d3d8_shader.cpp
+++ b/src/d3d8/d3d8_shader.cpp
@@ -136,8 +136,8 @@ namespace dxvk {
     uint32_t i = 0;
     DWORD token;
 
-    std::stringstream dbg;
-    dbg << "D3D8: Vertex Declaration Tokens:\n\t";
+    //std::stringstream dbg;
+    //dbg << "D3D8: Vertex Declaration Tokens:\n\t";
 
     WORD currentStream = 0;
     WORD currentOffset = 0;
@@ -165,74 +165,89 @@ namespace dxvk {
     if (options.forceVsDecl.size() == 0) do {
       token = pDeclaration[i++];
 
-      D3DVSD_TOKENTYPE tokenType = D3DVSD_TOKENTYPE(VSD_SHIFT_MASK(token, D3DVSD_TOKENTYPE));
+      const D3DVSD_TOKENTYPE tokenType = D3DVSD_TOKENTYPE(VSD_SHIFT_MASK(token, D3DVSD_TOKENTYPE));
 
       switch (tokenType) {
         case D3DVSD_TOKEN_NOP:
-          dbg << "NOP";
+          //dbg << "NOP";
           break;
         case D3DVSD_TOKEN_STREAM: {
-          dbg << "STREAM ";
+          //dbg << "STREAM ";
 
           // TODO: D3DVSD_STREAM_TESS
-          if (token & D3DVSD_STREAMTESSMASK) {
-            dbg << "TESS";
+          if (unlikely(token & D3DVSD_STREAMTESSMASK)) {
+            //dbg << "TESS";
+
+            static bool s_streamTessErrorShown;
+
+            if (!std::exchange(s_streamTessErrorShown, true))
+              Logger::warn("D3D8Device::CreateVertexShader: Unhandled D3DVSD_STREAMTESSMASK");
           }
 
-          DWORD streamNum = VSD_SHIFT_MASK(token, D3DVSD_STREAMNUMBER);
+          const DWORD streamNum = VSD_SHIFT_MASK(token, D3DVSD_STREAMNUMBER);
+          //dbg << ", num=" << streamNum;
 
           currentStream = WORD(streamNum);
           currentOffset = 0; // reset offset
 
-          dbg << ", num=" << streamNum;
           break;
         }
         case D3DVSD_TOKEN_STREAMDATA: {
-
-          dbg << "STREAMDATA ";
+          //dbg << "STREAMDATA ";
 
           // D3DVSD_SKIP
           if (token & VSD_SKIP_FLAG) {
-            auto skipCount = VSD_SHIFT_MASK(token, D3DVSD_SKIPCOUNT);
-            dbg << "SKIP " << " count=" << skipCount;
+            const DWORD skipCount = VSD_SHIFT_MASK(token, D3DVSD_SKIPCOUNT);
+            //dbg << "SKIP " << " count=" << skipCount;
             currentOffset += WORD(skipCount) * sizeof(DWORD);
             break;
           }
 
           // D3DVSD_REG
-          DWORD dataLoadType = VSD_SHIFT_MASK(token, D3DVSD_DATALOADTYPE);
+          const DWORD dataLoadType = VSD_SHIFT_MASK(token, D3DVSD_DATALOADTYPE);
 
-          if ( dataLoadType == 0 ) { // vertex
+          if (likely(dataLoadType == 0)) { // vertex
             D3DVSDT_TYPE     type = D3DVSDT_TYPE(VSD_SHIFT_MASK(token, D3DVSD_DATATYPE));
             D3DVSDE_REGISTER reg  = D3DVSDE_REGISTER(VSD_SHIFT_MASK(token, D3DVSD_VERTEXREG));
+            //dbg << "type=" << type << ", register=" << reg;
 
             // FVF normals are expected to only have 3 components
             if (unlikely(pFunction == nullptr && reg == D3DVSDE_NORMAL && type != D3DVSDT_FLOAT3)) {
-              Logger::err("D3D8Device::CreateVertexShader: Invalid FVF declaration: D3DVSDE_NORMAL must use D3DVSDT_FLOAT3");
+              Logger::warn("D3D8Device::CreateVertexShader: Invalid FVF declaration: D3DVSDE_NORMAL must use D3DVSDT_FLOAT3");
               return D3DERR_INVALIDCALL;
             }
 
             addVertexElement(reg, type);
-
-            dbg << "type=" << type << ", register=" << reg;
+          // TODO: When would this bit be 1?
           } else {
-            // TODO: When would this bit be 1?
-            dbg << "D3DVSD_DATALOADTYPE " << dataLoadType;
+            //dbg << "D3DVSD_DATALOADTYPE " << dataLoadType;
+
+            static bool s_dataLoadTypeErrorShown;
+
+            if (!std::exchange(s_dataLoadTypeErrorShown, true))
+              Logger::warn("D3D8Device::CreateVertexShader: Unhandled non-zero D3DVSD_DATALOADTYPE");
           }
           break;
         }
-        case D3DVSD_TOKEN_TESSELLATOR:
-          dbg << "TESSELLATOR " << std::hex << token;
-          // TODO: D3DVSD_TOKEN_TESSELLATOR
-          break;
-        case D3DVSD_TOKEN_CONSTMEM: {
-          dbg << "CONSTMEM ";
-          DWORD count     = VSD_SHIFT_MASK(token, D3DVSD_CONSTCOUNT);
-          DWORD regCount  = count * 4;
-          DWORD addr      = VSD_SHIFT_MASK(token, D3DVSD_CONSTADDRESS);
-          DWORD rs        = VSD_SHIFT_MASK(token, D3DVSD_CONSTRS);
+        // TODO: D3DVSD_TOKEN_TESSELLATOR
+        case D3DVSD_TOKEN_TESSELLATOR: {
+          //dbg << "TESSELLATOR " << std::hex << token;
 
-          dbg << "count=" << count << ", addr=" << addr << ", rs=" << rs;
+          static bool s_tesselatorErrorShown;
+
+          if (!std::exchange(s_tesselatorErrorShown, true))
+            Logger::warn("D3D8Device::CreateVertexShader: Unhandled D3DVSD_TOKEN_TESSELLATOR");
+
+          break;
+        }
+        case D3DVSD_TOKEN_CONSTMEM: {
+          //dbg << "CONSTMEM ";
+
+          const DWORD count    = VSD_SHIFT_MASK(token, D3DVSD_CONSTCOUNT);
+          const DWORD regCount = count * 4;
+          //const DWORD rs       = VSD_SHIFT_MASK(token, D3DVSD_CONSTRS);
+          DWORD addr           = VSD_SHIFT_MASK(token, D3DVSD_CONSTADDRESS);
+          //dbg << "count=" << count << ", rs=" << rs << ", addr=" << addr;
 
           // Add a DEF instruction for each constant
           for (uint32_t j = 0; j < regCount; j += 4) {
@@ -248,26 +263,31 @@ namespace dxvk {
           break;
         }
         case D3DVSD_TOKEN_EXT: {
-          dbg << "EXT " << std::hex << token << " ";
-          DWORD extInfo = VSD_SHIFT_MASK(token, D3DVSD_EXTINFO);
-          DWORD extCount = VSD_SHIFT_MASK(token, D3DVSD_EXTCOUNT);
-          dbg << "info=" << extInfo << ", count=" << extCount;
+          //dbg << "EXT " << std::hex << token << " ";
+
+          /*const DWORD extInfo = VSD_SHIFT_MASK(token, D3DVSD_EXTINFO);
+          const DWORD extCount = VSD_SHIFT_MASK(token, D3DVSD_EXTCOUNT);
+          dbg << "info=" << extInfo << ", count=" << extCount;*/
+
           break;
         }
         case D3DVSD_TOKEN_END: {
+          //dbg << "END";
           vertexElements[elementIdx++] = D3DDECL_END();
-          dbg << "END";
           break;
         }
         default:
-          dbg << "UNKNOWN TYPE";
+          //dbg << "UNKNOWN TYPE " << std::hex << token << " ";
+/*
+          Logger::warn(str::format("D3D8Device::CreateVertexShader: Unhandled token type ", std::hex, token));
+*/
           break;
       }
-      dbg << "\n\t";
-      //dbg << std::hex << token << " ";
+
+      //dbg << "\n\t";
     } while (token != D3DVSD_END());
 
-    Logger::debug(dbg.str());
+    //Logger::debug(dbg.str());
 
     // If forceVsDecl is set, use that decl instead.
     if (options.forceVsDecl.size() > 0) {
@@ -283,20 +303,18 @@ namespace dxvk {
       // Copy first token (version)
       tokens.push_back(pFunction[0]);
 
-      DWORD vsMajor = D3DSHADER_VERSION_MAJOR(pFunction[0]);
-      DWORD vsMinor = D3DSHADER_VERSION_MINOR(pFunction[0]);
-      Logger::debug(str::format("VS version: ", vsMajor, ".", vsMinor));
+      /*const DWORD vsMajor = D3DSHADER_VERSION_MAJOR(pFunction[0]);
+      const DWORD vsMinor = D3DSHADER_VERSION_MINOR(pFunction[0]);
+      Logger::debug(str::format("VS version: ", vsMajor, ".", vsMinor));*/
 
       // Insert dcl instructions
       for (UINT vn = 0; vn < D3D8_NUM_VERTEX_INPUT_REGISTERS; vn++) {
-
         // If bit N is set then we need to dcl register vN
         if ((shaderInputRegisters & (1 << vn)) != 0) {
+          //Logger::debug(str::format("\tShader Input Regsiter: v", vn));
 
-          Logger::debug(str::format("\tShader Input Regsiter: v", vn));
-
-          DWORD usage = D3D8_VERTEX_INPUT_REGISTERS[vn][0];
-          DWORD index = D3D8_VERTEX_INPUT_REGISTERS[vn][1];
+          const DWORD usage = D3D8_VERTEX_INPUT_REGISTERS[vn][0];
+          const DWORD index = D3D8_VERTEX_INPUT_REGISTERS[vn][1];
 
           tokens.push_back(encodeInstruction(d3d9::D3DSIO_DCL));                  // dcl opcode
           tokens.push_back(encodeDeclaration(d3d9::D3DDECLUSAGE(usage), index));  // usage token
@@ -315,18 +333,17 @@ namespace dxvk {
       do {
         token = pFunction[i++];
 
-        DWORD opcode = token & D3DSI_OPCODE_MASK;
+        const DWORD opcode = token & D3DSI_OPCODE_MASK;
 
         // Instructions
         if ((token & VS_BIT_PARAM) == 0) {
-
           // Swizzle fixup for opcodes that require explicit use of a replicate swizzle.
           if (opcode == D3DSIO_RSQ  || opcode == D3DSIO_RCP
            || opcode == D3DSIO_EXP  || opcode == D3DSIO_LOG
            || opcode == D3DSIO_EXPP || opcode == D3DSIO_LOGP) {
-            tokens.push_back(token);                            // instr
-            tokens.push_back(token = pFunction[i++]);           // dest
-            token = pFunction[i++];                             // src0
+            tokens.push_back(token);                   // instr
+            tokens.push_back(token = pFunction[i++]);  // dest
+            token = pFunction[i++];                    // src0
 
             // If no swizzling is done, then use the w-component.
             // See d8vk#43 for more information as this may need to change in some cases.

--- a/src/d3d9/d3d9_adapter.cpp
+++ b/src/d3d9/d3d9_adapter.cpp
@@ -79,12 +79,14 @@ namespace dxvk {
     copyToStringArray(pIdentifier->DeviceName,  displayName.c_str());    // The GDI device name. Not the actual device name.
     copyToStringArray(pIdentifier->Driver,      m_deviceDriver.c_str()); // This is the driver's dll.
 
+    const bool isExtended = m_parent->IsD3DCompatibile(D3DCompatibility::D3D9Ex);
+
     pIdentifier->DeviceIdentifier       = m_deviceGuid;
     pIdentifier->DeviceId               = m_deviceId;
     pIdentifier->VendorId               = m_vendorId;
     pIdentifier->Revision               = 0;
     pIdentifier->SubSysId               = 0;
-    pIdentifier->WHQLLevel              = m_parent->IsExtended() ? 1 : 0; // This doesn't check with the driver on Direct3D9Ex and is always 1.
+    pIdentifier->WHQLLevel              = isExtended ? 1 : 0; // This doesn't check with the driver on Direct3D9Ex and is always 1.
     pIdentifier->DriverVersion.QuadPart = INT64_MAX;
 
     return D3D_OK;
@@ -121,7 +123,7 @@ namespace dxvk {
     if (!IsSupportedAdapterFormat(AdapterFormat))
       return D3DERR_NOTAVAILABLE;
 
-    const bool isD3D8Compatible = m_parent->IsD3D8Compatible();
+    const bool isD3D8Compatible = m_parent->IsD3DCompatibile(D3DCompatibility::D3D8);
     const bool isNvidia         = m_vendorId == uint32_t(DxvkGpuVendor::Nvidia);
     const bool isAmd            = m_vendorId == uint32_t(DxvkGpuVendor::Amd);
 
@@ -353,7 +355,7 @@ namespace dxvk {
       return D3DERR_INVALIDCALL;
 
     if (unlikely(DeviceType == D3DDEVTYPE_SW)) {
-      if (m_parent->IsD3D8Compatible())
+      if (m_parent->IsD3DCompatibile(D3DCompatibility::D3D8))
         return D3DERR_INVALIDCALL;
       else
         return D3DERR_NOTAVAILABLE;
@@ -361,7 +363,8 @@ namespace dxvk {
 
     auto& options = m_parent->GetOptions();
 
-    const uint32_t maxShaderModel = m_parent->IsD3D8Compatible() ? std::min(1u, options.shaderModel) : options.shaderModel;
+    const uint32_t maxShaderModel = m_parent->IsD3DCompatibile(D3DCompatibility::D3D8) ? std::min(1u, options.shaderModel)
+                                                                                       : options.shaderModel;
     const VkPhysicalDeviceLimits& limits = m_adapter->deviceProperties().limits;
 
     // TODO: Actually care about what the adapter supports here.
@@ -480,7 +483,7 @@ namespace dxvk {
                                     | D3DPBLENDCAPS_BLENDFACTOR;
 
     // Only 9Ex devices advertise D3DPBLENDCAPS_SRCCOLOR2 and D3DPBLENDCAPS_INVSRCCOLOR2
-    if (m_parent->IsExtended())
+    if (m_parent->IsD3DCompatibile(D3DCompatibility::D3D9Ex))
       pCaps->SrcBlendCaps          |= D3DPBLENDCAPS_SRCCOLOR2
                                     | D3DPBLENDCAPS_INVSRCCOLOR2;
 
@@ -830,13 +833,13 @@ namespace dxvk {
   }
 
 
-  bool D3D9Adapter::IsExtended() const {
-    return m_parent->IsExtended();
+  void D3D9Adapter::RefreshFormatsTable() const {
+    m_d3d9Formats->RefreshFormatSupport(this);
   }
 
 
-  bool D3D9Adapter::IsD3D8Compatible() const {
-    return m_parent->IsD3D8Compatible();
+  bool D3D9Adapter::IsD3DCompatibile(D3DCompatibility d3dCompatibility) const {
+    return m_parent->IsD3DCompatibile(d3dCompatibility);
   }
 
 

--- a/src/d3d9/d3d9_adapter.h
+++ b/src/d3d9/d3d9_adapter.h
@@ -4,6 +4,7 @@
 
 #include "d3d9_options.h"
 #include "d3d9_format.h"
+#include "d3d9_bridge.h"
 
 #include "../dxvk/dxvk_adapter.h"
 
@@ -98,9 +99,9 @@ namespace dxvk {
       return m_9On12Args;
     }
 
-    bool IsExtended() const;
+    void RefreshFormatsTable() const;
 
-    bool IsD3D8Compatible() const;
+    bool IsD3DCompatibile(D3DCompatibility d3dCompatibility) const;
 
   private:
 
@@ -153,7 +154,7 @@ namespace dxvk {
     std::vector<D3DDISPLAYMODEEX>            m_modes;
     D3D9Format                               m_modeCacheFormat;
 
-    std::unique_ptr<const D3D9VkFormatTable> m_d3d9Formats;
+    std::unique_ptr<D3D9VkFormatTable>       m_d3d9Formats;
 
   };
 

--- a/src/d3d9/d3d9_bridge.cpp
+++ b/src/d3d9/d3d9_bridge.cpp
@@ -8,28 +8,28 @@
 
 namespace dxvk {
 
-  DxvkD3D8Bridge::DxvkD3D8Bridge(D3D9DeviceEx* pDevice)
+  DxvkLegacyD3DDeviceBridge::DxvkLegacyD3DDeviceBridge(D3D9DeviceEx* pDevice)
     : m_device(pDevice) {
   }
 
-  DxvkD3D8Bridge::~DxvkD3D8Bridge() {
+  DxvkLegacyD3DDeviceBridge::~DxvkLegacyD3DDeviceBridge() {
   }
 
-  ULONG STDMETHODCALLTYPE DxvkD3D8Bridge::AddRef() {
+  ULONG STDMETHODCALLTYPE DxvkLegacyD3DDeviceBridge::AddRef() {
     return m_device->AddRef();
   }
 
-  ULONG STDMETHODCALLTYPE DxvkD3D8Bridge::Release() {
+  ULONG STDMETHODCALLTYPE DxvkLegacyD3DDeviceBridge::Release() {
     return m_device->Release();
   }
 
-  HRESULT STDMETHODCALLTYPE DxvkD3D8Bridge::QueryInterface(
+  HRESULT STDMETHODCALLTYPE DxvkLegacyD3DDeviceBridge::QueryInterface(
           REFIID  riid,
           void** ppvObject) {
     return m_device->QueryInterface(riid, ppvObject);
   }
 
-  HRESULT DxvkD3D8Bridge::UpdateTextureFromBuffer(
+  HRESULT DxvkLegacyD3DDeviceBridge::UpdateTextureFromBuffer(
         IDirect3DSurface9*  pDestSurface,
         IDirect3DSurface9*  pSrcSurface,
         const RECT*         pSrcRect,
@@ -89,37 +89,42 @@ namespace dxvk {
     return D3D_OK;
   }
 
-  bool DxvkD3D8Bridge::IsSupportedSurfaceFormat(D3DFORMAT Format) {
+  bool DxvkLegacyD3DDeviceBridge::IsSupportedSurfaceFormat(D3DFORMAT Format) {
     auto mapping = m_device->LookupFormat(EnumerateFormat(Format));
     return mapping.IsValid();
   }
 
-  DxvkD3D8InterfaceBridge::DxvkD3D8InterfaceBridge(D3D9InterfaceEx* pObject)
+  DxvkLegacyD3DInterfaceBridge::DxvkLegacyD3DInterfaceBridge(D3D9InterfaceEx* pObject)
     : m_interface(pObject) {
   }
 
-  DxvkD3D8InterfaceBridge::~DxvkD3D8InterfaceBridge() {
+  DxvkLegacyD3DInterfaceBridge::~DxvkLegacyD3DInterfaceBridge() {
   }
 
-  ULONG STDMETHODCALLTYPE DxvkD3D8InterfaceBridge::AddRef() {
+  ULONG STDMETHODCALLTYPE DxvkLegacyD3DInterfaceBridge::AddRef() {
     return m_interface->AddRef();
   }
 
-  ULONG STDMETHODCALLTYPE DxvkD3D8InterfaceBridge::Release() {
+  ULONG STDMETHODCALLTYPE DxvkLegacyD3DInterfaceBridge::Release() {
     return m_interface->Release();
   }
 
-  HRESULT STDMETHODCALLTYPE DxvkD3D8InterfaceBridge::QueryInterface(
+  HRESULT STDMETHODCALLTYPE DxvkLegacyD3DInterfaceBridge::QueryInterface(
           REFIID  riid,
           void** ppvObject) {
     return m_interface->QueryInterface(riid, ppvObject);
   }
 
-  void DxvkD3D8InterfaceBridge::EnableD3D8CompatibilityMode() {
-    m_interface->EnableD3D8CompatibilityMode();
+  void DxvkLegacyD3DInterfaceBridge::SetD3DCompatibility(D3DCompatibility d3dCompatibility) const {
+    // The D3D9Ex compatibility flag is internal only, and can't be set by the bridge
+    if (likely(d3dCompatibility != D3DCompatibility::D3D9Ex)) {
+      m_interface->SetD3DCompatibility(d3dCompatibility);
+    } /* else {
+      Logger::err("DxvkLegacyD3DInterfaceBridge::SetD3DCompatibility: Invalid compatibility level: D3D9Ex");
+    } */
   }
 
-  const Config* DxvkD3D8InterfaceBridge::GetConfig() const {
+  const Config* DxvkLegacyD3DInterfaceBridge::GetConfig() const {
     return &m_interface->GetInstance()->config();
   }
 

--- a/src/d3d9/d3d9_bridge.h
+++ b/src/d3d9/d3d9_bridge.h
@@ -2,6 +2,12 @@
 
 #include <windows.h>
 #include "../util/config/config.h"
+#include "../util/util_flags.h"
+
+enum class DxvkD3DCompatibility : uint8_t {
+  D3D9Ex,
+  D3D8
+};
 
 /**
  * The D3D9 bridge allows D3D8 to access DXVK internals.
@@ -13,8 +19,8 @@
 /**
  * \brief D3D9 device interface for D3D8 interop
  */
-MIDL_INTERFACE("D3D9D3D8-42A9-4C1E-AA97-BEEFCAFE2000")
-IDxvkD3D8Bridge : public IUnknown {
+MIDL_INTERFACE("D3D0D3D9-42A9-4C1E-AA97-BEEFCAFE2000")
+IDxvkLegacyD3DDeviceBridge : public IUnknown {
 
   // D3D8 keeps D3D9 objects contained in a namespace.
   #ifdef DXVK_D3D9_NAMESPACE
@@ -47,12 +53,14 @@ IDxvkD3D8Bridge : public IUnknown {
 /**
  * \brief D3D9 instance interface for D3D8 interop
  */
-MIDL_INTERFACE("D3D9D3D8-A407-773E-18E9-CAFEBEEF3000")
-IDxvkD3D8InterfaceBridge : public IUnknown {
+MIDL_INTERFACE("D3D0D3D9-A407-773E-18E9-CAFEBEEF3000")
+IDxvkLegacyD3DInterfaceBridge : public IUnknown {
   /**
-   * \brief Enforces D3D8-specific features and validations
+   * \brief Enforces legacy D3D features and validations
+   *
+   * \param [in] d3dCompatibility D3D compatibility level to be set
    */
-  virtual void EnableD3D8CompatibilityMode() = 0;
+  virtual void SetD3DCompatibility(DxvkD3DCompatibility d3dCompatibility) const = 0;
 
   /**
    * \brief Retrieves the DXVK configuration
@@ -63,22 +71,25 @@ IDxvkD3D8InterfaceBridge : public IUnknown {
 };
 
 #ifndef _MSC_VER
-__CRT_UUID_DECL(IDxvkD3D8Bridge, 0xD3D9D3D8, 0x42A9, 0x4C1E, 0xAA, 0x97, 0xBE, 0xEF, 0xCA, 0xFE, 0x20, 0x00);
-__CRT_UUID_DECL(IDxvkD3D8InterfaceBridge, 0xD3D9D3D8, 0xA407, 0x773E, 0x18, 0xE9, 0xCA, 0xFE, 0xBE, 0xEF, 0x30, 0x00);
+__CRT_UUID_DECL(IDxvkLegacyD3DDeviceBridge,    0xD3D0D3D9, 0x42A9, 0x4C1E, 0xAA, 0x97, 0xBE, 0xEF, 0xCA, 0xFE, 0x20, 0x00);
+__CRT_UUID_DECL(IDxvkLegacyD3DInterfaceBridge, 0xD3D0D3D9, 0xA407, 0x773E, 0x18, 0xE9, 0xCA, 0xFE, 0xBE, 0xEF, 0x30, 0x00);
 #endif
 
 namespace dxvk {
 
+  using D3DCompatibility = DxvkD3DCompatibility;
+  using D3DCompatibilityFlags = Flags<D3DCompatibility>;
+
   class D3D9DeviceEx;
   class D3D9InterfaceEx;
 
-  class DxvkD3D8Bridge : public IDxvkD3D8Bridge {
+  class DxvkLegacyD3DDeviceBridge : public IDxvkLegacyD3DDeviceBridge {
 
   public:
 
-    DxvkD3D8Bridge(D3D9DeviceEx* pDevice);
+    DxvkLegacyD3DDeviceBridge(D3D9DeviceEx* pDevice);
 
-    ~DxvkD3D8Bridge();
+    ~DxvkLegacyD3DDeviceBridge();
 
     ULONG STDMETHODCALLTYPE AddRef();
     ULONG STDMETHODCALLTYPE Release();
@@ -100,13 +111,13 @@ namespace dxvk {
 
   };
 
-  class DxvkD3D8InterfaceBridge : public IDxvkD3D8InterfaceBridge {
+  class DxvkLegacyD3DInterfaceBridge : public IDxvkLegacyD3DInterfaceBridge {
 
   public:
 
-    DxvkD3D8InterfaceBridge(D3D9InterfaceEx* pObject);
+    DxvkLegacyD3DInterfaceBridge(D3D9InterfaceEx* pObject);
 
-    ~DxvkD3D8InterfaceBridge();
+    ~DxvkLegacyD3DInterfaceBridge();
 
     ULONG STDMETHODCALLTYPE AddRef();
     ULONG STDMETHODCALLTYPE Release();
@@ -114,7 +125,7 @@ namespace dxvk {
             REFIID  riid,
             void** ppvObject);
 
-    void EnableD3D8CompatibilityMode();
+    void SetD3DCompatibility(D3DCompatibility d3dCompatibility) const;
 
     const Config* GetConfig() const;
 

--- a/src/d3d9/d3d9_buffer.cpp
+++ b/src/d3d9/d3d9_buffer.cpp
@@ -30,10 +30,12 @@ namespace dxvk {
       return S_OK;
     }
 
+/*
     if (logQueryInterfaceError(__uuidof(IDirect3DVertexBuffer9), riid)) {
       Logger::warn("D3D9VertexBuffer::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));
     }
+*/
 
     return E_NOINTERFACE;
   }
@@ -91,10 +93,12 @@ namespace dxvk {
       return S_OK;
     }
 
+/*
     if (logQueryInterfaceError(__uuidof(IDirect3DIndexBuffer9), riid)) {
       Logger::warn("D3D9IndexBuffer::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));
     }
+*/
 
     return E_NOINTERFACE;
   }

--- a/src/d3d9/d3d9_common_texture.cpp
+++ b/src/d3d9/d3d9_common_texture.cpp
@@ -164,10 +164,12 @@ namespace dxvk {
     ///////////////////
     // Desc Validation
 
+    const bool isExtended = pDevice->IsD3DCompatibile(D3DCompatibility::D3D9Ex);
+
     // Resources can't be created in D3DPOOL_MANAGED
     // when using extended devices. Note that the D3DPOOL
     // value of 6 (D3DPOOL_MANAGED_EX) can be used.
-    if (pDevice->IsExtended() && pDesc->Pool == D3DPOOL_MANAGED)
+    if (isExtended && pDesc->Pool == D3DPOOL_MANAGED)
       return D3DERR_INVALIDCALL;
 
     if (pDesc->Width == 0 || pDesc->Height == 0 || pDesc->Depth == 0)
@@ -240,7 +242,7 @@ namespace dxvk {
     // plain surfaces outside of D3DPOOL_SCRATCH in D3D9Ex
     if (pDesc->Format == D3D9Format::ATI2
      && (pDesc->Usage & D3DUSAGE_RENDERTARGET ||
-        (pDevice->IsExtended() && isPlainSurface && pDesc->Pool != D3DPOOL_SCRATCH)))
+        (isExtended && isPlainSurface && pDesc->Pool != D3DPOOL_SCRATCH)))
       return D3DERR_INVALIDCALL;
 
     // Auto-Mipgen is only valid on textures (for obvious reasons)
@@ -624,7 +626,9 @@ namespace dxvk {
       case D3D9Format::A8R8G8B8: dxgiFormat = DXGI_FORMAT_B8G8R8A8_UNORM; break;
       case D3D9Format::X8R8G8B8: dxgiFormat = DXGI_FORMAT_B8G8R8X8_UNORM; break;
       default:
+/*
         Logger::warn(str::format("D3D9: Unsupported format for shared textures: ", m_desc.Format));
+*/
         return;
     }
 
@@ -647,8 +651,10 @@ namespace dxvk {
       metadata.MiscFlags          = D3D11_RESOURCE_MISC_SHARED;
       metadata.TextureLayout      = D3D11_TEXTURE_LAYOUT_UNDEFINED;
 
+/*
       if (ntHandle == INVALID_HANDLE_VALUE || !setSharedMetadata(ntHandle, &metadata, sizeof(metadata)))
         Logger::warn("D3D9: Failed to write shared resource info for a texture");
+*/
 
       if (ntHandle != INVALID_HANDLE_VALUE)
         ::CloseHandle(ntHandle);

--- a/src/d3d9/d3d9_common_texture.cpp
+++ b/src/d3d9/d3d9_common_texture.cpp
@@ -651,10 +651,8 @@ namespace dxvk {
       metadata.MiscFlags          = D3D11_RESOURCE_MISC_SHARED;
       metadata.TextureLayout      = D3D11_TEXTURE_LAYOUT_UNDEFINED;
 
-/*
       if (ntHandle == INVALID_HANDLE_VALUE || !setSharedMetadata(ntHandle, &metadata, sizeof(metadata)))
         Logger::warn("D3D9: Failed to write shared resource info for a texture");
-*/
 
       if (ntHandle != INVALID_HANDLE_VALUE)
         ::CloseHandle(ntHandle);

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -54,7 +54,6 @@ namespace dxvk {
     , m_d3d9Options        ( dxvkDevice, pParent->GetInstance()->config() )
     , m_multithread        ( BehaviorFlags & D3DCREATE_MULTITHREADED )
     , m_isSWVP             ( (BehaviorFlags & D3DCREATE_SOFTWARE_VERTEXPROCESSING) != 0 )
-    , m_isD3D8Compatible   ( pParent->IsD3D8Compatible() )
     , m_csThread           ( dxvkDevice, dxvkDevice->createContext() )
     , m_csChunk            ( AllocCsChunk() )
     , m_submissionFence    ( new sync::Fence() )
@@ -62,15 +61,18 @@ namespace dxvk {
     , m_d3d9Interop        ( this )
     , m_d3d9On12Args       ( pAdapter->Get9On12Args() )
     , m_d3d9On12           ( this )
-    , m_d3d8Bridge         ( this ) {
+    , m_legacyD3DBridge    ( this )
+    , m_d3dCompatibility   ( pParent->GetD3DCompatibilityFlags() ) {
 
     // If we can SWVP, then we use an extended constant set
     // as SWVP has many more slots available than HWVP.
     bool canSWVP = CanSWVP();
     DetermineConstantLayouts(canSWVP);
 
+/*
     if (canSWVP)
       Logger::info("D3D9DeviceEx: Using extended constant set for software vertex processing.");
+*/
 
     if (m_dxvkDevice->debugFlags().test(DxvkDebugFlag::Markers))
       m_annotation = new D3D9UserDefinedAnnotation(this);
@@ -123,9 +125,12 @@ namespace dxvk {
       vsConstSet.maxChangedConstB = vsConstSet.layout.boolCount;
       psConstSet.maxChangedConstF = psConstSet.layout.floatCount;
 
+/*
       if (supportsRobustness2) {
         Logger::warn("Disabling robust constant buffer access because of alignment.");
       }
+*/
+
     }
 
     // Check for VK_EXT_graphics_pipeline_libraries
@@ -222,18 +227,16 @@ namespace dxvk {
 
     *ppvObject = nullptr;
 
-    bool extended = m_parent->IsExtended()
-                 && riid == __uuidof(IDirect3DDevice9Ex);
-
     if (riid == __uuidof(IUnknown)
      || riid == __uuidof(IDirect3DDevice9)
-     || extended) {
+     || (m_d3dCompatibility.test(D3DCompatibility::D3D9Ex) &&
+         riid == __uuidof(IDirect3DDevice9Ex))) {
       *ppvObject = ref(this);
       return S_OK;
     }
 
-    if (riid == __uuidof(IDxvkD3D8Bridge)) {
-      *ppvObject = ref(&m_d3d8Bridge);
+    if (riid == __uuidof(IDxvkLegacyD3DDeviceBridge)) {
+      *ppvObject = ref(&m_legacyD3DBridge);
       return S_OK;
     }
 
@@ -256,10 +259,12 @@ namespace dxvk {
     if (riid == __uuidof(IDirect3DDevice9Ex))
       return E_NOINTERFACE;
 
+/*
     if (logQueryInterfaceError(__uuidof(IDirect3DDevice9), riid)) {
       Logger::warn("D3D9DeviceEx::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));
     }
+*/
 
     return E_NOINTERFACE;
   }
@@ -506,7 +511,7 @@ namespace dxvk {
         return hr;
     }
 
-    if (!IsExtended()) {
+    if (!m_d3dCompatibility.test(D3DCompatibility::D3D9Ex)) {
       // The internal references are always cleared, regardless of whether the Reset call succeeds.
       ResetState(pPresentationParameters);
       m_implicitSwapchain->DestroyBackBuffers();
@@ -545,6 +550,8 @@ namespace dxvk {
 
     m_cursor.ResetCursor();
 
+    const bool isExtended = m_d3dCompatibility.test(D3DCompatibility::D3D9Ex);
+
     /*
       * Before calling the IDirect3DDevice9::Reset method for a device,
       * an application should release any explicit render targets,
@@ -554,16 +561,16 @@ namespace dxvk {
       * We have to check after ResetState clears the references held by SetTexture, etc.
       * This matches what Windows D3D9 does.
     */
-    if (unlikely(m_losableResourceCounter.load() != 0 && !IsExtended() && m_d3d9Options.countLosableResources)) {
+    if (unlikely(m_losableResourceCounter.load() != 0 && !isExtended && m_d3d9Options.countLosableResources)) {
       Logger::warn(str::format("Device reset failed because device still has alive losable resources: Device not reset. Remaining resources: ", m_losableResourceCounter.load()));
       m_deviceLostState = D3D9DeviceLostState::NotReset;
       // D3D8 returns D3DERR_DEVICELOST here, whereas D3D9 returns D3DERR_INVALIDCALL.
-      return m_isD3D8Compatible ? D3DERR_DEVICELOST : D3DERR_INVALIDCALL;
+      return m_d3dCompatibility.test(D3DCompatibility::D3D8) ? D3DERR_DEVICELOST : D3DERR_INVALIDCALL;
     }
 
     hr = ResetSwapChain(pPresentationParameters, nullptr);
     if (unlikely(FAILED(hr))) {
-      if (!IsExtended()) {
+      if (!isExtended) {
         Logger::warn("Device reset failed: Device not reset");
         m_deviceLostState = D3D9DeviceLostState::NotReset;
       }
@@ -692,7 +699,8 @@ namespace dxvk {
       if (unlikely(pSharedHandle != nullptr && Pool != D3DPOOL_DEFAULT))
         return D3DERR_INVALIDCALL;
 
-      const Com<D3D9Texture2D> texture = new D3D9Texture2D(this, &desc, IsExtended(), pSharedHandle);
+      const bool isExtended = m_d3dCompatibility.test(D3DCompatibility::D3D9Ex);
+      const Com<D3D9Texture2D> texture = new D3D9Texture2D(this, &desc, isExtended, pSharedHandle);
 
       m_initializer->InitTexture(texture->GetCommonTexture(), initialData);
       *ppTexture = texture.ref();
@@ -727,8 +735,10 @@ namespace dxvk {
     if (unlikely(pSharedHandle != nullptr && Pool != D3DPOOL_DEFAULT))
       return D3DERR_INVALIDCALL;
 
+/*
     if (unlikely(pSharedHandle))
         Logger::err("CreateVolumeTexture: Shared volume textures not supported");
+*/
 
     D3D9_COMMON_TEXTURE_DESC desc;
     desc.Width              = Width;
@@ -755,7 +765,8 @@ namespace dxvk {
       return D3DERR_INVALIDCALL;
 
     try {
-      const Com<D3D9Texture3D> texture = new D3D9Texture3D(this, &desc, IsExtended());
+      const bool isExtended = m_d3dCompatibility.test(D3DCompatibility::D3D9Ex);
+      const Com<D3D9Texture3D> texture = new D3D9Texture3D(this, &desc, isExtended);
       m_initializer->InitTexture(texture->GetCommonTexture());
       *ppVolumeTexture = texture.ref();
 
@@ -788,8 +799,10 @@ namespace dxvk {
     if (unlikely(pSharedHandle != nullptr && Pool != D3DPOOL_DEFAULT))
       return D3DERR_INVALIDCALL;
 
+/*
     if (unlikely(pSharedHandle))
         Logger::err("CreateCubeTexture: Shared cube textures not supported");
+*/
 
     D3D9_COMMON_TEXTURE_DESC desc;
     desc.Width              = EdgeLength;
@@ -816,7 +829,8 @@ namespace dxvk {
       return D3DERR_INVALIDCALL;
 
     try {
-      const Com<D3D9TextureCube> texture = new D3D9TextureCube(this, &desc, IsExtended());
+      const bool isExtended = m_d3dCompatibility.test(D3DCompatibility::D3D9Ex);
+      const Com<D3D9TextureCube> texture = new D3D9TextureCube(this, &desc, isExtended);
       m_initializer->InitTexture(texture->GetCommonTexture());
       *ppCubeTexture = texture.ref();
 
@@ -848,8 +862,10 @@ namespace dxvk {
     if (unlikely(pSharedHandle != nullptr && Pool != D3DPOOL_DEFAULT))
       return D3DERR_NOTAVAILABLE;
 
+/*
     if (unlikely(pSharedHandle))
         Logger::err("CreateVertexBuffer: Shared vertex buffers not supported");
+*/
 
     D3D9_BUFFER_DESC desc;
     desc.Format = D3D9Format::VERTEXDATA;
@@ -859,11 +875,13 @@ namespace dxvk {
     desc.Type   = D3DRTYPE_VERTEXBUFFER;
     desc.Usage  = Usage;
 
-    if (FAILED(D3D9CommonBuffer::ValidateBufferProperties(&desc, IsExtended())))
+    const bool isExtended = m_d3dCompatibility.test(D3DCompatibility::D3D9Ex);
+
+    if (FAILED(D3D9CommonBuffer::ValidateBufferProperties(&desc, isExtended)))
       return D3DERR_INVALIDCALL;
 
     try {
-      const Com<D3D9VertexBuffer> buffer = new D3D9VertexBuffer(this, &desc, IsExtended());
+      const Com<D3D9VertexBuffer> buffer = new D3D9VertexBuffer(this, &desc, isExtended);
       m_initializer->InitBuffer(buffer->GetCommonBuffer());
       *ppVertexBuffer = buffer.ref();
 
@@ -895,8 +913,10 @@ namespace dxvk {
     if (unlikely(pSharedHandle != nullptr && Pool != D3DPOOL_DEFAULT))
       return D3DERR_NOTAVAILABLE;
 
+/*
     if (unlikely(pSharedHandle))
         Logger::err("CreateIndexBuffer: Shared index buffers not supported");
+*/
 
     D3D9_BUFFER_DESC desc;
     desc.Format = EnumerateFormat(Format);
@@ -905,11 +925,13 @@ namespace dxvk {
     desc.Type   = D3DRTYPE_INDEXBUFFER;
     desc.Usage  = Usage;
 
-    if (FAILED(D3D9CommonBuffer::ValidateBufferProperties(&desc, IsExtended())))
+    const bool isExtended = m_d3dCompatibility.test(D3DCompatibility::D3D9Ex);
+
+    if (FAILED(D3D9CommonBuffer::ValidateBufferProperties(&desc, isExtended)))
       return D3DERR_INVALIDCALL;
 
     try {
-      const Com<D3D9IndexBuffer> buffer = new D3D9IndexBuffer(this, &desc, IsExtended());
+      const Com<D3D9IndexBuffer> buffer = new D3D9IndexBuffer(this, &desc, isExtended);
       m_initializer->InitBuffer(buffer->GetCommonBuffer());
       *ppIndexBuffer = buffer.ref();
 
@@ -1097,12 +1119,13 @@ namespace dxvk {
 
       if (srcFirstMipExtent != dstFirstMipExtent)
         return D3DERR_INVALIDCALL;
-    } else {
+    } /* else {
       if (unlikely(srcFirstMipExtent.width  > dstFirstMipExtent.width
                 || srcFirstMipExtent.height > dstFirstMipExtent.height
                 || srcFirstMipExtent.depth  > dstFirstMipExtent.depth))
         Logger::warn("D3D9DeviceEx::UpdateTexture: Source dimensions exceed the destination");
     }
+*/
 
     for (uint32_t a = 0; a < arraySlices; a++) {
       // The docs claim that the dirty box is just a performance optimization, however in practice games rely on it.
@@ -1383,7 +1406,7 @@ namespace dxvk {
       bool srcHasAttachmentUsage = (srcTextureInfo->Desc()->Usage & (D3DUSAGE_RENDERTARGET | D3DUSAGE_DEPTHSTENCIL)) != 0;
 
       // D3D9Ex allows StretchRect to regular (non-RT) textures if it is a simple copy.
-      bool isCopy = IsExtended()
+      bool isCopy = m_d3dCompatibility.test(D3DCompatibility::D3D9Ex)
         && pSourceRect == nullptr && pDestRect == nullptr // Yes, the rects have to be null. Even passing a rect that is the same size as the texture is invalid.
         && srcTextureInfo->Desc()->Pool == D3DPOOL_DEFAULT
         && dstTextureInfo->Desc()->Pool == D3DPOOL_DEFAULT
@@ -1394,7 +1417,8 @@ namespace dxvk {
       // - both destination and source are depth stencil surfaces
       // - both destination and source are offscreen plain surfaces.
       // The only way to get a surface with resource type D3DRTYPE_SURFACE without USAGE_RT or USAGE_DS is CreateOffscreenPlainSurface.
-      if (unlikely((!dstHasAttachmentUsage && (!dstIsSurface || !srcIsSurface || srcHasAttachmentUsage)) && !m_isD3D8Compatible && !isCopy))
+      if (unlikely((!dstHasAttachmentUsage && (!dstIsSurface || !srcIsSurface || srcHasAttachmentUsage)) &&
+                                               !m_d3dCompatibility.test(D3DCompatibility::D3D8) && !isCopy))
         return D3DERR_INVALIDCALL;
     }
 
@@ -2517,7 +2541,7 @@ namespace dxvk {
             if ((Value == AlphaToCoverageEnable
               || Value == AlphaToCoverageDisable) &&
                  vendorId == amdVendorId &&
-                 !m_isD3D8Compatible) {
+                 !m_d3dCompatibility.test(D3DCompatibility::D3D8)) {
               UpdateAlphaToCoverangeAndAlphaTest();
               break;
             }
@@ -2534,7 +2558,7 @@ namespace dxvk {
             // INST (AMD specific)
             if (unlikely(Value == uint32_t(D3D9Format::INST) &&
                          vendorId == amdVendorId &&
-                         !m_isD3D8Compatible)) {
+                         !m_d3dCompatibility.test(D3DCompatibility::D3D8))) {
               // Geometry instancing is supported by SM3, but ATI/AMD
               // exposed this hack to retroactively enable it on their
               // SM2-capable hardware. It's esentially a no-op.
@@ -2543,7 +2567,7 @@ namespace dxvk {
 
             // CENT (AMD & Nvidia)
             if (unlikely(Value == uint32_t(D3D9Format::CENT) &&
-                         !m_isD3D8Compatible)) {
+                         !m_d3dCompatibility.test(D3DCompatibility::D3D8))) {
               // Centroid (alternate pixel center) hack.
               // Taken into account anyway, so yet another no-op.
               break;
@@ -2597,7 +2621,7 @@ namespace dxvk {
           const uint32_t vendorId = m_adapter->GetVendorId();
 
           // Nvidia's driver hack for ATOC (also supported on Intel), COPM and SSAA
-          if (likely(vendorId != amdVendorId && !m_isD3D8Compatible)) {
+          if (likely(vendorId != amdVendorId && !m_d3dCompatibility.test(D3DCompatibility::D3D8))) {
             // ATOC (Nvidia & Intel)
             constexpr uint32_t AlphaToCoverageEnable  = uint32_t(D3D9Format::ATOC);
             // Disabling both ATOC and SSAA is done using D3DFMT_UNKNOWN (0)
@@ -2613,14 +2637,18 @@ namespace dxvk {
             if (unlikely(Value == uint32_t(D3D9Format::COPM) &&
                          vendorId == nvidiaVendorId)) {
               // UE3 calls this MinimalNVIDIADriverShaderOptimization
+/*
               Logger::info("D3D9DeviceEx::SetRenderState: MinimalNVIDIADriverShaderOptimization is unsupported");
+*/
               break;
             }
 
             // SSAA (Nvidia specific)
             if (unlikely(Value == uint32_t(D3D9Format::SSAA) &&
                          vendorId == nvidiaVendorId)) {
+/*
               Logger::warn("D3D9DeviceEx::SetRenderState: Transparency supersampling (SSAA) is unsupported");
+*/
               break;
             }
           }
@@ -2705,7 +2733,7 @@ namespace dxvk {
     try {
       const Com<D3D9StateBlock> sb = new D3D9StateBlock(this, stateBlockType);
       *ppSB = sb.ref();
-      if (!m_isD3D8Compatible)
+      if (!m_d3dCompatibility.test(D3DCompatibility::D3D8))
         m_losableResourceCounter++;
 
       return D3D_OK;
@@ -2740,7 +2768,7 @@ namespace dxvk {
     InitReturnPtr(ppSB);
 
     *ppSB = m_recorder.ref();
-    if (!m_isD3D8Compatible)
+    if (!m_d3dCompatibility.test(D3DCompatibility::D3D8))
       m_losableResourceCounter++;
     m_recorder = nullptr;
 
@@ -4323,7 +4351,8 @@ namespace dxvk {
       return D3DERR_INVALIDCALL;
 
     try {
-      const Com<D3D9Surface> surface = new D3D9Surface(this, &desc, IsExtended(), nullptr, pSharedHandle);
+      const bool isExtended = m_d3dCompatibility.test(D3DCompatibility::D3D9Ex);
+      const Com<D3D9Surface> surface = new D3D9Surface(this, &desc, isExtended, nullptr, pSharedHandle);
       m_initializer->InitTexture(surface->GetCommonTexture());
       *ppSurface = surface.ref();
       m_losableResourceCounter++;
@@ -4392,7 +4421,8 @@ namespace dxvk {
       if (unlikely(pSharedHandle != nullptr && Pool != D3DPOOL_DEFAULT))
         return D3DERR_INVALIDCALL;
 
-      const Com<D3D9Surface> surface = new D3D9Surface(this, &desc, IsExtended(), nullptr, pSharedHandle);
+      const bool isExtended = m_d3dCompatibility.test(D3DCompatibility::D3D9Ex);
+      const Com<D3D9Surface> surface = new D3D9Surface(this, &desc, isExtended, nullptr, pSharedHandle);
       m_initializer->InitTexture(surface->GetCommonTexture(), initialData);
       *ppSurface = surface.ref();
 
@@ -4452,7 +4482,8 @@ namespace dxvk {
       return D3DERR_INVALIDCALL;
 
     try {
-      const Com<D3D9Surface> surface = new D3D9Surface(this, &desc, IsExtended(), nullptr, pSharedHandle);
+      const bool isExtended = m_d3dCompatibility.test(D3DCompatibility::D3D9Ex);
+      const Com<D3D9Surface> surface = new D3D9Surface(this, &desc, isExtended, nullptr, pSharedHandle);
       m_initializer->InitTexture(surface->GetCommonTexture());
       *ppSurface = surface.ref();
       m_losableResourceCounter++;
@@ -4703,11 +4734,6 @@ namespace dxvk {
     }
 
     return D3D_OK;
-  }
-
-
-  bool D3D9DeviceEx::IsExtended() {
-    return m_parent->IsExtended();
   }
 
 
@@ -5128,9 +5154,11 @@ namespace dxvk {
       DxvkBufferSlice mappedBufferSlice = pResource->GetBufferSlice(Subresource);
       const Rc<DxvkBuffer> mappedBuffer = pResource->GetBuffer();
 
+/*
       if (unlikely(pResource->GetFormatMapping().ConversionFormatInfo.FormatType != D3D9ConversionFormat_None)) {
         Logger::err(str::format("Reading back format", pResource->Desc()->Format, " is not supported. It is uploaded using the fomrat converter."));
       }
+*/
 
       if (pResource->GetImage() != nullptr) {
         Rc<DxvkImage> resourceImage = pResource->GetImage();
@@ -5445,12 +5473,14 @@ namespace dxvk {
       // The texture uses a format which gets converted by a compute shader.
       const void* mapPtr = MapTexture(pSrcTexture, SrcSubresource);
 
+/*
       // The compute shader does not support only converting a subrect of the texture
       if (unlikely(SrcOffset.x != 0 || SrcOffset.y != 0 || SrcOffset.z != 0
         || DestOffset.x != 0 || DestOffset.y != 0 || DestOffset.z != 0
         || SrcExtent != srcTexLevelExtent)) {
         Logger::warn("Offset and rect not supported with the texture converter.");
       }
+*/
 
       if (unlikely(srcTexLevelExtent != dstTexLevelExtent)) {
         Logger::err("Different extents are not supported with the texture converter.");
@@ -7149,7 +7179,7 @@ namespace dxvk {
 
 
   void D3D9DeviceEx::UpdateAlphaToCoverangeAndAlphaTest() {
-    if (likely(!m_isD3D8Compatible)) {
+    if (likely(!m_d3dCompatibility.test(D3DCompatibility::D3D8))) {
       // ATOC is not supported by D3D8
       bool alphaToCoverageEnabled = true;
 
@@ -8758,7 +8788,7 @@ namespace dxvk {
     rs[D3DRS_POINTSCALE_B]               = bit::cast<DWORD>(0.0f);
     rs[D3DRS_POINTSCALE_C]               = bit::cast<DWORD>(0.0f);
     rs[D3DRS_POINTSIZE]                  = bit::cast<DWORD>(1.0f);
-    rs[D3DRS_POINTSIZE_MIN]              = m_isD3D8Compatible ? bit::cast<DWORD>(0.0f) : bit::cast<DWORD>(1.0f);
+    rs[D3DRS_POINTSIZE_MIN]              = m_d3dCompatibility.test(D3DCompatibility::D3D8) ? bit::cast<DWORD>(0.0f) : bit::cast<DWORD>(1.0f);
     rs[D3DRS_POINTSIZE_MAX]              = bit::cast<DWORD>(limits.pointSizeRange[1]);
     UpdatePushConstant<D3D9RenderStateItem::PointSize>();
     UpdatePushConstant<D3D9RenderStateItem::PointSizeMin>();
@@ -8908,7 +8938,7 @@ namespace dxvk {
 
     // In D3D8, this represents the value of D3DRS_PATCHSEGMENTS.
     // It defaults to 1.0f and is reset as any other render state.
-    if (m_isD3D8Compatible)
+    if (m_d3dCompatibility.test(D3DCompatibility::D3D8))
       m_state.nPatchSegments = 1.0f;
 
     m_alphaTestEnabled = false;
@@ -8959,6 +8989,8 @@ namespace dxvk {
       m_mostRecentlyUsedSwapchain = m_implicitSwapchain.ptr();
     }
 
+    const bool isExtended = m_d3dCompatibility.test(D3DCompatibility::D3D9Ex);
+
     if (pPresentationParameters->EnableAutoDepthStencil) {
       D3D9_COMMON_TEXTURE_DESC desc;
       desc.Width              = pPresentationParameters->BackBufferWidth;
@@ -8979,13 +9011,13 @@ namespace dxvk {
       if (FAILED(D3D9CommonTexture::NormalizeTextureProperties(this, D3DRTYPE_SURFACE, &desc)))
         return D3DERR_NOTAVAILABLE;
 
-      m_autoDepthStencil = new D3D9Surface(this, &desc, IsExtended(), nullptr, nullptr);
+      m_autoDepthStencil = new D3D9Surface(this, &desc, isExtended, nullptr, nullptr);
       m_initializer->InitTexture(m_autoDepthStencil->GetCommonTexture());
       SetDepthStencilSurface(m_autoDepthStencil.ptr());
       m_losableResourceCounter++;
     }
 
-    if (!IsExtended()) {
+    if (!isExtended) {
       SetRenderTarget(0, m_implicitSwapchain->GetBackBuffer(0));
     } else {
       // Extended devices will not reset the MinZ/MaxZ viewport values
@@ -9120,7 +9152,7 @@ namespace dxvk {
   void D3D9DeviceEx::NotifyWindowActivated(HWND window, bool activated) {
     D3D9DeviceLock lock = LockDevice();
 
-    if (likely(!m_d3d9Options.deviceLossOnFocusLoss || IsExtended()))
+    if (likely(!m_d3d9Options.deviceLossOnFocusLoss || m_d3dCompatibility.test(D3DCompatibility::D3D9Ex)))
       return;
 
     if (activated && m_deviceLostState == D3D9DeviceLostState::Lost) {

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -226,7 +226,7 @@ namespace dxvk {
     friend struct D3D9WindowContext;
     friend class D3D9ConstantBuffer;
     friend class D3D9UserDefinedAnnotation;
-    friend class DxvkD3D8Bridge;
+    friend class DxvkLegacyD3DDeviceBridge;
     friend D3D9VkInteropDevice;
   public:
 
@@ -807,8 +807,6 @@ namespace dxvk {
 
     bool SupportsVCacheQuery() const;
 
-    bool IsExtended();
-
     HWND GetWindow();
 
     const Rc<DxvkDevice>& GetDXVKDevice() {
@@ -1005,7 +1003,7 @@ namespace dxvk {
 
     inline bool IsNVDepthBoundsTestEnabled () {
       // NVDB is not supported by D3D8
-      if (unlikely(m_isD3D8Compatible))
+      if (unlikely(m_d3dCompatibility.test(D3DCompatibility::D3D8)))
         return false;
 
       return m_state.renderStates[D3DRS_ADAPTIVETESS_X] == uint32_t(D3D9Format::NVDB);
@@ -1132,7 +1130,7 @@ namespace dxvk {
     void ConsiderFlush(GpuFlushType FlushType);
 
     bool ChangeReportedMemory(int64_t delta) {
-      if (IsExtended())
+      if (m_d3dCompatibility.test(D3DCompatibility::D3D9Ex))
         return true;
 
       int64_t availableMemory = m_availableMemory.fetch_add(delta);
@@ -1189,8 +1187,8 @@ namespace dxvk {
       return m_recorder != nullptr;
     }
 
-    bool IsD3D8Compatible() const {
-      return m_isD3D8Compatible;
+    bool IsD3DCompatibile(D3DCompatibility d3dCompatibility) const {
+      return m_d3dCompatibility.test(d3dCompatibility);
     }
 
     // Device Lost
@@ -1652,7 +1650,6 @@ namespace dxvk {
     D3D9SpecializationInfo          m_specInfo = D3D9SpecializationInfo();
 
     bool                            m_isSWVP;
-    bool                            m_isD3D8Compatible;
     bool                            m_ffZTest          = false;
 
     // the enablement of below features is tracked independently
@@ -1714,7 +1711,9 @@ namespace dxvk {
     D3D9VkInteropDevice             m_d3d9Interop;
     D3D9ON12_ARGS                   m_d3d9On12Args = { };
     D3D9On12                        m_d3d9On12;
-    DxvkD3D8Bridge                  m_d3d8Bridge;
+
+    DxvkLegacyD3DDeviceBridge       m_legacyD3DBridge;
+    D3DCompatibilityFlags           m_d3dCompatibility;
 
     // Sampler statistics
     constexpr static uint32_t       SamplerCountBits = 12u;

--- a/src/d3d9/d3d9_format.cpp
+++ b/src/d3d9/d3d9_format.cpp
@@ -428,7 +428,9 @@ namespace dxvk {
       case D3D9Format::AL16: return {}; // Unsupported
 
       default:
+/*
         Logger::warn(str::format("ConvertFormat: Unknown format encountered: ", Format));
+*/
         return {}; // Unsupported
     }
   }
@@ -458,8 +460,7 @@ namespace dxvk {
             D3D9Adapter*     pParent,
       const Rc<DxvkAdapter>& adapter,
       const D3D9Options&     options)
-    : m_isExtended (pParent->IsExtended()),
-      m_isD3D8Compatible (pParent->IsD3D8Compatible()) {
+    : m_isExtended (pParent->IsD3DCompatibile(D3DCompatibility::D3D9Ex)) {
 
     const uint32_t vendorId = pParent->GetVendorId();
     const bool     isNvidia = vendorId == uint32_t(DxvkGpuVendor::Nvidia);
@@ -469,6 +470,8 @@ namespace dxvk {
     // NVIDIA does not natively support any DF formats
     m_dfSupport = !isNvidia ? options.supportDFFormats : false;
     m_x4r4g4b4Support = options.supportX4R4G4B4;
+    // W11V11U10 is only supported by D3D8
+    m_w11v11u10Support = false;
     // Only AMD supports D16_LOCKABLE natively
     m_d16lockableSupport = isAmd;
 
@@ -490,6 +493,7 @@ namespace dxvk {
     // Only Intel supports D24FS8 natively
     m_d24fs8Support = isIntel;
 
+/*
     if (!m_d24s8Support)
       Logger::info("D3D9: VK_FORMAT_D24_UNORM_S8_UINT -> VK_FORMAT_D32_SFLOAT_S8_UINT");
 
@@ -499,6 +503,8 @@ namespace dxvk {
       else
         Logger::info("D3D9: VK_FORMAT_D16_UNORM_S8_UINT -> VK_FORMAT_D32_SFLOAT_S8_UINT");
     }
+*/
+
   }
 
   D3D9_VK_FORMAT_MAPPING D3D9VkFormatTable::GetFormatMapping(
@@ -508,8 +514,7 @@ namespace dxvk {
     if (Format == D3D9Format::X4R4G4B4 && !m_x4r4g4b4Support)
       return D3D9_VK_FORMAT_MAPPING();
 
-    // W11V11U10 is only supported by d3d8
-    if (Format == D3D9Format::W11V11U10 && !m_isD3D8Compatible)
+    if (Format == D3D9Format::W11V11U10 && !m_w11v11u10Support)
       return D3D9_VK_FORMAT_MAPPING();
 
     if (Format == D3D9Format::D16_LOCKABLE && !m_d16lockableSupport)
@@ -575,7 +580,7 @@ namespace dxvk {
       case D3D9Format::P8:
         return &p8;
 
-      // only supported by d3d8
+      // only supported by D3D8
       case D3D9Format::W11V11U10:
         return &w11v11u10;
 
@@ -596,14 +601,14 @@ namespace dxvk {
       case D3D9Format::D32F_LOCKABLE:
         return &d32f_lockable;
 
-      // only considered on d3d9Ex interfaces
+      // only considered on D3D9Ex interfaces
       case D3D9Format::D32_LOCKABLE:
         if (m_isExtended)
           return &d32_lockable;
 
         [[fallthrough]];
 
-      // only considered on d3d9Ex interfaces
+      // only considered on D3D9Ex interfaces
       case D3D9Format::S8_LOCKABLE:
         if (m_isExtended)
           return &s8_lockable;
@@ -624,6 +629,12 @@ namespace dxvk {
 
     return (supported.linear  & Features) == Features
         || (supported.optimal & Features) == Features;
+  }
+
+  void D3D9VkFormatTable::RefreshFormatSupport(
+    const D3D9Adapter*          pParent) {
+    // W11V11U10 is only supported by D3D8
+    m_w11v11u10Support = pParent->IsD3D8Compatible();
   }
 
 }

--- a/src/d3d9/d3d9_format.cpp
+++ b/src/d3d9/d3d9_format.cpp
@@ -634,7 +634,7 @@ namespace dxvk {
   void D3D9VkFormatTable::RefreshFormatSupport(
     const D3D9Adapter*          pParent) {
     // W11V11U10 is only supported by D3D8
-    m_w11v11u10Support = pParent->IsD3D8Compatible();
+    m_w11v11u10Support = pParent->IsD3DCompatibile(D3DCompatibility::D3D8);
   }
 
 }

--- a/src/d3d9/d3d9_format.h
+++ b/src/d3d9/d3d9_format.h
@@ -222,6 +222,9 @@ namespace dxvk {
     const DxvkFormatInfo* GetUnsupportedFormatInfo(
       D3D9Format            Format) const;
 
+    void RefreshFormatSupport(
+      const D3D9Adapter*          pParent);
+
   private:
 
     bool CheckImageFormatSupport(
@@ -230,13 +233,13 @@ namespace dxvk {
             VkFormatFeatureFlags2 Features) const;
 
     bool m_isExtended;
-    bool m_isD3D8Compatible;
 
     bool m_d24s8Support;
     bool m_d16s8Support;
 
     bool m_dfSupport;
     bool m_x4r4g4b4Support;
+    bool m_w11v11u10Support;
     bool m_d16lockableSupport;
 
     bool m_d32flockableSupport;

--- a/src/d3d9/d3d9_interface.cpp
+++ b/src/d3d9/d3d9_interface.cpp
@@ -15,12 +15,11 @@ namespace dxvk {
   Singleton<DxvkInstance> g_dxvkInstance;
 
   D3D9InterfaceEx::D3D9InterfaceEx(bool bExtended, const D3D9ON12_ARGS* pOverrideList, uint32_t OverrideCount)
-    : m_instance    ( g_dxvkInstance.acquire(DxvkInstanceFlag::ClientApiIsD3D9) )
-    , m_d3d8Bridge  ( this )
-    , m_extended    ( bExtended ) 
-    , m_d3d9Options ( nullptr, m_instance->config() )
-    , m_d3d9Interop ( this )
-    , m_d3d9ExtInterface( this ) {
+    : m_instance           ( g_dxvkInstance.acquire(DxvkInstanceFlag::ClientApiIsD3D9) )
+    , m_legacyD3DBridge    ( this )
+    , m_d3d9Options        ( nullptr, m_instance->config() )
+    , m_d3d9Interop        ( this )
+    , m_d3d9VkExtInterface ( this ) {
     // D3D9 doesn't enumerate adapters like physical adapters...
     // only as connected displays.
 
@@ -74,8 +73,18 @@ namespace dxvk {
     }
 #endif
 
+    if (bExtended) {
+      m_d3dCompatibility.set(D3DCompatibility::D3D9Ex);
+/*
+      Logger::info("The D3D9 interface is operating in D3D9Ex mode.");
+*/
+    }
+
+/*
     if (unlikely(m_d3d9Options.shaderModel == 0))
-      Logger::warn("D3D9InterfaceEx: WARNING! Fixed-function exclusive mode is enabled.");
+      Logger::warn("WARNING! Fixed-function exclusive mode is enabled.");
+*/
+
   }
 
 
@@ -92,13 +101,14 @@ namespace dxvk {
 
     if (riid == __uuidof(IUnknown)
      || riid == __uuidof(IDirect3D9)
-     || (m_extended && riid == __uuidof(IDirect3D9Ex))) {
+     || (m_d3dCompatibility.test(D3DCompatibility::D3D9Ex) &&
+         riid == __uuidof(IDirect3D9Ex))) {
       *ppvObject = ref(this);
       return S_OK;
     }
 
-    if (riid == __uuidof(IDxvkD3D8InterfaceBridge)) {
-      *ppvObject = ref(&m_d3d8Bridge);
+    if (riid == __uuidof(IDxvkLegacyD3DInterfaceBridge)) {
+      *ppvObject = ref(&m_legacyD3DBridge);
       return S_OK;
     }
 
@@ -109,21 +119,25 @@ namespace dxvk {
     }
 
     if (riid == __uuidof(ID3D9VkExtInterface)) {
-      *ppvObject = ref(&m_d3d9ExtInterface);
+      *ppvObject = ref(&m_d3d9VkExtInterface);
       return S_OK;
     }
 
+/*
     if (logQueryInterfaceError(__uuidof(IDirect3D9), riid)) {
       Logger::warn("D3D9InterfaceEx::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));
     }
+*/
 
     return E_NOINTERFACE;
   }
 
 
   HRESULT STDMETHODCALLTYPE D3D9InterfaceEx::RegisterSoftwareDevice(void* pInitializeFunction) {
+/*
     Logger::warn("D3D9InterfaceEx::RegisterSoftwareDevice: Stub");
+*/
     return D3D_OK;
   }
 
@@ -472,7 +486,7 @@ namespace dxvk {
     if (unlikely(pPresentationParameters == nullptr))
       return D3DERR_INVALIDCALL;
 
-    if (m_extended) {
+    if (m_d3dCompatibility.test(D3DCompatibility::D3D9Ex)) {
       // The swap effect value on a D3D9Ex device
       // can not be higher than D3DSWAPEFFECT_FLIPEX.
       if (unlikely(pPresentationParameters->SwapEffect > D3DSWAPEFFECT_FLIPEX))

--- a/src/d3d9/d3d9_interface.cpp
+++ b/src/d3d9/d3d9_interface.cpp
@@ -514,7 +514,7 @@ namespace dxvk {
     // Allow D3DSWAPEFFECT_COPY to bypass this restriction in D3D8 compatibility
     // mode, since it may be a remapping of D3DSWAPEFFECT_COPY_VSYNC and RC Cars
     // depends on it not being validated.
-    if (unlikely(!IsD3D8Compatible()
+    if (unlikely(!m_d3dCompatibility.test(D3DCompatibility::D3D8)
               && pPresentationParameters->SwapEffect == D3DSWAPEFFECT_COPY
               && pPresentationParameters->BackBufferCount > 1))
       return D3DERR_INVALIDCALL;

--- a/src/d3d9/d3d9_interface.h
+++ b/src/d3d9/d3d9_interface.h
@@ -131,7 +131,7 @@ namespace dxvk {
     HRESULT ValidatePresentationParameters(
         const D3DPRESENT_PARAMETERS* pPresentationParameters);
 
-    const D3D9Options& GetOptions() { return m_d3d9Options; }
+    const D3D9Options& GetOptions() const { return m_d3d9Options; }
 
     D3D9Adapter* GetAdapter(UINT Ordinal) {
       return Ordinal < m_adapters.size()
@@ -139,15 +139,28 @@ namespace dxvk {
         : nullptr;
     }
 
-    bool IsExtended() { return m_extended; }
-
-    bool IsD3D8Compatible() const {
-      return m_isD3D8Compatible;
+    D3DCompatibilityFlags GetD3DCompatibilityFlags() const {
+      return m_d3dCompatibility;
     }
 
-    void EnableD3D8CompatibilityMode() {
-      m_isD3D8Compatible = true;
-      Logger::info("The D3D9 interface is now operating in D3D8 compatibility mode.");
+    bool IsD3DCompatibile(D3DCompatibility d3dCompatibility) const {
+      return m_d3dCompatibility.test(d3dCompatibility);
+    }
+
+    void SetD3DCompatibility(D3DCompatibility d3dCompatibility) {
+      m_d3dCompatibility.set(d3dCompatibility);
+
+/*
+      switch (d3dCompatibility) {
+        case D3DCompatibility::D3D8:
+          Logger::info("The D3D9 interface is now operating in D3D8 compatibility mode.");
+          break;
+        default:
+          break;
+      }
+*/
+
+      RefreshAdapterFormatTables();
     }
 
     Rc<DxvkInstance> GetInstance() { return m_instance; }
@@ -155,18 +168,20 @@ namespace dxvk {
     bool HasFormatsUnlocked() const { return m_unlockAdditionalFormats; }
 
     void EnableAdditionalFormats() {
-            m_unlockAdditionalFormats = true;
+      m_unlockAdditionalFormats = true;
     }
 
   private:
 
+    inline void RefreshAdapterFormatTables() {
+      for (auto& adapter : m_adapters)
+        adapter.RefreshFormatsTable();
+    }
+
     Rc<DxvkInstance>              m_instance;
 
-    DxvkD3D8InterfaceBridge       m_d3d8Bridge;
-
-    bool                          m_extended;
-
-    bool                          m_isD3D8Compatible = false;
+    DxvkLegacyD3DInterfaceBridge  m_legacyD3DBridge;
+    D3DCompatibilityFlags         m_d3dCompatibility;
 
     D3D9Options                   m_d3d9Options;
 
@@ -181,7 +196,7 @@ namespace dxvk {
 
     bool m_unlockAdditionalFormats = false;
 
-    D3D9VkExtInterface            m_d3d9ExtInterface;
+    D3D9VkExtInterface            m_d3d9VkExtInterface;
 
   };
 

--- a/src/d3d9/d3d9_interop.cpp
+++ b/src/d3d9/d3d9_interop.cpp
@@ -360,7 +360,8 @@ namespace dxvk {
           const D3D9_COMMON_TEXTURE_DESC& desc,
           IDirect3DResource9**            ppResult) {
     try {
-      const Com<ResourceType> texture = new ResourceType(m_device, &desc, m_device->IsExtended());
+      const bool isExtended = m_device->IsD3DCompatibile(D3DCompatibility::D3D9Ex);
+      const Com<ResourceType> texture = new ResourceType(m_device, &desc, isExtended);
       m_device->m_initializer->InitTexture(texture->GetCommonTexture());
       *ppResult = texture.ref();
 

--- a/src/d3d9/d3d9_interop.h
+++ b/src/d3d9/d3d9_interop.h
@@ -154,6 +154,7 @@ namespace dxvk {
     void STDMETHODCALLTYPE UnlockAdditionalFormats();
 
   private:
+
     D3D9InterfaceEx *m_interface;
 
   };

--- a/src/d3d9/d3d9_query.cpp
+++ b/src/d3d9/d3d9_query.cpp
@@ -59,10 +59,12 @@ namespace dxvk {
       return S_OK;
     }
 
+/*
     if (logQueryInterfaceError(__uuidof(IDirect3DQuery9), riid)) {
       Logger::warn("D3D9Query::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));
     }
+*/
 
     return E_NOINTERFACE;
   }

--- a/src/d3d9/d3d9_shader.cpp
+++ b/src/d3d9/d3d9_shader.cpp
@@ -114,7 +114,7 @@ namespace dxvk {
     // Vertex shader version checks
     if (ShaderStage == VK_SHADER_STAGE_VERTEX_BIT) {
       // Late fixed-function capable hardware exposed support for VS 1.1
-      const uint32_t shaderModelVS = pDevice->IsD3D8Compatible() ? 1u : std::max(1u, options->shaderModel);
+      const uint32_t shaderModelVS = pDevice->IsD3DCompatibile(D3DCompatibility::D3D8) ? 1u : std::max(1u, options->shaderModel);
 
       if (unlikely(majorVersion > shaderModelVS
                || (majorVersion == 1 && minorVersion > 1)
@@ -124,7 +124,7 @@ namespace dxvk {
       }
     // Pixel shader version checks
     } else if (ShaderStage == VK_SHADER_STAGE_FRAGMENT_BIT) {
-      const uint32_t shaderModelPS = pDevice->IsD3D8Compatible() ? std::min(1u, options->shaderModel) : options->shaderModel;
+      const uint32_t shaderModelPS = pDevice->IsD3DCompatibile(D3DCompatibility::D3D8) ? std::min(1u, options->shaderModel) : options->shaderModel;
 
       if (unlikely(majorVersion > shaderModelPS
                || (majorVersion == 1 && minorVersion > 4)

--- a/src/d3d9/d3d9_shader.cpp
+++ b/src/d3d9/d3d9_shader.cpp
@@ -19,8 +19,11 @@ namespace dxvk {
     const uint32_t bytecodeLength = AnalysisInfo.bytecodeByteLength;
 
     const std::string name = Key.toString();
+
+/*
     Logger::debug(str::format("Compiling shader ", name));
-    
+*/
+
     // If requested by the user, dump both the raw DXBC
     // shader and the compiled SPIR-V module to a file.
     const std::string& dumpPath = pDevice->GetOptions()->shaderDumpPath;

--- a/src/d3d9/d3d9_shader.h
+++ b/src/d3d9/d3d9_shader.h
@@ -122,10 +122,12 @@ namespace dxvk {
         return S_OK;
       }
 
+/*
       if (logQueryInterfaceError(__uuidof(Base), riid)) {
         Logger::warn("D3D9Shader::QueryInterface: Unknown interface query");
         Logger::warn(str::format(riid));
       }
+*/
 
       return E_NOINTERFACE;
     }

--- a/src/d3d9/d3d9_shader_validator.cpp
+++ b/src/d3d9/d3d9_shader_validator.cpp
@@ -161,9 +161,11 @@ namespace dxvk {
     m_ctx   = std::make_unique<DxsoDecodeContext>(DxsoProgramInfo{ programType, m_minorVersion, m_majorVersion });
     m_state = D3D9ShaderValidatorState::ValidatingInstructions;
 
+/*
     const char* shaderTypeOutput = m_isPixelShader ? "PS" : "VS";
     Logger::debug(str::format("IDirect3DShaderValidator9::Instruction: Validating ",
                               shaderTypeOutput, " version ", m_majorVersion, ".", m_minorVersion));
+*/
 
     return D3D_OK;
   }
@@ -194,10 +196,13 @@ namespace dxvk {
     if (m_callback)
       m_callback(pFile, Line, Unknown, MessageID, Message.c_str(), m_userData);
 
+/*
     // TODO: Consider switching this to debug, once we're
     // confident the implementation doesn't cause any issues
     Logger::warn(Message);
+*/
 
+/*
     // Log instruction that caused the error as raw bytecode
     if (Logger::logLevel() <= LogLevel::Debug && pInstr && InstrLength) {
       std::stringstream instMsg;
@@ -210,6 +215,7 @@ namespace dxvk {
 
       Logger::debug(instMsg.str());
     }
+*/
 
     m_state = D3D9ShaderValidatorState::Error;
     return E_FAIL;

--- a/src/d3d9/d3d9_stateblock.cpp
+++ b/src/d3d9/d3d9_stateblock.cpp
@@ -18,7 +18,7 @@ namespace dxvk {
   }
 
   D3D9StateBlock::~D3D9StateBlock() {
-    if (!m_parent->IsD3D8Compatible())
+    if (!m_parent->IsD3DCompatibile(D3DCompatibility::D3D8))
       m_parent->DecrementLosableCounter();
   }
 
@@ -36,10 +36,12 @@ namespace dxvk {
       return S_OK;
     }
 
+/*
     if (logQueryInterfaceError(__uuidof(IDirect3DStateBlock9), riid)) {
       Logger::warn("D3D9StateBlock::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));
     }
+*/
 
     return E_NOINTERFACE;
   }

--- a/src/d3d9/d3d9_surface.cpp
+++ b/src/d3d9/d3d9_surface.cpp
@@ -94,10 +94,12 @@ namespace dxvk {
       return S_OK;
     }
 
+/*
     if (logQueryInterfaceError(__uuidof(IDirect3DSurface9), riid)) {
       Logger::warn("D3D9Surface::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));
     }
+*/
 
     return E_NOINTERFACE;
   }
@@ -137,7 +139,8 @@ namespace dxvk {
     // for surfaces in D3DPOOL_DEFAULT. D3D8 additionally clears the content
     // for non-D3DPOOL_DEFAULT surfaces if their type is not D3DRTYPE_TEXTURE.
     if (desc.Pool == D3DPOOL_DEFAULT
-     || (m_texture->Device()->IsD3D8Compatible() && type != D3DRTYPE_TEXTURE)) {
+     || (m_texture->Device()->IsD3DCompatibile(D3DCompatibility::D3D8) &&
+         type != D3DRTYPE_TEXTURE)) {
       pLockedRect->pBits = nullptr;
       pLockedRect->Pitch = 0;
     }
@@ -152,7 +155,7 @@ namespace dxvk {
       // with formats which need to be block aligned, surfaces created via
       // CreateImageSurface and D3D8 cube textures outside of D3DPOOL_DEFAULT
       if ((isBlockAlignedFormat && desc.Pool == D3DPOOL_DEFAULT) || isSystemMemSurface
-       || (m_texture->Device()->IsD3D8Compatible() &&
+       || (m_texture->Device()->IsD3DCompatibile(D3DCompatibility::D3D8) &&
            desc.Pool != D3DPOOL_DEFAULT && type == D3DRTYPE_CUBETEXTURE)) {
         const LONG width  = pRect->right  - pRect->left;
         const LONG height = pRect->bottom - pRect->top;

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -86,7 +86,8 @@ namespace dxvk {
 
     if (riid == __uuidof(IUnknown)
      || riid == __uuidof(IDirect3DSwapChain9)
-     || (GetParent()->IsExtended() && riid == __uuidof(IDirect3DSwapChain9Ex))) {
+     || (m_parent->IsD3DCompatibile(D3DCompatibility::D3D9Ex) &&
+         riid == __uuidof(IDirect3DSwapChain9Ex))) {
       *ppvObject = ref(this);
       return S_OK;
     }
@@ -96,10 +97,12 @@ namespace dxvk {
       return S_OK;
     }
 
+/*
     if (logQueryInterfaceError(__uuidof(IDirect3DSwapChain9), riid)) {
       Logger::warn("D3D9SwapChainEx::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));
     }
+*/
 
     return E_NOINTERFACE;
   }
@@ -1053,10 +1056,12 @@ namespace dxvk {
     // we might need to lock for the BlitGDI fallback path
     desc.IsLockable         = true;
 
+    const bool isExtended = m_parent->IsD3DCompatibile(D3DCompatibility::D3D9Ex);
+
     for (uint32_t i = 0; i < bufferCount; i++) {
       D3D9Surface* surface;
       try {
-        surface = new D3D9Surface(m_parent, &desc, m_parent->IsExtended(), this, nullptr);
+        surface = new D3D9Surface(m_parent, &desc, isExtended, this, nullptr);
         m_parent->IncrementLosableCounter();
       } catch (const DxvkError& e) {
         DestroyBackBuffers();
@@ -1354,11 +1359,10 @@ namespace dxvk {
       m_srcRect.left   = 0;
       m_srcRect.right  = m_presentParams.BackBufferWidth;
       m_srcRect.bottom = m_presentParams.BackBufferHeight;
-    }
-    else
+    } else {
       m_srcRect = *pSourceRect;
+    }
 
-    
     UINT width, height;
     wsi::getWindowSize(m_window, &width, &height);
 
@@ -1369,10 +1373,9 @@ namespace dxvk {
       dstRect.left   = 0;
       dstRect.right  = LONG(width);
       dstRect.bottom = LONG(height);
-      
-    }
-    else
+    } else {
       dstRect = *pDestRect;
+    }
 
     m_partialCopy =
        dstRect.left != 0
@@ -1397,11 +1400,11 @@ namespace dxvk {
 
 
   std::string D3D9SwapChainEx::GetApiName() {
-    if (this->GetParent()->Is9On12Device())
-      return this->GetParent()->IsExtended() ? "D3D9On12Ex" : "D3D9On12";
+    if (m_parent->Is9On12Device())
+      return m_parent->IsD3DCompatibile(D3DCompatibility::D3D9Ex) ? "D3D9ExOn12" : "D3D9On12";
 
-    return this->GetParent()->IsD3D8Compatible() ? "D3D8" :
-           this->GetParent()->IsExtended() ? "D3D9Ex" : "D3D9";
+    return m_parent->IsD3DCompatibile(D3DCompatibility::D3D8) ? "D3D8" :
+           m_parent->IsD3DCompatibile(D3DCompatibility::D3D9Ex) ? "D3D9Ex" : "D3D9";
   }
 
 

--- a/src/d3d9/d3d9_swvp_emu.cpp
+++ b/src/d3d9/d3d9_swvp_emu.cpp
@@ -213,7 +213,9 @@ namespace dxvk {
 
         if (elementInfo.Class == DecltypeClass::Dec) {
           // TODO!
+/*
           Logger::warn("Encountered DEC3/UDEC3N class, ignoring...");
+*/
           continue;
         }
 

--- a/src/d3d9/d3d9_texture.cpp
+++ b/src/d3d9/d3d9_texture.cpp
@@ -38,10 +38,12 @@ namespace dxvk {
       return S_OK;
     }
 
+/*
     if (logQueryInterfaceError(__uuidof(IDirect3DTexture9), riid)) {
       Logger::warn("D3D9Texture2D::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));
     }
+*/
 
     return E_NOINTERFACE;
   }
@@ -138,10 +140,12 @@ namespace dxvk {
       return S_OK;
     }
 
+/*
     if (logQueryInterfaceError(__uuidof(IDirect3DVolumeTexture9), riid)) {
       Logger::warn("D3D9Texture3D::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));
     }
+*/
 
     return E_NOINTERFACE;
   }
@@ -232,10 +236,12 @@ namespace dxvk {
       return S_OK;
     }
 
+/*
     if (logQueryInterfaceError(__uuidof(IDirect3DCubeTexture9), riid)) {
       Logger::warn("D3D9TextureCube::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));
     }
+*/
 
     return E_NOINTERFACE;
   }

--- a/src/d3d9/d3d9_vertex_declaration.cpp
+++ b/src/d3d9/d3d9_vertex_declaration.cpp
@@ -40,10 +40,12 @@ namespace dxvk {
       return S_OK;
     }
 
+/*
     if (logQueryInterfaceError(__uuidof(IDirect3DVertexDeclaration9), riid)) {
       Logger::warn("D3D9VertexDecl::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));
     }
+*/
 
     return E_NOINTERFACE;
   }

--- a/src/d3d9/d3d9_volume.cpp
+++ b/src/d3d9/d3d9_volume.cpp
@@ -74,10 +74,12 @@ namespace dxvk {
       return S_OK;
     }
 
+/*
     if (logQueryInterfaceError(__uuidof(IDirect3DVolume9), riid)) {
       Logger::warn("D3D9Volume::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));
     }
+*/
 
     return E_NOINTERFACE;
   }

--- a/src/dxbc/dxbc_compiler.cpp
+++ b/src/dxbc/dxbc_compiler.cpp
@@ -60,58 +60,58 @@ namespace dxvk {
     switch (ins.opClass) {
       case DxbcInstClass::Declaration:
         return this->emitDcl(ins);
-      
+
       case DxbcInstClass::CustomData:
         return this->emitCustomData(ins);
-        
+
       case DxbcInstClass::Atomic:
         return this->emitAtomic(ins);
-        
+
       case DxbcInstClass::AtomicCounter:
         return this->emitAtomicCounter(ins);
-        
+
       case DxbcInstClass::Barrier:
         return this->emitBarrier(ins);
-        
+
       case DxbcInstClass::BitExtract:
         return this->emitBitExtract(ins);
-        
+
       case DxbcInstClass::BitInsert:
         return this->emitBitInsert(ins);
-        
+
       case DxbcInstClass::BitScan:
         return this->emitBitScan(ins);
-        
+
       case DxbcInstClass::BufferQuery:
         return this->emitBufferQuery(ins);
-        
+
       case DxbcInstClass::BufferLoad:
         return this->emitBufferLoad(ins);
-        
+
       case DxbcInstClass::BufferStore:
         return this->emitBufferStore(ins);
-        
+
       case DxbcInstClass::ConvertFloat16:
         return this->emitConvertFloat16(ins);
-        
+
       case DxbcInstClass::ConvertFloat64:
         return this->emitConvertFloat64(ins);
-        
+
       case DxbcInstClass::ControlFlow:
         return this->emitControlFlow(ins);
-        
+
       case DxbcInstClass::GeometryEmit:
         return this->emitGeometryEmit(ins);
-      
+
       case DxbcInstClass::HullShaderPhase:
         return this->emitHullShaderPhase(ins);
-      
+
       case DxbcInstClass::HullShaderInstCnt:
         return this->emitHullShaderInstCnt(ins);
-      
+
       case DxbcInstClass::Interpolate:
         return this->emitInterpolate(ins);
-      
+
       case DxbcInstClass::NoOperation:
         return;
 
@@ -120,65 +120,66 @@ namespace dxvk {
 
       case DxbcInstClass::TextureQuery:
         return this->emitTextureQuery(ins);
-        
+
       case DxbcInstClass::TextureQueryLod:
         return this->emitTextureQueryLod(ins);
-        
+
       case DxbcInstClass::TextureQueryMs:
         return this->emitTextureQueryMs(ins);
-        
+
       case DxbcInstClass::TextureQueryMsPos:
         return this->emitTextureQueryMsPos(ins);
-        
+
       case DxbcInstClass::TextureFetch:
         return this->emitTextureFetch(ins);
-        
+
       case DxbcInstClass::TextureGather:
         return this->emitTextureGather(ins);
-        
+
       case DxbcInstClass::TextureSample:
         return this->emitTextureSample(ins);
-        
+
       case DxbcInstClass::TypedUavLoad:
         return this->emitTypedUavLoad(ins);
-        
+
       case DxbcInstClass::TypedUavStore:
         return this->emitTypedUavStore(ins);
-        
+
       case DxbcInstClass::VectorAlu:
         return this->emitVectorAlu(ins);
-        
+
       case DxbcInstClass::VectorCmov:
         return this->emitVectorCmov(ins);
-        
+
       case DxbcInstClass::VectorCmp:
         return this->emitVectorCmp(ins);
-        
+
       case DxbcInstClass::VectorDeriv:
         return this->emitVectorDeriv(ins);
-        
+
       case DxbcInstClass::VectorDot:
         return this->emitVectorDot(ins);
-        
+
       case DxbcInstClass::VectorIdiv:
         return this->emitVectorIdiv(ins);
-        
+
       case DxbcInstClass::VectorImul:
         return this->emitVectorImul(ins);
-        
+
       case DxbcInstClass::VectorMsad:
         return this->emitVectorMsad(ins);
-        
+
       case DxbcInstClass::VectorShift:
         return this->emitVectorShift(ins);
-        
+
       case DxbcInstClass::VectorSinCos:
         return this->emitVectorSinCos(ins);
-        
-      default:
+
+/*     default:
         Logger::warn(
           str::format("DxbcCompiler: Unhandled opcode class: ",
           ins.op));
+*/
     }
   }
 
@@ -343,11 +344,13 @@ namespace dxvk {
       
       case DxbcOpcode::DclGsInstanceCount:
         return this->emitDclGsInstanceCount(ins);
-      
+
+/*
       default:
         Logger::warn(
           str::format("DxbcCompiler: Unhandled opcode: ",
           ins.op));
+*/
     }
   }
   
@@ -442,9 +445,11 @@ namespace dxvk {
         } else if (ins.dst[0].idxDim == 1) {
           regIdx = ins.dst[0].idx[0].offset;
         } else {
+/*
           Logger::err(str::format(
             "DxbcCompiler: ", ins.op,
             ": Invalid index dimension"));
+*/
           return;
         }
         
@@ -491,11 +496,12 @@ namespace dxvk {
           case DxbcOpcode::DclOutputSiv:
             this->emitDclOutput(regIdx, regDim, ins.dst[0].mask, sv, im);
             break;
-          
+/*
           default:
             Logger::err(str::format(
               "DxbcCompiler: Unexpected opcode: ",
               ins.op));
+*/
         }
       } break;
   
@@ -668,11 +674,12 @@ namespace dxvk {
             m_module.constu32(0)));
       } break;
 
+/*
       default:
         Logger::err(str::format(
           "DxbcCompiler: Unsupported operand type declaration: ",
           ins.dst[0].type));
-        
+*/
     }
   }
   
@@ -912,11 +919,13 @@ namespace dxvk {
   
   
   void DxbcCompiler::emitDclStream(const DxbcShaderInstruction& ins) {
+/*
     if (ins.dst[0].idx[0].offset != 0 && m_moduleInfo.xfb == nullptr)
       Logger::err("Dxbc: Multiple streams not supported");
+*/
   }
-  
-  
+
+
   void DxbcCompiler::emitDclResourceTyped(const DxbcShaderInstruction& ins) {
     // dclResource takes two operands:
     //    (dst0) The resource register ID
@@ -946,10 +955,12 @@ namespace dxvk {
       bit::extract(ins.imm[0].u32, 8, 11));
     auto wType = static_cast<DxbcResourceReturnType>(
       bit::extract(ins.imm[0].u32, 12, 15));
-    
+
+/*
     if ((xType != yType) || (xType != zType) || (xType != wType))
       Logger::warn("DxbcCompiler: dcl_resource: Ignoring resource return types");
-    
+*/
+
     // Declare the actual sampled type
     const DxbcScalarType sampledType = [xType] {
       switch (xType) {
@@ -1616,11 +1627,12 @@ namespace dxvk {
     switch (ins.customDataType) {
       case DxbcCustomDataClass::ImmConstBuf:
         return emitDclImmediateConstantBuffer(ins);
-      
+/*
       default:
         Logger::warn(str::format(
           "DxbcCompiler: Unsupported custom data block: ",
           ins.customDataType));
+*/
     }
   }
   
@@ -1848,11 +1860,13 @@ namespace dxvk {
         dst.id = m_module.opConvertFtoU(
           typeId, src.at(0).id);
         break;
-      
+
       default:
+/*
         Logger::warn(str::format(
           "DxbcCompiler: Unhandled instruction: ",
           ins.op));
+*/
         return;
     }
     
@@ -2006,11 +2020,14 @@ namespace dxvk {
         condition = m_module.opULessThan(
           conditionType, src.at(0).id, src.at(1).id);
         break;
-      
+
+
       default:
+/*
         Logger::warn(str::format(
           "DxbcCompiler: Unhandled instruction: ",
           ins.op));
+*/
         return;
     }
     
@@ -2075,11 +2092,13 @@ namespace dxvk {
       case DxbcOpcode::DerivRtyFine:
         value.id = m_module.opDpdyFine(typeId, value.id);
         break;
-      
+
       default:
+/*
         Logger::warn(str::format(
           "DxbcCompiler: Unhandled instruction: ",
           ins.op));
+*/
         return;
     }
     
@@ -2144,7 +2163,9 @@ namespace dxvk {
     if (ins.dst[0].type != DxbcOperandType::Null
      && ins.dst[1].type != DxbcOperandType::Null
      && ins.dst[0].mask != ins.dst[1].mask) {
+/*
       Logger::warn("DxbcCompiler: Idiv with different destination masks not supported");
+*/
       return;
     }
     
@@ -2232,10 +2253,10 @@ namespace dxvk {
       
       result = emitDstOperandModifiers(result, ins.modifiers);
       emitRegisterStore(ins.dst[1], result);
-    } else {
+    } /* else {
       // TODO implement this
       Logger::warn("DxbcCompiler: Extended Imul not yet supported");
-    }
+    } */
   }
   
   
@@ -2307,11 +2328,13 @@ namespace dxvk {
           getVectorTypeId(result.type),
           shiftReg.id, countReg.id);
         break;
-      
+
       default:
+/*
         Logger::warn(str::format(
           "DxbcCompiler: Unhandled instruction: ",
           ins.op));
+*/
         return;
     }
     
@@ -2531,11 +2554,13 @@ namespace dxvk {
           pointer.id, scopeId, semanticsId,
           src[0].id);
         break;
-      
+
       default:
+/*
         Logger::warn(str::format(
           "DxbcCompiler: Unhandled instruction: ",
           ins.op));
+*/
         return;
     }
     
@@ -2595,11 +2620,13 @@ namespace dxvk {
         value.id = m_module.opISub(typeId, value.id,
           m_module.constu32(1));
         break;
-      
+
       default:
+/*
         Logger::warn(str::format(
           "DxbcCompiler: Unhandled instruction: ",
           ins.op));
+*/
         return;
     }
 
@@ -2649,7 +2676,7 @@ namespace dxvk {
                       |  spv::MemorySemanticsMakeAvailableMask
                       |  spv::MemorySemanticsMakeVisibleMask;
     }
-    
+
     if (executionScope != spv::ScopeInvocation) {
       m_module.opControlBarrier(
         m_module.constu32(executionScope),
@@ -2659,12 +2686,12 @@ namespace dxvk {
       m_module.opMemoryBarrier(
         m_module.constu32(memoryScope),
         m_module.constu32(memorySemantics));
-    } else {
+    } /* else {
       Logger::warn("DxbcCompiler: sync instruction has no effect");
-    }
+    } */
   }
-  
-  
+
+
   void DxbcCompiler::emitBitExtract(const DxbcShaderInstruction& ins) {
     // ibfe and ubfe take the following arguments:
     //    (dst0) The destination register
@@ -2672,7 +2699,7 @@ namespace dxvk {
     //    (src1) Offset of the bits to extract
     //    (src2) Register to extract bits from
     const bool isSigned = ins.op == DxbcOpcode::IBfe;
-    
+
     DxbcRegisterValue bitCnt = emitRegisterLoad(ins.src[0], ins.dst[0].mask);
     DxbcRegisterValue bitOfs = emitRegisterLoad(ins.src[1], ins.dst[0].mask);
 
@@ -2681,7 +2708,7 @@ namespace dxvk {
     
     if (ins.src[1].type != DxbcOperandType::Imm32)
       bitOfs = emitRegisterMaskBits(bitOfs, 0x1F);
-    
+
     const DxbcRegisterValue src = emitRegisterLoad(ins.src[2], ins.dst[0].mask);
     
     const uint32_t componentCount  = src.type.ccount;
@@ -2772,7 +2799,7 @@ namespace dxvk {
       case DxbcOpcode::FirstBitLo:  dst.id = m_module.opFindILsb(typeId, src.id); break;
       case DxbcOpcode::FirstBitHi:  dst.id = m_module.opFindUMsb(typeId, src.id); break;
       case DxbcOpcode::FirstBitShi: dst.id = m_module.opFindSMsb(typeId, src.id); break;
-      default: Logger::warn(str::format("DxbcCompiler: Unhandled instruction: ", ins.op)); return;
+      default: /* Logger::warn(str::format("DxbcCompiler: Unhandled instruction: ", ins.op)); */ return;
     }
     
     // The 'Hi' variants are counted from the MSB in DXBC
@@ -3350,9 +3377,11 @@ namespace dxvk {
         result.id = m_module.opConvertUtoF(
           getVectorTypeId(result.type), val.id);
         break;
-      
+
       default:
+/*
         Logger::warn(str::format("DxbcCompiler: Unhandled instruction: ", ins.op));
+*/
         return;
     }
     
@@ -3368,15 +3397,17 @@ namespace dxvk {
   void DxbcCompiler::emitHullShaderPhase(const DxbcShaderInstruction& ins) {
     switch (ins.op) {
       case DxbcOpcode::HsDecls: {
+/*
         if (m_hs.currPhaseType != DxbcCompilerHsPhase::None)
           Logger::err("DXBC: HsDecls not the first phase in hull shader");
-        
+*/
+
         m_hs.currPhaseType = DxbcCompilerHsPhase::Decl;
       } break;
-        
+
       case DxbcOpcode::HsControlPointPhase: {
         m_hs.cpPhase = this->emitNewHullShaderControlPointPhase();
-        
+
         m_hs.currPhaseType = DxbcCompilerHsPhase::ControlPoint;
         m_hs.currPhaseId   = 0;
         
@@ -3404,15 +3435,16 @@ namespace dxvk {
         m_module.setDebugName(phase.functionId,
           str::format("hs_join_", m_hs.currPhaseId).c_str());
       } break;
-        
+/*
       default:
         Logger::warn(str::format(
           "DxbcCompiler: Unhandled instruction: ",
           ins.op));
+*/
     }
   }
-  
-  
+
+
   void DxbcCompiler::emitInterpolate(const DxbcShaderInstruction& ins) {
     m_module.enableCapability(spv::CapabilityInterpolationFunction);
 
@@ -3461,11 +3493,13 @@ namespace dxvk {
           m_vRegs.at(registerId).id,
           offset.id);
       } break;
-      
+
       default:
+/*
         Logger::warn(str::format(
           "DxbcCompiler: Unhandled instruction: ",
           ins.op));
+*/
         return;
     }
     
@@ -3943,13 +3977,17 @@ namespace dxvk {
         } break;
 
         default:
+/*
           Logger::warn(str::format(
             "DxbcCompiler: Unhandled instruction: ",
             ins.op));
+*/
           return;
       }
     } else {
+/*
       Logger::warn(str::format("DxbcCompiler: ", ins.op, ": Unsupported image type"));
+*/
       resultId = m_module.constNull(resultTypeId);
     }
 
@@ -4142,13 +4180,17 @@ namespace dxvk {
         } break;
 
         default:
+/*
           Logger::warn(str::format(
             "DxbcCompiler: Unhandled instruction: ",
             ins.op));
+*/
           return;
       }
     } else {
+/*
       Logger::warn(str::format("DxbcCompiler: ", ins.op, ": Unsupported image type"));
+*/
       resultId = m_module.constNull(resultTypeId);
     }
     
@@ -4786,15 +4828,16 @@ namespace dxvk {
         this->emitControlFlowCallc(ins);
         this->emitUavBarrier(-1, -1);
         break;
-
+/*
       default:
         Logger::warn(str::format(
           "DxbcCompiler: Unhandled instruction: ",
           ins.op));
+*/
     }
   }
-  
-  
+
+
   DxbcRegisterValue DxbcCompiler::emitBuildConstVecf32(
           float                   x,
           float                   y,
@@ -5078,7 +5121,7 @@ namespace dxvk {
       value.id, value.id,
       value.id, value.id, 
     }};
-    
+
     DxbcRegisterValue result;
     result.type.ctype  = value.type.ctype;
     result.type.ccount = size;
@@ -5087,40 +5130,40 @@ namespace dxvk {
       size, ids.data());
     return result;
   }
-  
-  
+
+
   DxbcRegisterValue DxbcCompiler::emitRegisterAbsolute(
           DxbcRegisterValue       value) {
     const uint32_t typeId = getVectorTypeId(value.type);
-    
+
     switch (value.type.ctype) {
       case DxbcScalarType::Float32: value.id = m_module.opFAbs(typeId, value.id); break;
       case DxbcScalarType::Float64: value.id = m_module.opFAbs(typeId, value.id); break;
       case DxbcScalarType::Sint32:  value.id = m_module.opSAbs(typeId, value.id); break;
       case DxbcScalarType::Sint64:  value.id = m_module.opSAbs(typeId, value.id); break;
-      default: Logger::warn("DxbcCompiler: Cannot get absolute value for given type");
+      /* default:  Logger::warn("DxbcCompiler: Cannot get absolute value for given type"); */
     }
-    
+
     return value;
   }
-  
-  
+
+
   DxbcRegisterValue DxbcCompiler::emitRegisterNegate(
           DxbcRegisterValue       value) {
     const uint32_t typeId = getVectorTypeId(value.type);
-    
+
     switch (value.type.ctype) {
       case DxbcScalarType::Float32: value.id = m_module.opFNegate(typeId, value.id); break;
       case DxbcScalarType::Float64: value.id = m_module.opFNegate(typeId, value.id); break;
       case DxbcScalarType::Sint32:  value.id = m_module.opSNegate(typeId, value.id); break;
       case DxbcScalarType::Sint64:  value.id = m_module.opSNegate(typeId, value.id); break;
-      default: Logger::warn("DxbcCompiler: Cannot negate given type");
+      /* default:  Logger::warn("DxbcCompiler: Cannot negate given type"); */
     }
-    
+
     return value;
   }
-  
-  
+
+
   DxbcRegisterValue DxbcCompiler::emitRegisterZeroTest(
           DxbcRegisterValue       value,
           DxbcZeroTest            test) {
@@ -6678,10 +6721,11 @@ namespace dxvk {
           ptr, emitRegisterExtract(value, mask),
           DxbcRegMask(true, false, false, false));
       } break;
-      
+/*
       default:
         Logger::warn(str::format(
           "DxbcCompiler: Unhandled VS SV output: ", sv));
+*/
     }
   }
   
@@ -6743,10 +6787,12 @@ namespace dxvk {
       
       emitValueStore(ptr, tessValue,
         DxbcRegMask(true, false, false, false));
-    } else {
+    } /*else {
+
       Logger::warn(str::format(
         "DxbcCompiler: Unhandled HS SV output: ", sv));
-    }
+
+    }*/
   }
   
   
@@ -6780,10 +6826,11 @@ namespace dxvk {
           ptr, emitRegisterExtract(value, mask),
           DxbcRegMask(true, false, false, false));
       } break;
-      
+/*
       default:
         Logger::warn(str::format(
           "DxbcCompiler: Unhandled GS SV output: ", sv));
+*/
     }
   }
   
@@ -6792,11 +6839,13 @@ namespace dxvk {
           DxbcSystemValue         sv,
           DxbcRegMask             mask,
     const DxbcRegisterValue&      value) {
+/*
     Logger::warn(str::format(
       "DxbcCompiler: Unhandled PS SV output: ", sv));
+*/
   }
-  
-  
+
+
   void DxbcCompiler::emitDsSystemValueStore(
           DxbcSystemValue         sv,
           DxbcRegMask             mask,
@@ -6809,27 +6858,28 @@ namespace dxvk {
       case DxbcSystemValue::ViewportId:
         emitVsSystemValueStore(sv, mask, value);
         break;
-      
+/*
       default:
         Logger::warn(str::format(
           "DxbcCompiler: Unhandled DS SV output: ", sv));
+*/
     }
   }
-  
-  
+
+
   void DxbcCompiler::emitClipCullStore(
           DxbcSystemValue         sv,
           uint32_t                dstArray) {
     uint32_t offset = 0;
-    
+
     if (dstArray == 0)
       return;
-    
+
     for (auto e = m_osgn->begin(); e != m_osgn->end(); e++) {
       if (e->systemValue == sv) {
         DxbcRegisterPointer srcPtr = m_oRegs.at(e->registerId);
         DxbcRegisterValue srcValue = emitValueLoad(srcPtr);
-        
+
         for (uint32_t i = 0; i < 4; i++) {
           if (e->componentMask[i]) {
             uint32_t offsetId = m_module.consti32(offset++);

--- a/src/dxbc/dxbc_compiler.cpp
+++ b/src/dxbc/dxbc_compiler.cpp
@@ -949,12 +949,17 @@ namespace dxvk {
     // one, but in practice this should not be much of a problem.
     auto xType = static_cast<DxbcResourceReturnType>(
       bit::extract(ins.imm[0].u32, 0, 3));
+/*
+    // Since DxbcCompiler: dcl_resource: Ignoring resource return types
+    // yType, zType, wType are needed only for logging and, therefore,
+    // can be safely commented out.
     auto yType = static_cast<DxbcResourceReturnType>(
       bit::extract(ins.imm[0].u32, 4, 7));
     auto zType = static_cast<DxbcResourceReturnType>(
       bit::extract(ins.imm[0].u32, 8, 11));
     auto wType = static_cast<DxbcResourceReturnType>(
       bit::extract(ins.imm[0].u32, 12, 15));
+*/
 
 /*
     if ((xType != yType) || (xType != zType) || (xType != wType))

--- a/src/dxbc/dxbc_decoder.cpp
+++ b/src/dxbc/dxbc_decoder.cpp
@@ -80,12 +80,14 @@ namespace dxvk {
   
   void DxbcDecodeContext::decodeCustomData(DxbcCodeSlice code) {
     const uint32_t blockLength = code.at(1);
-    
+
     if (blockLength < 2) {
+/*
       Logger::err("DxbcDecodeContext: Invalid custom data block");
+*/
       return;
     }
-    
+
     // Custom data blocks have their own instruction class
     m_instruction.op      = DxbcOpcode::CustomData;
     m_instruction.opClass = DxbcInstClass::CustomData;
@@ -137,11 +139,12 @@ namespace dxvk {
         case DxbcExtOpcode::ResourceDim:
         case DxbcExtOpcode::ResourceReturnType:
           break;  // part of resource description
-        
+/*
         default:
           Logger::warn(str::format(
             "DxbcDecodeContext: Unhandled extended opcode: ",
             extOpcode));
+*/
       }
     }
     
@@ -198,7 +201,7 @@ namespace dxvk {
               bit::extract(token,  8,  9),
               bit::extract(token, 10, 11));
             break;
-          
+
           // Selection of one component. We can generate both a
           // mask and a swizzle for this so that the compiler
           // won't have to deal with this case specifically.
@@ -207,18 +210,22 @@ namespace dxvk {
             reg.mask    = DxbcRegMask(n == 0, n == 1, n == 2, n == 3);
             reg.swizzle = DxbcRegSwizzle(n, n, n, n);
           } break;
-          
+
+/*
           default:
             Logger::warn("DxbcDecodeContext: Invalid component selection mode");
+*/
         }
       } break;
-          
+
+/*
       default:
         Logger::warn("DxbcDecodeContext: Invalid component count");
+*/
     }
   }
-  
-  
+
+
   void DxbcDecodeContext::decodeOperandExtensions(DxbcCodeSlice& code, DxbcRegister& reg, uint32_t token) {
     while (bit::extract(token, 31, 31)) {
       token = code.read();
@@ -233,11 +240,12 @@ namespace dxvk {
         case DxbcOperandExt::OperandModifier:
           reg.modifiers = bit::extract(token, 6, 13);
           break;
-        
+/*
         default:
           Logger::warn(str::format(
             "DxbcDecodeContext: Unhandled extended operand token: ",
             extTokenType));
+*/
       }
     }
   }
@@ -260,14 +268,16 @@ namespace dxvk {
           reg.imm.u32_4[2] = code.read();
           reg.imm.u32_4[3] = code.read();
         } break;
-
+/*
         default:
           Logger::warn("DxbcDecodeContext: Invalid component count for immediate operand");
+*/
+
       }
     }
   }
-  
-  
+
+
   void DxbcDecodeContext::decodeOperandIndex(DxbcCodeSlice& code, DxbcRegister& reg, uint32_t token) {
     reg.idxDim = bit::extract(token, 20, 21);
     
@@ -300,11 +310,12 @@ namespace dxvk {
             m_indices.at(m_indexId++),
             DxbcScalarType::Sint32);
           break;
-        
+/*
         default:
           Logger::warn(str::format(
             "DxbcDecodeContext: Unhandled index representation: ",
             repr));
+*/
       }
     }
   }

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -5962,8 +5962,10 @@ namespace dxvk {
 
     m_state.om.attachmentMask.clear();
 
+/*
     VkCommandBufferInheritanceRenderingInfo renderingInheritance = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_RENDERING_INFO };
     VkCommandBufferInheritanceInfo inheritance = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_INFO, &renderingInheritance };
+*/
 
     uint32_t colorInfoCount = 0;
     uint32_t lateClearCount = 0;
@@ -5986,9 +5988,9 @@ namespace dxvk {
         colorInfo.imageLayout = colorTarget.view->getLayout();
         colorInfo.loadOp = ops.colorOps[i].loadOp;
         colorInfo.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
-
+/*
         renderingInheritance.rasterizationSamples = colorTarget.view->image()->info().sampleCount;
-
+*/
         if (ops.colorOps[i].loadOp == VK_ATTACHMENT_LOAD_OP_CLEAR) {
           colorInfo.clearValue.color = ops.colorOps[i].clearValue;
 
@@ -6009,7 +6011,9 @@ namespace dxvk {
       }
     }
 
+/*
     VkFormat depthStencilFormat = VK_FORMAT_UNDEFINED;
+*/
     VkImageAspectFlags depthStencilAspects = 0;
     VkImageAspectFlags depthStencilWritable = 0;
 
@@ -6019,7 +6023,9 @@ namespace dxvk {
     const auto& depthTarget = framebufferInfo.getDepthTarget();
 
     if (depthTarget.view) {
+/*
       depthStencilFormat = depthTarget.view->info().format;
+*/
       depthStencilAspects = depthTarget.view->info().aspects;
       depthStencilWritable = vk::getWritableAspectsForLayout(depthTarget.view->info().layout);
 
@@ -6036,8 +6042,10 @@ namespace dxvk {
         depthInfo.clearValue.depthStencil.depth = ops.depthOps.clearValue.depth;
         depthInfo.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
       }
-
+/*
       renderingInheritance.rasterizationSamples = depthTarget.view->image()->info().sampleCount;
+*/
+
     }
 
     auto& stencilInfo = m_state.om.renderingInfo.stencil;
@@ -6063,18 +6071,24 @@ namespace dxvk {
     if (colorInfoCount) {
       renderingInfo.colorAttachmentCount = colorInfoCount;
       renderingInfo.pColorAttachments = m_state.om.renderingInfo.color.data();
+/*
       renderingInheritance.colorAttachmentCount = colorInfoCount;
       renderingInheritance.pColorAttachmentFormats = colorFormats.data();
+*/
     }
 
     if (depthStencilAspects & VK_IMAGE_ASPECT_DEPTH_BIT) {
       renderingInfo.pDepthAttachment = &depthInfo;
+/*
       renderingInheritance.depthAttachmentFormat = depthStencilFormat;
+*/
     }
 
     if (depthStencilAspects & VK_IMAGE_ASPECT_STENCIL_BIT) {
       renderingInfo.pStencilAttachment = &stencilInfo;
+/*
       renderingInheritance.stencilAttachmentFormat = depthStencilFormat;
+*/
     }
 
     // Reset render area tracking, will be adjusted when drawing with viewports.
@@ -6084,19 +6098,16 @@ namespace dxvk {
     if (lateClearCount)
       std::swap(m_state.om.renderAreaLo, m_state.om.renderAreaHi);
 
+/*
     // On drivers that don't natively support secondary command buffers, only use
     // them to enable MSAA resolve attachments. Also ignore render passes with only
     // one color attachment here since those tend to only have a small number of
     // draws and we are almost certainly going to use the output anyway.
-    bool useSecondaryCmdBuffer = !m_device->perfHints().preferPrimaryCmdBufs
-      && renderingInheritance.rasterizationSamples > VK_SAMPLE_COUNT_1_BIT;
+    bool useSecondaryCmdBuffer = false;
 
     if (m_device->perfHints().preferRenderPassOps) {
-      useSecondaryCmdBuffer = renderingInheritance.rasterizationSamples > VK_SAMPLE_COUNT_1_BIT;
-
-      if (!m_device->perfHints().preferPrimaryCmdBufs)
-        useSecondaryCmdBuffer |= depthStencilAspects || colorInfoCount > 1u || !hasMipmappedRt;
-    }
+      useSecondaryCmdBuffer = renderingInheritance.rasterizationSamples > VK_SAMPLE_COUNT_1_BIT
+                           || depthStencilAspects || colorInfoCount > 1u || !hasMipmappedRt;
 
     if (useSecondaryCmdBuffer) {
       // Begin secondary command buffer on tiling GPUs so that subsequent
@@ -6110,6 +6121,10 @@ namespace dxvk {
       // Begin rendering right away on regular GPUs
       m_cmd->cmdBeginRendering(&renderingInfo);
     }
+*/
+
+      // Begin rendering right away on regular GPUs
+      m_cmd->cmdBeginRendering(&renderingInfo);
 
     if (lateClearCount) {
       VkClearRect clearRect = { };

--- a/src/dxvk/dxvk_cs.cpp
+++ b/src/dxvk/dxvk_cs.cpp
@@ -63,44 +63,35 @@ namespace dxvk {
   
   
   DxvkCsChunkPool::~DxvkCsChunkPool() {
-    DxvkCsChunk* chunk = m_stackTop.load();
-
-    while (chunk != nullptr) {
-      DxvkCsChunk* temp = chunk;
-      chunk = chunk->m_nextCached;
-      delete temp;
-    }
+    for (DxvkCsChunk* chunk : m_chunks)
+      delete chunk;
   }
   
   
   DxvkCsChunk* DxvkCsChunkPool::allocChunk(DxvkCsChunkFlags flags) {
-    DxvkCsChunk* stackTop = m_stackTop.load( std::memory_order_acquire );
+    DxvkCsChunk* chunk = nullptr;
 
-    do {
-      if (unlikely(stackTop == nullptr)) {
-        DxvkCsChunk* chunk = new DxvkCsChunk();
-        chunk->init(flags);
-        return chunk;
+    { std::lock_guard<dxvk::mutex> lock(m_mutex);
+      
+      if (m_chunks.size() != 0) {
+        chunk = m_chunks.back();
+        m_chunks.pop_back();
       }
-    } while (!m_stackTop.compare_exchange_weak( stackTop, stackTop->m_nextCached,
-        std::memory_order_release,
-        std::memory_order_acquire));
-
-    stackTop->m_nextCached = nullptr;
-    stackTop->init(flags);
-    return stackTop;
+    }
+    
+    if (!chunk)
+      chunk = new DxvkCsChunk();
+    
+    chunk->init(flags);
+    return chunk;
   }
   
   
   void DxvkCsChunkPool::freeChunk(DxvkCsChunk* chunk) {
     chunk->reset();
-    DxvkCsChunk* stackTop = m_stackTop.load( std::memory_order_acquire );
 
-    do {
-      chunk->m_nextCached = stackTop;
-    } while (!m_stackTop.compare_exchange_weak( stackTop, chunk,
-        std::memory_order_release,
-        std::memory_order_acquire));
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
+    m_chunks.push_back(chunk);
   }
   
   

--- a/src/dxvk/dxvk_cs.h
+++ b/src/dxvk/dxvk_cs.h
@@ -194,7 +194,7 @@ namespace dxvk {
    * Stores a list of commands.
    */
   class DxvkCsChunk : public RcObject {
-  friend class DxvkCsChunkPool;
+
   public:
 
     DxvkCsChunk();
@@ -326,7 +326,6 @@ namespace dxvk {
     DxvkCsCmd** m_next = &m_head;
 
     DxvkCsChunkFlags m_flags;
-    DxvkCsChunk* m_nextCached = nullptr;
 
     alignas(64)
     char m_data[DxvkCsChunkSize];
@@ -389,8 +388,8 @@ namespace dxvk {
     
   private:
 
-    alignas(CACHE_LINE_SIZE)
-    std::atomic<DxvkCsChunk*> m_stackTop = { nullptr };
+    dxvk::mutex               m_mutex;
+    std::vector<DxvkCsChunk*> m_chunks;
 
   };
   

--- a/src/dxvk/dxvk_device.cpp
+++ b/src/dxvk/dxvk_device.cpp
@@ -664,6 +664,7 @@ namespace dxvk {
     hints.preferRenderPassOps = tilerMode;
     hints.preferCachedMemory = tilerMode;
 
+/*
     // Honeykrisp does not have native support for secondary command buffers
     // and would suffer from added CPU overhead, so be less aggressive.
     // TODO: Enable ANV once mesa issue 12791 is resolved.
@@ -671,6 +672,8 @@ namespace dxvk {
     hints.preferPrimaryCmdBufs = m_adapter->matchesDriver(VK_DRIVER_ID_MESA_HONEYKRISP)
                               || m_adapter->matchesDriver(VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA)
                               || m_adapter->matchesDriver(VK_DRIVER_ID_MESA_RADV, Version(), Version(25, 0, 2));
+*/
+
     return hints;
   }
 

--- a/src/dxvk/dxvk_device.h
+++ b/src/dxvk/dxvk_device.h
@@ -39,7 +39,9 @@ namespace dxvk {
     VkBool32 renderPassClearFormatBug   : 1;
     VkBool32 renderPassResolveFormatBug : 1;
     VkBool32 preferRenderPassOps        : 1;
+/*
     VkBool32 preferPrimaryCmdBufs       : 1;
+*/
     VkBool32 preferCachedMemory         : 1;
   };
   

--- a/src/util/sync/sync_ringbuffer_allocator.h
+++ b/src/util/sync/sync_ringbuffer_allocator.h
@@ -35,6 +35,7 @@ namespace dxvk::sync {
         // safe guard, but this allocator is not meant to hit this condition
         if (unlikely(desired.allocCount > size)) {
           checkThrowError(allocTime);
+          expected = m_indices.load();
           continue;
         }
 
@@ -52,10 +53,12 @@ namespace dxvk::sync {
       Indices expected = m_indices.load();
       Indices desired;
 
+/*
       if (unlikely(expected.consumer != index)) {
         Logger::err( str::format( "RingbufferAllocator expected release ",
           expected.consumer, ", got ", index ) );
       }
+*/
 
       do {
         desired = expected;
@@ -63,9 +66,12 @@ namespace dxvk::sync {
         desired.allocCount--;
       } while (!m_indices.compare_exchange_weak( expected, desired ));
 
+/*
       if (unlikely(desired.allocCount < 0)) {
         Logger::err( "RingbufferAllocator allocCount < 0" );
       }
+*/
+
     }
 
     T* getDataUnsafe()


### PR DESCRIPTION
Upstream DXVK commits:

[8b751b0](https://github.com/doitsujin/dxvk/commit/8b751b0b6204196656dd843f4a4d9642dd6d6e33) - [dxvk] Disable secondary command buffers on desktop - Note: GPLALL disables them completely.

[7fedbb7](https://github.com/doitsujin/dxvk/commit/7fedbb7f837d77d0aa032558c8a43c0e5b43a64f) - [d3d8] Properly handle W11V11U10 support

[6c7162f](https://github.com/doitsujin/dxvk/commit/6c7162fb10e1efb6e31e8cc3eb09a4afd6954e88) - [d3d8] Rework legacy D3D compatibility mode handling

[eab8045](https://github.com/doitsujin/dxvk/commit/eab80451253174e2ee16c9ceeaaffd933253b7b2) - [d3d8] Clean up CopyRects logging - [[d3d8] Assorted debug loggers cleanup](https://github.com/doitsujin/dxvk/pull/5817)

[6227b63](https://github.com/doitsujin/dxvk/commit/6227b633e8d528952873c4c146773663964fcb31) - [d3d8] Warn on unhandled tokens in TranslateVertexShader8 - [[d3d8] Assorted debug loggers cleanup](https://github.com/doitsujin/dxvk/pull/5817)

[bee7816](https://github.com/doitsujin/dxvk/commit/bee7816e5cbd07e843799c9a684af2a5fd0c4b76) - [d3d9] Handle D3D9Ex checks with the D3D compatibility flags

DXVK Low Latency commits:

[7f35548](https://github.com/netborg-afps/dxvk-low-latency/commit/7f35548c732dcf456f8660c0efd29003c1f7220f) - [dxvk] Fix edge case in ringbuffer allocator

[e394d0c](https://github.com/netborg-afps/dxvk-low-latency/commit/e394d0c644327056902730cee143b03f2485f47c) - Revert "[dxvk] Optimize DxvkCsChunkPool"