### PR TITLE
Build Improvements-Reduced Logging-Sleep Improvements-SIMD-MSAA Improvements

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -69,7 +69,7 @@ jobs:
 
   merge-artifacts:
     runs-on: ubuntu-latest
-    needs: [artifacts-mingw-w64, artifacts-steamrt-sniper]
+    needs: [artifacts-mingw-w64, artifacts-steamrt4]
     steps:
       - name: Get version
         id: get-version

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -34,10 +34,10 @@ jobs:
         path: build/dxvk-${{ env.VERSION_NAME }}
         if-no-files-found: error
 
-  artifacts-steamrt-sniper:
+  artifacts-steamrt4:
     runs-on: ubuntu-latest
     container: 
-      image: registry.gitlab.steamos.cloud/steamrt/sniper/sdk:beta
+      image: registry.gitlab.steamos.cloud/steamrt/steamrt4/sdk:latest
       options: --user 1001
 
     steps:

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('dxvk', ['c', 'cpp'], version : '2.6.9', meson_version : '>= 0.58', default_options : [ 'cpp_std=c++17', 'b_vscrt=static_from_buildtype', 'warning_level=2' ])
+project('dxvk', ['c', 'cpp'], version : '2.6.9', meson_version : '>= 0.58', default_options : [ 'cpp_std=c++17', 'b_vscrt=static_from_buildtype', 'warning_level=2', 'b_ndebug=true' ])
 
 pkg = import('pkgconfig')
 cpu_family = target_machine.cpu_family()
@@ -10,19 +10,50 @@ cc = meson.get_compiler('c')
 dxvk_is_msvc = cpp.get_argument_syntax() == 'msvc'
 
 compiler_args = [
-  '-O3', # Optimizes for speed. -Os fails to compile due to compiler bug
-  '-pipe', # Enables use of pipes instead of temporary files for communication between the various stages of compilation; faster compilation, uses more memory, no impact on code
-  '-march=x86-64', # SSE2 required
-  '-mtune=x86-64', # Tuning for SSE2 CPUs 
-  '-msse',
-  '-msse2',
-  '-mfpmath=sse',
-  '-fno-semantic-interposition', # Semantic interposition prevents a range of inter-procedural optimizations
-  '-ffunction-sections', # Place each function into its own section, improves locality of reference in the instruction space
-  '-fdata-sections', # Place each data item into its own section, improves locality of reference in the instruction space
-  '-flto=auto', # Enables FullLTO for Clang and GCC
+  '-O3', # Optimizes for speed. -Os fails to compile due to interaction of LTO and -fdeclone-ctor-dtor compiler flag. Use `-O3` as a baseline and add '-Os' compiler flags.
+  '-pipe', # Enables use of pipes instead of temporary files for communication between the various stages of compilation; faster compilation, uses more memory, no impact on code.
+  '-march=x86-64', # Generic CPU with 64-bit extensions, MMX, SSE, SSE2, and FXSR ISA support - SSE2 CPU required.
+  '-mtune=barcelona', # Tuning for CX16, MMX, SSE, SSE2, SSE3, SSE4A, 3DNow!, enhanced 3DNow!, ABM and 64-bit ISA - better tuning, than 'x86-64/k8', even for Intel CPUs.
+  '-msse', # Required for proper enabling '-mfpmath=sse'.
+  '-msse2', # Required for proper enabling '-mfpmath=sse'.
+  '-mfpmath=sse', # Use SSE FP-blocks, instead of x87.
+
+  '-mstackrealign', # Safeguard - Re-align the stack at the start of every function to guarantee the standard stack alignment.
+  '-fwrapv', # Safeguard - Treat signed integer overflow as predictable two's complement wraparound instead of undefined behavior.
+  '-fno-strict-aliasing', # Safeguard - Disables optimizations that rely on the strict aliasing rule (pointers of different types can point to the same memory location).
+
+  '-fno-semantic-interposition', # Perf - Semantic interposition prevents a range of inter-procedural optimizations
+  '-favoid-store-forwarding', # Perf/GCC16 - Restructures code to eliminate pipeline memory stalls, ensuring the CPU doesn't burn idle clock cycles waiting for overlapping memory addresses to clear. 
+  '-flive-range-shrinkage', # Perf - Decrease register pressure through register live range shrinkage.
+
+  '-fira-algorithm=CB', # Perf - Algorithm for the integrated register allocator (IRA). Chaitin-Briggs (CB) generates better code for x86-64 and ARM.
+  '-fira-region=all', # Perf - Use all loops as register allocation regions. Gives the best results for machines with a small register set, such as x86-64.
+  '-fira-hoist-pressure', # Perf/Size - Use IRA to evaluate register pressure in the code hoisting pass for decisions to hoist expressions.
+  '-fira-loop-pressure', # Perf/Size - Use IRA to evaluate register pressure in loops for decisions to move loop invariants.
+
+  '-fipa-pta', # Perf - Interprocedural pointer analysis and interprocedural modification and reference analysis.
+  '-fipa-reorder-for-locality', # Perf/GCC15 - Group call chains in the binary layout to improve code locality and minimize jump distances between frequently called functions.
+
+  '-fsched-pressure', # Perf/Size - Improves the generated code and decreases its size by preventing register pressure increase above the number of available hard registers and subsequent spills in register allocation.
+  '-fsched-spec-load', # Perf - Allow speculative motion of some load instructions.
+
+  '-fgraphite-identity', # Perf - Enables the identity loop transformation within the Graphite loop optimization infrastructure.
+  '-floop-nest-optimize', # Perf - Enables generic loop nest optimizer based on the Pluto optimization algorithms, which calculates a loop structure optimized for data-locality and parallelism.
+  '-ftree-loop-im', # Perf - Perform loop invariant motion on trees.
+  '-ftree-loop-ivcanon', # Perf - Create a canonical counter for number of iterations in loops for which determining number of iterations requires complicated analysis.
+
+  '-fvect-cost-model=cheap', # Perf - Cheap model disables vectorization of loops where doing so would be cost prohibitive.
+
+  '-ftracer', # Perf/Size - Perform tail duplication to enlarge superblock size. This transformation simplifies the control flow of the function allowing other optimizations to do a better job.
+
+  '-flto=auto', # LTO/Perf/Size - Enables FullLTO for Clang and GCC
+  '-ffunction-sections', # LTO/Perf/Size - Place each function into its own section, improves locality of reference in the instruction space
+  '-fdata-sections', # LTO/Perf/Size - Place each data item into its own section, improves locality of reference in the instruction space
+  '-fdevirtualize-at-ltrans', # LTO/Perf/Size - Stream extra information when running LTO - Enables more devirtualization but significantly increases the size of streamed data.
+  '-fext-dce', # LTO/Perf/Size/GCC16 - Perform dead code elimination on zero and sign extensions, with special dataflow analysis.
+
   '-Wimplicit-fallthrough',
-  '-Wno-deprecated', # Silences warnings about use of -mtune=x86-64
+  '-Wno-deprecated', # Silences warnings about use of -mtune=x86-64 and other deprecated flags
   '-Wno-switch', # Silences warnings about an enum value missing in a switch statement; used due to commenting out default sections that are used only for logging.
   # gcc
   '-fuse-linker-plugin', # Enabled by default in newer GCC toolchains
@@ -101,9 +132,11 @@ if platform == 'windows'
         '-Wl,--enable-stdcall-fixup',
         '-Wl,--kill-at',
       ]
-      # Fix stack alignment issues with mingw on 32-bit
+      # Fix stack alignment issues with gcc-mingw on 32-bit
+      # and with llvm-mingw on 32-bit
       compiler_args += [
-        '-mpreferred-stack-boundary=2'
+        '-mpreferred-stack-boundary=2', # GCC-exclusive
+        '-mstack-alignment=4' # Clang-exclusive
       ]
     endif
   else
@@ -118,7 +151,8 @@ if platform == 'windows'
       '/Gw', # Package global data in COMDAT sections for optimization, required for LTCG
       '/Qpar',# Enables automatic parallelization of loops
       '/Qpar-report:1', # Outputs an informational message for loops that are parallelized
-      '/Qvec-report:1' # Outputs an informational message for loops that are vectorized
+      '/Qvec-report:1', # Outputs an informational message for loops that are vectorized
+      '/UndefIntOverflow-' # Treat signed integer overflow as predictable two's complement wraparound instead of undefined behavior
     ]
     # MSVC Linker Options
     link_args += [

--- a/package-release.sh
+++ b/package-release.sh
@@ -72,7 +72,7 @@ function build_arch {
         $opt_strip                                          \
         --bindir "x$1"                                      \
         --libdir "x$1"                                      \
-        -Db_ndebug=if-release                               \
+        -Db_ndebug=true                                     \
         -Dbuild_id=$opt_buildid                             \
         "$DXVK_BUILD_DIR/build.$1"
 

--- a/src/d3d11/d3d11_context.cpp
+++ b/src/d3d11/d3d11_context.cpp
@@ -1351,8 +1351,10 @@ namespace dxvk {
 
     auto shader = static_cast<D3D11VertexShader*>(pVertexShader);
 
+/*
     if (NumClassInstances)
       Logger::err("D3D11: Class instances not supported");
+*/
 
     if (m_state.vs != shader) {
       m_state.vs = shader;

--- a/src/dxgi/dxgi_adapter.cpp
+++ b/src/dxgi/dxgi_adapter.cpp
@@ -110,10 +110,12 @@ namespace dxvk {
       return S_OK;
     }
 
+/*
     if (logQueryInterfaceError(__uuidof(IDXGIAdapter), riid)) {
       Logger::warn("DxgiAdapter::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));
     }
+*/
 
     return E_NOINTERFACE;
   }
@@ -338,7 +340,9 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE DxgiAdapter::RegisterHardwareContentProtectionTeardownStatusEvent(
           HANDLE                        hEvent,
           DWORD*                        pdwCookie) {
+/*
     Logger::err("DxgiAdapter::RegisterHardwareContentProtectionTeardownStatusEvent: Not implemented");
+*/
     return E_NOTIMPL;
   }
 
@@ -368,7 +372,9 @@ namespace dxvk {
 
   void STDMETHODCALLTYPE DxgiAdapter::UnregisterHardwareContentProtectionTeardownStatus(
           DWORD                         dwCookie) {
+/*
     Logger::err("DxgiAdapter::UnregisterHardwareContentProtectionTeardownStatus: Not implemented");
+*/
   }
 
 

--- a/src/dxgi/dxgi_factory.cpp
+++ b/src/dxgi/dxgi_factory.cpp
@@ -126,12 +126,10 @@ namespace dxvk {
       }
     }
 
-/*
     // If any monitors are left on the list, enable the
     // fallback to always enumerate all monitors.
     if ((m_monitorFallback = !monitors.empty()))
       Logger::warn("DXGI: Found monitors not associated with any adapter, using fallback");
-*/
   }
 
 

--- a/src/dxgi/dxgi_factory.cpp
+++ b/src/dxgi/dxgi_factory.cpp
@@ -126,19 +126,21 @@ namespace dxvk {
       }
     }
 
+/*
     // If any monitors are left on the list, enable the
     // fallback to always enumerate all monitors.
     if ((m_monitorFallback = !monitors.empty()))
       Logger::warn("DXGI: Found monitors not associated with any adapter, using fallback");
+*/
   }
-  
-  
+
+
   DxgiFactory::~DxgiFactory() {
     g_dxgiOptions.release();
     g_dxvkInstance.release();
   }
-  
-  
+
+
   HRESULT STDMETHODCALLTYPE DxgiFactory::QueryInterface(REFIID riid, void** ppvObject) {
     if (ppvObject == nullptr)
       return E_POINTER;
@@ -175,10 +177,12 @@ namespace dxvk {
       return S_OK;
     }
 
+/*
     if (logQueryInterfaceError(__uuidof(IDXGIFactory), riid)) {
       Logger::warn("DxgiFactory::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));
     }
+*/
 
     return E_NOINTERFACE;
   }
@@ -186,8 +190,9 @@ namespace dxvk {
   
   HRESULT STDMETHODCALLTYPE DxgiFactory::GetParent(REFIID riid, void** ppParent) {
     InitReturnPtr(ppParent);
-    
+/*
     Logger::warn("DxgiFactory::GetParent: Unknown interface query");
+*/
     return E_NOINTERFACE;
   }
   
@@ -272,8 +277,9 @@ namespace dxvk {
           IDXGIOutput*          pRestrictToOutput,
           IDXGISwapChain1**     ppSwapChain) {
     InitReturnPtr(ppSwapChain);
-    
+/*
     Logger::err("DxgiFactory::CreateSwapChainForCoreWindow: Not implemented");
+*/
     return E_NOTIMPL;
   }
   
@@ -417,13 +423,17 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE DxgiFactory::GetSharedResourceAdapterLuid(
           HANDLE                hResource,
           LUID*                 pLuid) {
+/*
     Logger::err("DxgiFactory::GetSharedResourceAdapterLuid: Not implemented");
+*/
     return E_NOTIMPL;
   }
   
   
   HRESULT STDMETHODCALLTYPE DxgiFactory::MakeWindowAssociation(HWND WindowHandle, UINT Flags) {
+/*
     Logger::warn("DXGI: MakeWindowAssociation: Ignoring flags");
+*/
     return S_OK;
   }
   
@@ -437,7 +447,9 @@ namespace dxvk {
           HWND                  WindowHandle,
           UINT                  wMsg,
           DWORD*                pdwCookie) {
+/*
     Logger::err("DxgiFactory::RegisterOcclusionStatusWindow: Not implemented");
+*/
     return E_NOTIMPL;
   }
   
@@ -445,37 +457,47 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE DxgiFactory::RegisterStereoStatusEvent(
           HANDLE                hEvent,
           DWORD*                pdwCookie) {
+/*
     Logger::err("DxgiFactory::RegisterStereoStatusEvent: Not implemented");
+*/
     return E_NOTIMPL;
   }
-  
-  
+
+
   HRESULT STDMETHODCALLTYPE DxgiFactory::RegisterStereoStatusWindow(
           HWND                  WindowHandle,
           UINT                  wMsg,
           DWORD*                pdwCookie) {
+/*
     Logger::err("DxgiFactory::RegisterStereoStatusWindow: Not implemented");
+*/
     return E_NOTIMPL;
   }
-  
+
 
   HRESULT STDMETHODCALLTYPE DxgiFactory::RegisterOcclusionStatusEvent(
           HANDLE                hEvent,
           DWORD*                pdwCookie) {
+/*
     Logger::err("DxgiFactory::RegisterOcclusionStatusEvent: Not implemented");
+*/
     return E_NOTIMPL;
   }
-  
+
 
   void STDMETHODCALLTYPE DxgiFactory::UnregisterStereoStatus(
           DWORD                 dwCookie) {
+/*
     Logger::err("DxgiFactory::UnregisterStereoStatus: Not implemented");
+*/
   }
-  
-  
+
+
   void STDMETHODCALLTYPE DxgiFactory::UnregisterOcclusionStatus(
           DWORD                 dwCookie) {
+/*
     Logger::err("DxgiFactory::UnregisterOcclusionStatus: Not implemented");
+*/
   }
 
 
@@ -499,7 +521,9 @@ namespace dxvk {
       } return S_OK;
 
       default:
+/*
         Logger::err(str::format("DxgiFactory: CheckFeatureSupport: Unknown feature: ", uint32_t(Feature)));
+*/
         return E_INVALIDARG;
     }
   }
@@ -508,14 +532,18 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE DxgiFactory::RegisterAdaptersChangedEvent(
           HANDLE                hEvent,
           DWORD*                pdwCookie) {
+/*
     Logger::err("DxgiFactory: RegisterAdaptersChangedEvent: Stub");
+*/
     return E_NOTIMPL;
   }
 
 
   HRESULT STDMETHODCALLTYPE DxgiFactory::UnregisterAdaptersChangedEvent(
           DWORD                 Cookie) {
+/*
     Logger::err("DxgiFactory: UnregisterAdaptersChangedEvent: Stub");
+*/
     return E_NOTIMPL;
   }
 

--- a/src/dxgi/dxgi_format.cpp
+++ b/src/dxgi/dxgi_format.cpp
@@ -864,7 +864,9 @@ namespace dxvk {
     if (!CheckImageFormatSupport(device, VK_FORMAT_D24_UNORM_S8_UINT,
           VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT |
           VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT)) {
+/*
       Logger::info("DXGI: VK_FORMAT_D24_UNORM_S8_UINT -> VK_FORMAT_D32_SFLOAT_S8_UINT");
+*/
       RemapDepthFormat(DXGI_FORMAT_R24G8_TYPELESS,        VK_FORMAT_D32_SFLOAT_S8_UINT);
       RemapDepthFormat(DXGI_FORMAT_R24_UNORM_X8_TYPELESS, VK_FORMAT_D32_SFLOAT_S8_UINT);
       RemapDepthFormat(DXGI_FORMAT_X24_TYPELESS_G8_UINT,  VK_FORMAT_D32_SFLOAT_S8_UINT);
@@ -875,7 +877,9 @@ namespace dxvk {
           VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT |
           VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT |
           VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT)) {
+/*
       Logger::info("DXGI: VK_FORMAT_A8_UNORM_KHR -> VK_FORMAT_R8_UNORM");
+*/
       RemapColorFormat(DXGI_FORMAT_A8_UNORM, VK_FORMAT_R8_UNORM, {
           VK_COMPONENT_SWIZZLE_ZERO, VK_COMPONENT_SWIZZLE_ZERO,
           VK_COMPONENT_SWIZZLE_ZERO, VK_COMPONENT_SWIZZLE_R });
@@ -936,8 +940,9 @@ namespace dxvk {
       case DXGI_VK_FORMAT_MODE_RAW:
         return { pMapping->FormatRaw, pMapping->AspectColor };
     }
-    
+/*
     Logger::err("DXGI: GetFormatInfoFromMapping: Internal error");
+*/
     return DXGI_VK_FORMAT_INFO();
   }
 

--- a/src/dxgi/dxgi_main.cpp
+++ b/src/dxgi/dxgi_main.cpp
@@ -23,7 +23,9 @@ namespace dxvk {
 
 extern "C" {
   DLLEXPORT HRESULT __stdcall CreateDXGIFactory2(UINT Flags, REFIID riid, void **ppFactory) {
+/*
     dxvk::Logger::warn("CreateDXGIFactory2: Ignoring flags");
+*/
     return dxvk::createDxgiFactory(Flags, riid, ppFactory);
   }
 

--- a/src/dxgi/dxgi_output.cpp
+++ b/src/dxgi/dxgi_output.cpp
@@ -686,10 +686,8 @@ namespace dxvk {
 
     if (metadata)
       m_metadata = metadata.value();
-/*
     else
       Logger::err("DXGI: Failed to parse display metadata + colorimetry info, using blank.");
-*/
 
     // Normalize either the display metadata we got back, or our
     // blank one to get something sane here.

--- a/src/dxgi/dxgi_output.cpp
+++ b/src/dxgi/dxgi_output.cpp
@@ -62,10 +62,12 @@ namespace dxvk {
       return S_OK;
     }
 
+/*
     if (logQueryInterfaceError(__uuidof(IDXGIOutput), riid)) {
       Logger::warn("DxgiOutput::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));
     }
+*/
 
     return E_NOINTERFACE;
   }
@@ -186,6 +188,7 @@ namespace dxvk {
 
     *pClosestMatch = modes[0];
 
+/*
     Logger::debug(str::format(
       "DXGI: For mode ",
         modeToMatch.Width, "x", modeToMatch.Height, "@",
@@ -193,6 +196,7 @@ namespace dxvk {
       " found closest mode ",
         pClosestMatch->Width, "x", pClosestMatch->Height, "@",
         pClosestMatch->RefreshRate.Denominator ? (pClosestMatch->RefreshRate.Numerator / pClosestMatch->RefreshRate.Denominator) : 0));
+*/
 
     return S_OK;
   }
@@ -364,7 +368,9 @@ namespace dxvk {
 
 
   HRESULT STDMETHODCALLTYPE DxgiOutput::GetDisplaySurfaceData(IDXGISurface* pDestination) {
+/*
     Logger::err("DxgiOutput::GetDisplaySurfaceData: Not implemented");
+*/
     return E_NOTIMPL;
   }
   
@@ -409,30 +415,36 @@ namespace dxvk {
     pGammaCaps->MaxConvertedValue       = 1.0f;
     pGammaCaps->MinConvertedValue       = 0.0f;
     pGammaCaps->NumGammaControlPoints   = DXGI_VK_GAMMA_CP_COUNT;
-    
+
     for (uint32_t i = 0; i < pGammaCaps->NumGammaControlPoints; i++)
       pGammaCaps->ControlPointPositions[i] = GammaControlPointLocation(i);
     return S_OK;
   }
-  
-  
+
+
   void STDMETHODCALLTYPE DxgiOutput::ReleaseOwnership() {
+/*
     Logger::warn("DxgiOutput::ReleaseOwnership: Stub");
+*/
   }
-  
-  
+
+
   HRESULT STDMETHODCALLTYPE DxgiOutput::SetDisplaySurface(IDXGISurface* pScanoutSurface) {
+/*
     Logger::err("DxgiOutput::SetDisplaySurface: Not implemented");
+*/
     return E_NOTIMPL;
   }
 
 
   HRESULT STDMETHODCALLTYPE DxgiOutput::GetDisplaySurfaceData1(IDXGIResource* pDestination) {
+/*
     Logger::err("DxgiOutput::SetDisplaySurface1: Not implemented");
+*/
     return E_NOTIMPL;
   }
-  
-  
+
+
   HRESULT STDMETHODCALLTYPE DxgiOutput::SetGammaControl(const DXGI_GAMMA_CONTROL* pArray) {
     DXGI_VK_MONITOR_DATA* monitorInfo = nullptr;
     HRESULT hr = m_monitorInfo->AcquireMonitorData(m_monitor, &monitorInfo);
@@ -455,11 +467,13 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE DxgiOutput::TakeOwnership(
           IUnknown *pDevice,
           BOOL     Exclusive) {
+/*
     Logger::warn("DxgiOutput::TakeOwnership: Stub");
+*/
     return S_OK;
   }
-  
-  
+
+
   HRESULT STDMETHODCALLTYPE DxgiOutput::WaitForVBlank() {
     static bool s_errorShown = false;
 
@@ -530,7 +544,9 @@ namespace dxvk {
           DXGI_FORMAT EnumFormat,
           IUnknown*   pConcernedDevice,
           UINT*       pFlags) {
+/*
     Logger::warn("DxgiOutput: CheckOverlaySupport: Stub");
+*/
     return DXGI_ERROR_UNSUPPORTED;
   }
 
@@ -540,14 +556,18 @@ namespace dxvk {
           DXGI_COLOR_SPACE_TYPE ColorSpace,
           IUnknown*             pConcernedDevice,
           UINT*                 pFlags) {
+/*
     Logger::warn("DxgiOutput: CheckOverlayColorSpaceSupport: Stub");
+*/
     return DXGI_ERROR_UNSUPPORTED;
   }
   
 
   HRESULT STDMETHODCALLTYPE DxgiOutput::CheckHardwareCompositionSupport(
           UINT*                 pFlags) {
+/*
     Logger::warn("DxgiOutput: CheckHardwareCompositionSupport: Stub");
+*/
 
     *pFlags = 0;
     return S_OK;
@@ -666,8 +686,10 @@ namespace dxvk {
 
     if (metadata)
       m_metadata = metadata.value();
+/*
     else
       Logger::err("DXGI: Failed to parse display metadata + colorimetry info, using blank.");
+*/
 
     // Normalize either the display metadata we got back, or our
     // blank one to get something sane here.

--- a/src/dxgi/dxgi_surface.cpp
+++ b/src/dxgi/dxgi_surface.cpp
@@ -31,10 +31,12 @@ namespace dxvk {
       return S_OK;
     }
 
+/*
     if (logQueryInterfaceError(__uuidof(IDXGIVkSurfaceFactory), riid)) {
       Logger::warn("DxgiSurfaceFactory::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));
     }
+*/
 
     return E_NOINTERFACE;
   }
@@ -64,8 +66,10 @@ namespace dxvk {
 
       ATOM atom = ::RegisterClassExW(&wndClass);
 
+/*
       if (!atom)
         Logger::warn("DxgiSurfaceFactory: Failed to register dummy window class");
+*/
 
       s_wndClassRegistered.store(!!atom, std::memory_order_release);
     }
@@ -73,8 +77,10 @@ namespace dxvk {
     HWND hWnd = ::CreateWindowW(L"DXVKDUMMYWNDCLASS", L"DXVKDUMMYWINDOW",
       WS_OVERLAPPEDWINDOW, 0, 0, 320, 240, nullptr, nullptr, hInstance, nullptr);
 
+/*
     if (!hWnd)
       Logger::err("DxgiSurfaceFactory: Failed to create dummy window");
+*/
 
     return hWnd;
 #else

--- a/src/dxgi/dxgi_swapchain.cpp
+++ b/src/dxgi/dxgi_swapchain.cpp
@@ -97,10 +97,12 @@ namespace dxvk {
       return S_OK;
     }
 
+/*
     if (logQueryInterfaceError(__uuidof(IDXGISwapChain), riid)) {
       Logger::warn("DxgiSwapChain::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));
     }
+*/
 
     return E_NOINTERFACE;
   }
@@ -180,14 +182,18 @@ namespace dxvk {
   
   HRESULT STDMETHODCALLTYPE DxgiSwapChain::GetBackgroundColor(
           DXGI_RGBA*                pColor) {
+/*
     Logger::err("DxgiSwapChain::GetBackgroundColor: Not implemented");
+*/
     return E_NOTIMPL;
   }
   
   
   HRESULT STDMETHODCALLTYPE DxgiSwapChain::GetRotation(
           DXGI_MODE_ROTATION*       pRotation) {
+/*
     Logger::err("DxgiSwapChain::GetRotation: Not implemented");
+*/
     return E_NOTIMPL;
   }
   
@@ -195,8 +201,9 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE DxgiSwapChain::GetRestrictToOutput(
           IDXGIOutput**             ppRestrictToOutput) {
     InitReturnPtr(ppRestrictToOutput);
-    
+/*
     Logger::err("DxgiSwapChain::GetRestrictToOutput: Not implemented");
+*/
     return E_NOTIMPL;
   }
   
@@ -302,8 +309,9 @@ namespace dxvk {
           REFIID                    refiid,
           void**                    ppUnk) {
     InitReturnPtr(ppUnk);
-    
+/*
     Logger::err("DxgiSwapChain::GetCoreWindow: Not implemented");
+*/
     return E_NOTIMPL;
   }
   
@@ -552,7 +560,9 @@ namespace dxvk {
   
   HRESULT STDMETHODCALLTYPE DxgiSwapChain::SetBackgroundColor(
     const DXGI_RGBA*                pColor) {
+/*
     Logger::err("DxgiSwapChain::SetBackgroundColor: Not implemented");
+*/
     return E_NOTIMPL;
   }
   
@@ -562,8 +572,9 @@ namespace dxvk {
 
     if (Rotation == DXGI_MODE_ROTATION_IDENTITY)
       return S_OK;
-
+/*
     Logger::err(str::format("DxgiSwapChain::SetRotation(", Rotation,"): Not implemented"));
+*/
     return E_NOTIMPL;
   }
   
@@ -578,8 +589,10 @@ namespace dxvk {
 
   HRESULT STDMETHODCALLTYPE DxgiSwapChain::GetMatrixTransform(
           DXGI_MATRIX_3X2_F*        pMatrix) {
+/*
     // We don't support composition swap chains
     Logger::err("DxgiSwapChain::GetMatrixTransform: Not supported");
+*/
     return DXGI_ERROR_INVALID_CALL;
   }
 
@@ -607,8 +620,10 @@ namespace dxvk {
   
   HRESULT STDMETHODCALLTYPE DxgiSwapChain::SetMatrixTransform(
     const DXGI_MATRIX_3X2_F*        pMatrix) {
+/*
     // We don't support composition swap chains
     Logger::err("DxgiSwapChain::SetMatrixTransform: Not supported");
+*/
     return DXGI_ERROR_INVALID_CALL;
   }
 

--- a/src/dxgi/dxgi_swapchain_dispatcher.h
+++ b/src/dxgi/dxgi_swapchain_dispatcher.h
@@ -61,10 +61,12 @@ namespace dxvk {
         return S_OK;
       }
 
+/*
       if (logQueryInterfaceError(__uuidof(IDXGISwapChain), riid)) {
         Logger::warn("DxgiSwapChainDispatcher::QueryInterface: Unknown interface query");
         Logger::warn(str::format(riid));
       }
+*/
 
       return m_dispatch->QueryInterface(riid, ppvObject);
     }

--- a/src/dxso/dxso_compiler.cpp
+++ b/src/dxso/dxso_compiler.cpp
@@ -203,7 +203,9 @@ namespace dxvk {
       break;
 
     default:
+/*
       Logger::warn(str::format("DxsoCompiler::processInstruction: unhandled opcode: ", opcode));
+*/
       break;
     }
   }
@@ -2302,7 +2304,9 @@ namespace dxvk {
           typeId, emitRegisterLoad(src[0], mask).id);
         break;
       default:
+/*
         Logger::warn(str::format("DxsoCompiler::emitVectorAlu: unimplemented op ", opcode));
+*/
         return;
     }
 
@@ -2357,7 +2361,9 @@ namespace dxvk {
         componentCount = 4;
         break;
       default:
+/*
         Logger::warn(str::format("DxsoCompiler::emitMatrixAlu: unimplemented op ", opcode));
+*/
         return;
     }
 
@@ -3589,7 +3595,9 @@ void DxsoCompiler::emitControlFlowGenericLoop(
 
     // We generated a bad shader, let's not make it even worse.
     if (positionPtr == 0) {
+/*
       Logger::warn("Shader without Position output. Something is likely wrong here.");
+*/
       return;
     }
 

--- a/src/dxso/dxso_tables.cpp
+++ b/src/dxso/dxso_tables.cpp
@@ -86,7 +86,7 @@ namespace dxvk {
       case DxsoOpcode::SetP: return 3;
       case DxsoOpcode::TexLdl: return 3;
       case DxsoOpcode::BreakP: return 2;
-      default: Logger::warn("DxsoGetDefaultOpcodeLength: unknown opcode to get default length for."); return std::numeric_limits<uint32_t>::max();
+      default: /* Logger::warn("DxsoGetDefaultOpcodeLength: unknown opcode to get default length for."); */ return std::numeric_limits<uint32_t>::max();
     }
   }
 

--- a/src/dxvk/shaders/dxvk_blit_frag_2d_ms.frag
+++ b/src/dxvk/shaders/dxvk_blit_frag_2d_ms.frag
@@ -2,7 +2,7 @@
 
 #extension GL_EXT_control_flow_attributes : enable
 
-layout(set = 0, binding = 0) 
+layout(set = 0, binding = 0)
 uniform sampler2DMSArray s_image_ms;
 
 layout(location = 0) in vec2 i_pos;
@@ -24,22 +24,28 @@ layout(constant_id = 0) const uint c_src_samples = 1;
 layout(constant_id = 1) const uint c_dst_samples = 1;
 layout(constant_id = 2) const uint c_resolve_mode = FILTER_LINEAR;
 
+const float ALPHA_SQ_EPS = 0.0001; // 1e-4
+
+const float WEIGHT_EPS = 1e-5;
+
 void main() {
-  vec2 coord = vec2(p_src_coord0_x, p_src_coord0_y) + 
-               vec2(p_src_coord1_x - p_src_coord0_x, p_src_coord1_y - p_src_coord0_y) * i_pos;
-               
+  vec2 coord = vec2(p_src_coord0_x, p_src_coord0_y)
+             + vec2(p_src_coord1_x - p_src_coord0_x, p_src_coord1_y - p_src_coord0_y) * i_pos;
+
   ivec2 base_coord = ivec2(floor(coord));
 
   if (c_resolve_mode == RESOLVE_AVERAGE) {
     uint sample_count = max(1u, c_src_samples / c_dst_samples);
-    o_color = vec4(0.0f);
+    uint sample_base  = (uint(gl_SampleID) * c_src_samples) / c_dst_samples;
 
+    vec4 accum = vec4(0.0);
     [[unroll]]
-    for (uint i = 0u; i < sample_count; i++) {
-      uint sample_index = (gl_SampleID * c_src_samples) / c_dst_samples + i;
-      o_color += texelFetch(s_image_ms, ivec3(base_coord, gl_Layer), int(sample_index));
+    for (uint i = 0u; i < sample_count; ++i) {
+      uint sample_index = sample_base + i;
+      accum += texelFetch(s_image_ms, ivec3(base_coord, gl_Layer), int(sample_index));
     }
-    o_color /= float(sample_count);
+
+    o_color = accum / float(sample_count);
     return;
   }
 
@@ -49,46 +55,146 @@ void main() {
   ivec2 coord_11 = base_coord + ivec2(1, 1);
 
   vec2 f = fract(coord);
-  vec4 spatial_weights = vec4(
-    (1.0f - f.x) * (1.0f - f.y), // Weight for Top-Left (00)
-    f.x * (1.0f - f.y),          // Weight for Top-Right (10)
-    (1.0f - f.x) * f.y,          // Weight for Bottom-Left (01)
-    f.x * f.y                    // Weight for Bottom-Right (11)
+
+  vec4 spatial_weights_full = vec4(
+    (1.0 - f.x) * (1.0 - f.y), // Weight for Top-Left (00)
+    f.x         * (1.0 - f.y), // Weight for Top-Right (10)
+    (1.0 - f.x) * f.y,         // Weight for Bottom-Left (01)
+    f.x         * f.y          // Weight for Bottom-Right (11)
   );
 
+  bool fx_near_zero = (f.x <= WEIGHT_EPS) || (f.x >= 1.0 - WEIGHT_EPS);
+  bool fy_near_zero = (f.y <= WEIGHT_EPS) || (f.y >= 1.0 - WEIGHT_EPS);
+  bool onBoundary   = (fx_near_zero || fy_near_zero);
+
   if (c_resolve_mode == FILTER_NEAREST) {
-    spatial_weights = vec4(1.0f, 0.0f, 0.0f, 0.0f);
-  }
+    vec4 accumulated_color = vec4(0.0);
+    float total_weight = 0.0;
 
-  vec4 accumulated_color = vec4(0.0f);
-  float total_weight = 0.0f;
+    [[unroll]]
+    for (uint s = 0u; s < c_src_samples; ++s) {
+      int sample_idx = int(s);
 
-  [[unroll]]
-  for (uint s = 0u; s < c_src_samples; s++) {
-    int sample_idx = int(s);
+      vec4 c00 = texelFetch(s_image_ms, ivec3(coord_00, gl_Layer), sample_idx);
 
-    vec4 c00 = texelFetch(s_image_ms, ivec3(coord_00, gl_Layer), sample_idx);
-    vec4 c10 = texelFetch(s_image_ms, ivec3(coord_10, gl_Layer), sample_idx);
-    vec4 c01 = texelFetch(s_image_ms, ivec3(coord_01, gl_Layer), sample_idx);
-    vec4 c11 = texelFetch(s_image_ms, ivec3(coord_11, gl_Layer), sample_idx);
+      float alpha_sq_sum = c00.a * c00.a;
+      if (alpha_sq_sum <= ALPHA_SQ_EPS) continue;
 
-    vec4 gathered_alphas = vec4(c00.a, c10.a, c01.a, c11.a);
-
-    if (dot(gathered_alphas, gathered_alphas) <= 0.0001f) {
-      continue;
+      float w00 = 1.0 * c00.a;
+      accumulated_color += c00 * w00;
+      total_weight += w00;
     }
 
-    vec4 final_weights = spatial_weights * gathered_alphas;
-
-    accumulated_color += c00 * final_weights.x;
-    accumulated_color += c10 * final_weights.y;
-    accumulated_color += c01 * final_weights.z;
-    accumulated_color += c11 * final_weights.w;
-
-    total_weight += dot(final_weights, vec4(1.0f));
+    if (total_weight > 0.0) {
+      o_color = accumulated_color / total_weight;
+    } else {
+      o_color = texelFetch(s_image_ms, ivec3(base_coord, gl_Layer), 0);
+    }
+    return;
   }
 
-  if (total_weight > 0.0f) {
+  vec4 spatial_weights;
+  if (onBoundary) {
+    float fx = f.x;
+    float fy = f.y;
+    float fx_c = (fx <= WEIGHT_EPS) ? 0.0 : (fx >= 1.0 - WEIGHT_EPS ? 1.0 : fx);
+    float fy_c = (fy <= WEIGHT_EPS) ? 0.0 : (fy >= 1.0 - WEIGHT_EPS ? 1.0 : fy);
+
+    spatial_weights = vec4(
+      (1.0 - fx_c) * (1.0 - fy_c), // Weight for Top-Left (00)
+      fx_c         * (1.0 - fy_c), // Weight for Top-Right (10)
+      (1.0 - fx_c) * fy_c,         // Weight for Bottom-Left (01)
+      fx_c         * fy_c          // Weight for Bottom-Right (11)
+    );
+  } else {
+    spatial_weights = spatial_weights_full;
+  }
+
+  // Build fetch mask once per fragment (bit0 = 00, bit1 = 10, bit2 = 01, bit3 = 11)
+  uint mask = 0u;
+  if (spatial_weights.x > WEIGHT_EPS) mask |= 1u;
+  if (spatial_weights.y > WEIGHT_EPS) mask |= 2u;
+  if (spatial_weights.z > WEIGHT_EPS) mask |= 4u;
+  if (spatial_weights.w > WEIGHT_EPS) mask |= 8u;
+
+  vec4 accumulated_color = vec4(0.0);
+  float total_weight = 0.0;
+
+  // Specialized handling for the common masks: {1,3,5}
+  // - 1: only top-left (00)
+  // - 3: top row (00 + 10)
+  // - 5: left column (00 + 01)
+  // Default: fallback to full-4 fetch inner loop which covers mask==15 and others.
+  switch (mask) {
+    case 1u: { // 00 (top-left)
+      [[unroll]]
+      for (uint s = 0u; s < c_src_samples; ++s) {
+        int sample_idx = int(s);
+        vec4 c00 = texelFetch(s_image_ms, ivec3(coord_00, gl_Layer), sample_idx);
+        float alpha_sq_sum = c00.a * c00.a;
+        if (alpha_sq_sum <= ALPHA_SQ_EPS) continue;
+        float w00 = spatial_weights.x * c00.a;
+        accumulated_color += c00 * w00;
+        total_weight += w00;
+      }
+    } break;
+
+    case 3u: { // 00 + 10 (top row)
+      [[unroll]]
+      for (uint s = 0u; s < c_src_samples; ++s) {
+        int sample_idx = int(s);
+        vec4 c00 = texelFetch(s_image_ms, ivec3(coord_00, gl_Layer), sample_idx);
+        vec4 c10 = texelFetch(s_image_ms, ivec3(coord_10, gl_Layer), sample_idx);
+        float alpha_sq_sum = c00.a*c00.a + c10.a*c10.a;
+        if (alpha_sq_sum <= ALPHA_SQ_EPS) continue;
+        float w00 = spatial_weights.x * c00.a;
+        float w10 = spatial_weights.y * c10.a;
+        accumulated_color += c00 * w00;
+        accumulated_color += c10 * w10;
+        total_weight += (w00 + w10);
+      }
+    } break;
+
+    case 5u: { // 00 + 01 (left column)
+      [[unroll]]
+      for (uint s = 0u; s < c_src_samples; ++s) {
+        int sample_idx = int(s);
+        vec4 c00 = texelFetch(s_image_ms, ivec3(coord_00, gl_Layer), sample_idx);
+        vec4 c01 = texelFetch(s_image_ms, ivec3(coord_01, gl_Layer), sample_idx);
+        float alpha_sq_sum = c00.a*c00.a + c01.a*c01.a;
+        if (alpha_sq_sum <= ALPHA_SQ_EPS) continue;
+        float w00 = spatial_weights.x * c00.a;
+        float w01 = spatial_weights.z * c01.a;
+        accumulated_color += c00 * w00;
+        accumulated_color += c01 * w01;
+        total_weight += (w00 + w01);
+      }
+    } break;
+
+    default: { // fallback to full-4 fetch inner loop which covers mask==15 and others.
+      [[unroll]]
+      for (uint s = 0u; s < c_src_samples; ++s) {
+        int sample_idx = int(s);
+        vec4 c00 = texelFetch(s_image_ms, ivec3(coord_00, gl_Layer), sample_idx);
+        vec4 c10 = texelFetch(s_image_ms, ivec3(coord_10, gl_Layer), sample_idx);
+        vec4 c01 = texelFetch(s_image_ms, ivec3(coord_01, gl_Layer), sample_idx);
+        vec4 c11 = texelFetch(s_image_ms, ivec3(coord_11, gl_Layer), sample_idx);
+        float alpha_sq_sum = c00.a*c00.a + c10.a*c10.a + c01.a*c01.a + c11.a*c11.a;
+        if (alpha_sq_sum <= ALPHA_SQ_EPS) continue;
+        float w00 = spatial_weights.x * c00.a;
+        float w10 = spatial_weights.y * c10.a;
+        float w01 = spatial_weights.z * c01.a;
+        float w11 = spatial_weights.w * c11.a;
+        accumulated_color += c00 * w00;
+        accumulated_color += c10 * w10;
+        accumulated_color += c01 * w01;
+        accumulated_color += c11 * w11;
+        total_weight += (w00 + w10 + w01 + w11);
+      }
+    } break;
+  }
+
+  if (total_weight > 0.0) {
     o_color = accumulated_color / total_weight;
   } else {
     o_color = texelFetch(s_image_ms, ivec3(base_coord, gl_Layer), 0);

--- a/src/util/sync/sync_atomic_signal.h
+++ b/src/util/sync/sync_atomic_signal.h
@@ -10,7 +10,7 @@
 #include "../log/log.h"
 
 //#define _atomic_signal_debug(x) Logger::debug(x)
-#define _atomic_signal_debug(x) void()
+//#define _atomic_signal_debug(x) void()
 
 namespace dxvk::sync {
 
@@ -29,7 +29,9 @@ namespace dxvk::sync {
     ~AtomicSignal() {}
 
     void wait() {
+/*
       _atomic_signal_debug( std::string("enter wait for ") + m_name );
+*/
 
       while (true) {
 
@@ -45,31 +47,40 @@ namespace dxvk::sync {
           Logger::err(str::format("WaitOnAddress failed. LastError: ", GetLastError()));
 
       }
-
+/*
       _atomic_signal_debug( std::string("finish wait for ") + m_name );
+*/
     }
 
     void signal_one() {
+/*
       _atomic_signal_debug( std::string("enter signal_one for ") + m_name );
-
+*/
       bool _false = 0;
       if (m_flag.compare_exchange_strong(_false, true, std::memory_order_release, std::memory_order_acquire))
         WakeByAddressSingle(&m_flag);
 
+/*
       _atomic_signal_debug( std::string("finish signal_one for ") + m_name );
+*/
     }
 
     void signal_all() {
+/*
       _atomic_signal_debug( std::string("enter signal_all for ") + m_name );
-
+*/
       m_flag.store(true, std::memory_order_release);
       WakeByAddressAll(&m_flag);
 
+/*
       _atomic_signal_debug( std::string("finish signal_all for ") + m_name );
+*/
     }
 
     void clear() {
+/*
       _atomic_signal_debug( std::string("clear flag for ") + m_name );
+*/
       m_flag.store(false, std::memory_order_release);
     }
 
@@ -153,6 +164,7 @@ namespace dxvk::sync {
 
         if (unlikely(s == -1))
           Logger::err("futex-FUTEX_WAKE");
+
       }
 
     }

--- a/src/util/util_math.h
+++ b/src/util/util_math.h
@@ -2,9 +2,24 @@
 
 #include <cmath>
 
+#if defined(__SSE2__)
+  #include <emmintrin.h>
+#endif
+
 namespace dxvk {
-  
+
+  /*
+  IMPORTANT: 
+  1. Use unaligned loads/stores (_mm_loadu_ps/_mm_storeu_ps) for safety,
+  because Matrix4/Vector4 may be placed in memory without guaranteed
+  16-byte alignment in all places (mapped buffers, packed structs, etc).
+  2. DO NOT USE alignas(16), because with a Windows target platform, 
+  GCC will just not align rsp at all and silently generate code that can explode at any time.
+  Info: https://github.com/doitsujin/dxvk/pull/4448
+  */
+
   constexpr size_t CACHE_LINE_SIZE = 64;
+
   constexpr double pi = 3.14159265359;
 
   template<typename T>
@@ -13,7 +28,7 @@ namespace dxvk {
     if (n > hi) return hi;
     return n;
   }
-  
+
   template<typename T, typename U = T>
   constexpr T align(T what, U to) {
     return (what + to - 1) & ~(to - 1);
@@ -27,9 +42,23 @@ namespace dxvk {
   // Equivalent of std::clamp for use with floating point numbers
   // Handles (-){INFINITY,NAN} cases.
   // Will return min in cases of NAN, etc.
-  inline float fclamp(float value, float min, float max) {
-    return std::fmin(
-      std::fmax(value, min), max);
+  [[nodiscard]] inline float fclamp(float value, float min, float max) {
+  #if defined(__SSE2__)
+
+    __m128 v  = _mm_set_ss(value);
+    __m128 mn = _mm_set_ss(min);
+    __m128 mx = _mm_set_ss(max);
+
+    v = _mm_max_ss(v, mn);
+    v = _mm_min_ss(v, mx);
+
+    float result;
+    _mm_store_ss(&result, v);
+    return result;
+  #else
+
+    return std::fmin(std::fmax(value, min), max);
+  #endif
   }
 
   template<typename T>

--- a/src/util/util_matrix.cpp
+++ b/src/util/util_matrix.cpp
@@ -1,6 +1,311 @@
 #include "util_matrix.h"
 
+#include <cmath>
+#include <limits>
+
+#if defined(__SSE4_1__) || defined(__SSE2__)
+  #include <emmintrin.h> // SSE2
+#endif
+#if defined(__SSE4_1__)
+  #include <smmintrin.h> // SSE4.1 (for _mm_dp_ps)
+#endif
+
 namespace dxvk {
+
+#if defined(__SSE2__)
+
+  /*
+  IMPORTANT: 
+  1. Use unaligned loads/stores (_mm_loadu_ps/_mm_storeu_ps) for safety,
+  because Matrix4/Vector4 may be placed in memory without guaranteed
+  16-byte alignment in all places (mapped buffers, packed structs, etc).
+  2. DO NOT USE alignas(16), because with a Windows target platform, 
+  GCC will just not align rsp at all and silently generate code that can explode at any time.
+  Info: https://github.com/doitsujin/dxvk/pull/4448
+  */
+
+  Vector4& Matrix4::operator[](size_t index)       { return data[index]; }
+  const Vector4& Matrix4::operator[](size_t index) const { return data[index]; }
+
+  bool Matrix4::operator==(const Matrix4& m2) const {
+  #if defined(__SSE4_1__)
+    __m128i r0 = _mm_castps_si128(_mm_cmpeq_ps(_mm_loadu_ps(&data[0].x), _mm_loadu_ps(&m2.data[0].x)));
+    __m128i r1 = _mm_castps_si128(_mm_cmpeq_ps(_mm_loadu_ps(&data[1].x), _mm_loadu_ps(&m2.data[1].x)));
+    __m128i r2 = _mm_castps_si128(_mm_cmpeq_ps(_mm_loadu_ps(&data[2].x), _mm_loadu_ps(&m2.data[2].x)));
+    __m128i r3 = _mm_castps_si128(_mm_cmpeq_ps(_mm_loadu_ps(&data[3].x), _mm_loadu_ps(&m2.data[3].x)));
+
+    __m128i and01 = _mm_and_si128(r0, r1);
+    __m128i and23 = _mm_and_si128(r2, r3);
+    __m128i final_mask = _mm_and_si128(and01, and23);
+
+    return _mm_movemask_ps(_mm_castsi128_ps(final_mask)) == 0xF;
+  #else
+    for (uint32_t i = 0; i < 4; i++) {
+      __m128 r1 = _mm_loadu_ps(&data[i].x);
+      __m128 r2 = _mm_loadu_ps(&m2.data[i].x);
+      if (_mm_movemask_ps(_mm_cmpeq_ps(r1, r2)) != 0xF)
+        return false;
+    }
+    return true;
+  #endif
+  }
+
+  bool Matrix4::operator!=(const Matrix4& m2) const { return !operator==(m2); }
+
+  Matrix4 Matrix4::operator+(const Matrix4& other) const {
+    Matrix4 mat;
+    for (uint32_t i = 0; i < 4; i++) {
+      _mm_storeu_ps(&mat.data[i].x, _mm_add_ps(_mm_loadu_ps(&data[i].x), _mm_loadu_ps(&other.data[i].x)));
+    }
+    return mat;
+  }
+
+  Matrix4 Matrix4::operator-(const Matrix4& other) const {
+    Matrix4 mat;
+    for (uint32_t i = 0; i < 4; i++) {
+      _mm_storeu_ps(&mat.data[i].x, _mm_sub_ps(_mm_loadu_ps(&data[i].x), _mm_loadu_ps(&other.data[i].x)));
+    }
+    return mat;
+  }
+
+  Matrix4 Matrix4::operator*(const Matrix4& m2) const {
+    Matrix4 result;
+
+    __m128 colA0 = _mm_loadu_ps(&data[0].x);
+    __m128 colA1 = _mm_loadu_ps(&data[1].x);
+    __m128 colA2 = _mm_loadu_ps(&data[2].x);
+    __m128 colA3 = _mm_loadu_ps(&data[3].x);
+
+    for (uint32_t i = 0; i < 4; i++) {
+      __m128 colB = _mm_loadu_ps(&m2.data[i].x);
+
+      __m128 b0 = _mm_shuffle_ps(colB, colB, _MM_SHUFFLE(0, 0, 0, 0));
+      __m128 b1 = _mm_shuffle_ps(colB, colB, _MM_SHUFFLE(1, 1, 1, 1));
+      __m128 b2 = _mm_shuffle_ps(colB, colB, _MM_SHUFFLE(2, 2, 2, 2));
+      __m128 b3 = _mm_shuffle_ps(colB, colB, _MM_SHUFFLE(3, 3, 3, 3));
+
+      __m128 v0 = _mm_mul_ps(colA0, b0);
+      __m128 v1 = _mm_mul_ps(colA1, b1);
+      __m128 v2 = _mm_mul_ps(colA2, b2);
+      __m128 v3 = _mm_mul_ps(colA3, b3);
+
+      __m128 sum01 = _mm_add_ps(v0, v1);
+      __m128 sum23 = _mm_add_ps(v2, v3);
+      __m128 sum = _mm_add_ps(sum01, sum23);
+
+      _mm_storeu_ps(&result.data[i].x, sum);
+    }
+
+    return result;
+  }
+
+  Vector4 Matrix4::operator*(const Vector4& v) const {
+    Vector4 result;
+    __m128 vec = _mm_loadu_ps(&v.x);
+
+  #if defined(__SSE4_1__)
+    __m128 row0 = _mm_loadu_ps(&data[0].x);
+    __m128 row1 = _mm_loadu_ps(&data[1].x);
+    __m128 row2 = _mm_loadu_ps(&data[2].x);
+    __m128 row3 = _mm_loadu_ps(&data[3].x);
+
+    float x = _mm_cvtss_f32(_mm_dp_ps(row0, vec, 0xF1));
+    float y = _mm_cvtss_f32(_mm_dp_ps(row1, vec, 0xF1));
+    float z = _mm_cvtss_f32(_mm_dp_ps(row2, vec, 0xF1));
+    float w = _mm_cvtss_f32(_mm_dp_ps(row3, vec, 0xF1));
+
+    result.x = x; result.y = y; result.z = z; result.w = w;
+  #else
+    __m128 e0 = _mm_shuffle_ps(vec, vec, _MM_SHUFFLE(0, 0, 0, 0));
+    __m128 e1 = _mm_shuffle_ps(vec, vec, _MM_SHUFFLE(1, 1, 1, 1));
+    __m128 e2 = _mm_shuffle_ps(vec, vec, _MM_SHUFFLE(2, 2, 2, 2));
+    __m128 e3 = _mm_shuffle_ps(vec, vec, _MM_SHUFFLE(3, 3, 3, 3));
+
+    __m128 row0 = _mm_loadu_ps(&data[0].x);
+    __m128 row1 = _mm_loadu_ps(&data[1].x);
+    __m128 row2 = _mm_loadu_ps(&data[2].x);
+    __m128 row3 = _mm_loadu_ps(&data[3].x);
+
+    __m128 v0 = _mm_mul_ps(e0, row0);
+    __m128 v1 = _mm_mul_ps(e1, row1);
+    __m128 v2 = _mm_mul_ps(e2, row2);
+    __m128 v3 = _mm_mul_ps(e3, row3);
+
+    __m128 sum01 = _mm_add_ps(v0, v1);
+    __m128 sum23 = _mm_add_ps(v2, v3);
+    _mm_storeu_ps(&result.x, _mm_add_ps(sum01, sum23));
+  #endif
+
+    return result;
+  }
+
+  Matrix4 Matrix4::operator*(float scalar) const {
+    Matrix4 result;
+    __m128 s = _mm_set1_ps(scalar);
+    for (uint32_t i = 0; i < 4; i++) {
+      _mm_storeu_ps(&result.data[i].x, _mm_mul_ps(_mm_loadu_ps(&data[i].x), s));
+    }
+    return result;
+  }
+
+  Matrix4 Matrix4::operator/(float scalar) const {
+    return (*this) * (1.0f / scalar);
+  }
+
+  Matrix4 hadamardProduct(const Matrix4& a, const Matrix4& b) {
+    Matrix4 result;
+    for (uint32_t i = 0; i < 4; i++) {
+      _mm_storeu_ps(&result.data[i].x, _mm_mul_ps(_mm_loadu_ps(&a.data[i].x), _mm_loadu_ps(&b.data[i].x)));
+    }
+    return result;
+  }
+
+  Matrix4& Matrix4::operator+=(const Matrix4& other) {
+    for (uint32_t i = 0; i < 4; i++) {
+      _mm_storeu_ps(&data[i].x, _mm_add_ps(_mm_loadu_ps(&data[i].x), _mm_loadu_ps(&other.data[i].x)));
+    }
+    return *this;
+  }
+
+  Matrix4& Matrix4::operator-=(const Matrix4& other) {
+    for (uint32_t i = 0; i < 4; i++) {
+      _mm_storeu_ps(&data[i].x, _mm_sub_ps(_mm_loadu_ps(&data[i].x), _mm_loadu_ps(&other.data[i].x)));
+    }
+    return *this;
+  }
+
+  Matrix4& Matrix4::operator*=(const Matrix4& other) {
+    *this = (*this) * other;
+    return *this;
+  }
+
+  Matrix4 transpose(const Matrix4& m) {
+    Matrix4 result;
+    __m128 r0 = _mm_loadu_ps(&m.data[0].x);
+    __m128 r1 = _mm_loadu_ps(&m.data[1].x);
+    __m128 r2 = _mm_loadu_ps(&m.data[2].x);
+    __m128 r3 = _mm_loadu_ps(&m.data[3].x);
+
+    __m128 t0 = _mm_unpacklo_ps(r0, r1);
+    __m128 t1 = _mm_unpackhi_ps(r0, r1);
+    __m128 t2 = _mm_unpacklo_ps(r2, r3);
+    __m128 t3 = _mm_unpackhi_ps(r2, r3);
+
+    _mm_storeu_ps(&result.data[0].x, _mm_movelh_ps(t0, t2));
+    _mm_storeu_ps(&result.data[1].x, _mm_movehl_ps(t2, t0));
+    _mm_storeu_ps(&result.data[2].x, _mm_movelh_ps(t1, t3));
+    _mm_storeu_ps(&result.data[3].x, _mm_movehl_ps(t3, t1));
+
+    return result;
+  }
+
+  float determinant(const Matrix4& m) {
+    __m128 r0 = _mm_loadu_ps(&m.data[0].x);
+    __m128 r1 = _mm_loadu_ps(&m.data[1].x);
+    __m128 r2 = _mm_loadu_ps(&m.data[2].x);
+    __m128 r3 = _mm_loadu_ps(&m.data[3].x);
+
+    __m128 r2_wzx_y = _mm_shuffle_ps(r2, r2, _MM_SHUFFLE(1, 0, 2, 3));
+    __m128 r3_zwy_x = _mm_shuffle_ps(r3, r3, _MM_SHUFFLE(0, 1, 3, 2));
+    __m128 r2_wzy_x = _mm_shuffle_ps(r2, r2, _MM_SHUFFLE(0, 1, 2, 3));
+    __m128 r3_zwx_y = _mm_shuffle_ps(r3, r3, _MM_SHUFFLE(1, 0, 3, 2));
+
+    __m128 sub_cofactors = _mm_sub_ps(_mm_mul_ps(r2_wzx_y, r3_zwy_x), _mm_mul_ps(r2_wzy_x, r3_zwx_y));
+
+    __m128 c5 = _mm_shuffle_ps(sub_cofactors, sub_cofactors, _MM_SHUFFLE(0, 0, 0, 0));
+    __m128 c4 = _mm_shuffle_ps(sub_cofactors, sub_cofactors, _MM_SHUFFLE(1, 1, 1, 1));
+    __m128 c3 = _mm_shuffle_ps(sub_cofactors, sub_cofactors, _MM_SHUFFLE(2, 2, 2, 2));
+
+    __m128 r1_yxx_w = _mm_shuffle_ps(r1, r1, _MM_SHUFFLE(3, 0, 0, 1));
+    __m128 r1_zzy_z = _mm_shuffle_ps(r1, r1, _MM_SHUFFLE(2, 1, 2, 2));
+    __m128 r1_www_x = _mm_shuffle_ps(r1, r1, _MM_SHUFFLE(0, 3, 3, 3));
+
+    __m128 cofactors = _mm_sub_ps(_mm_mul_ps(r1_yxx_w, c5), _mm_mul_ps(r1_zzy_z, c4));
+    cofactors = _mm_add_ps(cofactors, _mm_mul_ps(r1_www_x, c3));
+
+    __m128 det_vec;
+  #if defined(__SSE4_1__)
+    det_vec = _mm_dp_ps(r0, cofactors, 0xF1);
+  #else
+    __m128 mul_rows = _mm_mul_ps(r0, cofactors);
+    __m128 shuf = _mm_shuffle_ps(mul_rows, mul_rows, _MM_SHUFFLE(1, 0, 3, 2));
+    __m128 sums = _mm_add_ps(mul_rows, shuf);
+    shuf = _mm_shuffle_ps(sums, sums, _MM_SHUFFLE(2, 3, 0, 1));
+    det_vec = _mm_add_ps(sums, shuf);
+  #endif
+
+    float det;
+    _mm_store_ss(&det, det_vec);
+    return det;
+  }
+
+  std::optional<Matrix4> tryInverse(const Matrix4& m) {
+    float coef00    = m[2][2] * m[3][3] - m[3][2] * m[2][3];
+    float coef02    = m[1][2] * m[3][3] - m[3][2] * m[1][3];
+    float coef03    = m[1][2] * m[2][3] - m[2][2] * m[1][3];
+    float coef04    = m[2][1] * m[3][3] - m[3][1] * m[2][3];
+    float coef06    = m[1][1] * m[3][3] - m[3][1] * m[1][3];
+    float coef07    = m[1][1] * m[2][3] - m[2][1] * m[1][3];
+    float coef08    = m[2][1] * m[3][2] - m[3][1] * m[2][2];
+    float coef10    = m[1][1] * m[3][2] - m[3][1] * m[1][2];
+    float coef11    = m[1][1] * m[2][2] - m[2][1] * m[1][2];
+    float coef12    = m[2][0] * m[3][3] - m[3][0] * m[2][3];
+    float coef14    = m[1][0] * m[3][3] - m[3][0] * m[1][3];
+    float coef15    = m[1][0] * m[2][3] - m[2][0] * m[1][3];
+    float coef16    = m[2][0] * m[3][2] - m[3][0] * m[2][2];
+    float coef18    = m[1][0] * m[3][2] - m[3][0] * m[1][2];
+    float coef19    = m[1][0] * m[2][2] - m[2][0] * m[1][2];
+    float coef20    = m[2][0] * m[3][1] - m[3][0] * m[2][1];
+    float coef22    = m[1][0] * m[3][1] - m[3][0] * m[1][1];
+    float coef23    = m[1][0] * m[2][1] - m[2][0] * m[1][1];
+
+    Vector4 fac0    = { coef00, coef00, coef02, coef03 };
+    Vector4 fac1    = { coef04, coef04, coef06, coef07 };
+    Vector4 fac2    = { coef08, coef08, coef10, coef11 };
+    Vector4 fac3    = { coef12, coef12, coef14, coef15 };
+    Vector4 fac4    = { coef16, coef16, coef18, coef19 };
+    Vector4 fac5    = { coef20, coef20, coef22, coef23 };
+
+    Vector4 vec0    = { m[1][0], m[0][0], m[0][0], m[0][0] };
+    Vector4 vec1    = { m[1][1], m[0][1], m[0][1], m[0][1] };
+    Vector4 vec2    = { m[1][2], m[0][2], m[0][2], m[0][2] };
+    Vector4 vec3    = { m[1][3], m[0][3], m[0][3], m[0][3] };
+
+    Vector4 inv0    = { vec1 * fac0 - vec2 * fac1 + vec3 * fac2 };
+    Vector4 inv1    = { vec0 * fac0 - vec2 * fac3 + vec3 * fac4 };
+    Vector4 inv2    = { vec0 * fac1 - vec1 * fac3 + vec3 * fac5 };
+    Vector4 inv3    = { vec0 * fac2 - vec1 * fac4 + vec2 * fac5 };
+
+    Vector4 signA   = { +1, -1, +1, -1 };
+    Vector4 signB   = { -1, +1, -1, +1 };
+    Matrix4 inverse = { inv0 * signA, inv1 * signB, inv2 * signA, inv3 * signB };
+
+    Vector4 row0    = { inverse[0][0], inverse[1][0], inverse[2][0], inverse[3][0] };
+
+    Vector4 dot0    = { m[0] * row0 };
+    float dot1      = (dot0.x + dot0.y) + (dot0.z + dot0.w);
+
+    if (unlikely(std::abs(dot1) <= std::numeric_limits<float>::min() * 10))
+      return std::nullopt;
+
+    return std::make_optional(inverse * (1.0f / dot1));
+  }
+
+  Matrix4 inverse(const Matrix4& m) {
+    return tryInverse(m).value_or(m);
+  }
+
+  std::ostream& operator<<(std::ostream& os, const Matrix4& m) {
+    os << "Matrix4(";
+    for (uint32_t i = 0; i < 4; i++) {
+      os << "\n\t" << m[i];
+      if (i < 3) os << ", ";
+    }
+    os << "\n)";
+    return os;
+  }
+
+#else
 
         Vector4& Matrix4::operator[](size_t index)       { return data[index]; }
   const Vector4& Matrix4::operator[](size_t index) const { return data[index]; }
@@ -234,5 +539,7 @@ namespace dxvk {
 
     return os;
   }
+
+#endif
 
 }

--- a/src/util/util_matrix.h
+++ b/src/util/util_matrix.h
@@ -1,10 +1,22 @@
 #pragma once
 
 #include <optional>
+#include <iosfwd>
+#include <cstddef>
 
 #include "util_vector.h"
 
 namespace dxvk {
+
+  /*
+  IMPORTANT: 
+  1. Use unaligned loads/stores (_mm_loadu_ps/_mm_storeu_ps) for safety,
+  because Matrix4/Vector4 may be placed in memory without guaranteed
+  16-byte alignment in all places (mapped buffers, packed structs, etc).
+  2. DO NOT USE alignas(16), because with a Windows target platform, 
+  GCC will just not align rsp at all and silently generate code that can explode at any time.
+  Info: https://github.com/doitsujin/dxvk/pull/4448
+  */
 
   class Matrix4 {
 
@@ -12,18 +24,18 @@ namespace dxvk {
 
     // Identity
     inline Matrix4() {
-      data[0] = { 1, 0, 0, 0 };
-      data[1] = { 0, 1, 0, 0 };
-      data[2] = { 0, 0, 1, 0 };
-      data[3] = { 0, 0, 0, 1 };
+      data[0] = Vector4{ 1.0f, 0.0f, 0.0f, 0.0f };
+      data[1] = Vector4{ 0.0f, 1.0f, 0.0f, 0.0f };
+      data[2] = Vector4{ 0.0f, 0.0f, 1.0f, 0.0f };
+      data[3] = Vector4{ 0.0f, 0.0f, 0.0f, 1.0f };
     }
 
     // Produces a scalar matrix, x * Identity
     inline explicit Matrix4(float x) {
-      data[0] = { x, 0, 0, 0 };
-      data[1] = { 0, x, 0, 0 };
-      data[2] = { 0, 0, x, 0 };
-      data[3] = { 0, 0, 0, x };
+      data[0] = Vector4{ x,    0.0f, 0.0f, 0.0f };
+      data[1] = Vector4{ 0.0f, x,    0.0f, 0.0f };
+      data[2] = Vector4{ 0.0f, 0.0f, x,    0.0f };
+      data[3] = Vector4{ 0.0f, 0.0f, 0.0f, x    };
     }
 
     inline Matrix4(
@@ -38,10 +50,10 @@ namespace dxvk {
     }
 
     inline Matrix4(const float matrix[4][4]) {
-      data[0] = Vector4(matrix[0]);
-      data[1] = Vector4(matrix[1]);
-      data[2] = Vector4(matrix[2]);
-      data[3] = Vector4(matrix[3]);
+      data[0] = Vector4{ matrix[0][0], matrix[0][1], matrix[0][2], matrix[0][3] };
+      data[1] = Vector4{ matrix[1][0], matrix[1][1], matrix[1][2], matrix[1][3] };
+      data[2] = Vector4{ matrix[2][0], matrix[2][1], matrix[2][2], matrix[2][3] };
+      data[3] = Vector4{ matrix[3][0], matrix[3][1], matrix[3][2], matrix[3][3] };
     }
 
     Matrix4(const Matrix4& other) = default;
@@ -50,21 +62,20 @@ namespace dxvk {
     Vector4& operator[](size_t index);
     const Vector4& operator[](size_t index) const;
 
-    bool operator==(const Matrix4& m2) const;
-    bool operator!=(const Matrix4& m2) const;
+    [[nodiscard]] bool operator==(const Matrix4& m2) const;
+    [[nodiscard]] bool operator!=(const Matrix4& m2) const;
 
-    Matrix4 operator+(const Matrix4& other) const;
-    Matrix4 operator-(const Matrix4& other) const;
+    [[nodiscard]] Matrix4 operator+(const Matrix4& other) const;
+    [[nodiscard]] Matrix4 operator-(const Matrix4& other) const;
 
-    Matrix4 operator*(const Matrix4& m2) const;
-    Vector4 operator*(const Vector4& v) const;
-    Matrix4 operator*(float scalar) const;
+    [[nodiscard]] Matrix4 operator*(const Matrix4& m2) const;
+    [[nodiscard]] Vector4 operator*(const Vector4& v) const;
+    [[nodiscard]] Matrix4 operator*(float scalar) const;
 
-    Matrix4 operator/(float scalar) const;
+    [[nodiscard]] Matrix4 operator/(float scalar) const;
 
     Matrix4& operator+=(const Matrix4& other);
     Matrix4& operator-=(const Matrix4& other);
-
     Matrix4& operator*=(const Matrix4& other);
 
     Vector4 data[4];
@@ -75,15 +86,15 @@ namespace dxvk {
 
   inline Matrix4 operator*(float scalar, const Matrix4& m) { return m * scalar; }
 
-  Matrix4 transpose(const Matrix4& m);
+  [[nodiscard]] Matrix4 transpose(const Matrix4& m);
 
-  float determinant(const Matrix4& m);
+  [[nodiscard]] float determinant(const Matrix4& m);
 
-  std::optional<Matrix4> tryInverse(const Matrix4& m);
+  [[nodiscard]] std::optional<Matrix4> tryInverse(const Matrix4& m);
 
-  Matrix4 inverse(const Matrix4& m);
+  [[nodiscard]] Matrix4 inverse(const Matrix4& m);
 
-  Matrix4 hadamardProduct(const Matrix4& a, const Matrix4& b);
+  [[nodiscard]] Matrix4 hadamardProduct(const Matrix4& a, const Matrix4& b);
 
   std::ostream& operator<<(std::ostream& os, const Matrix4& m);
 

--- a/src/util/util_shared_res.cpp
+++ b/src/util/util_shared_res.cpp
@@ -48,17 +48,23 @@ namespace dxvk {
   }
 #else
   HANDLE openKmtHandle(HANDLE kmt_handle) {
+/*
     Logger::warn("openKmtHandle: Shared resources not available on this platform.");
+*/
     return INVALID_HANDLE_VALUE;
   }
 
   bool setSharedMetadata(HANDLE handle, void *buf, uint32_t bufSize) {
+/*
     Logger::warn("setSharedMetadata: Shared resources not available on this platform.");
+*/
     return false;
   }
 
   bool getSharedMetadata(HANDLE handle, void *buf, uint32_t bufSize, uint32_t *metadataSize) {
+/*
     Logger::warn("getSharedMetadata: Shared resources not available on this platform.");
+*/
     return false;
   }
 #endif

--- a/src/util/util_sleep.cpp
+++ b/src/util/util_sleep.cpp
@@ -70,7 +70,7 @@ namespace dxvk {
         m_sleepGranularity = TimerDuration(1ms);
 
         if (NtSetTimerResolution && !NtSetTimerResolution(10000, TRUE, &cur)) {
-          Logger::info(str::format("Setting timer interval to ", (double(10000) / 10.0), " us"));
+          Logger::info(str::format("Setting timer interval to 1000 us"));
           m_sleepGranularity = TimerDuration(1ms);
         }
       }

--- a/src/util/util_sleep.cpp
+++ b/src/util/util_sleep.cpp
@@ -7,7 +7,7 @@
 
 // x86-specific pause macros to save energy during busy-waiting
 #if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
-#include <immintrin.h>
+#include <emmintrin.h>
 #define CPU_PAUSE() _mm_pause()
 // ARM-specific pause macros to save energy during busy-waiting
 #elif defined(__arm__) || defined(__aarch64__) || defined(_M_ARM) || defined(_M_ARM64)
@@ -39,12 +39,8 @@ namespace dxvk {
     if (m_initialized.load())
       return;
 
-    // Set sleepGranularity/SetTimerResolution
-    // to 1ms by default on any CPU/OS
+    // NtSetTimerResolution to 2ms by default
     initializePlatformSpecifics();
-
-    // Set sleepThreshold to 2ms
-    m_sleepThreshold = 2 * m_sleepGranularity;
 
     m_initialized.store(true, std::memory_order_release);
 }
@@ -67,20 +63,11 @@ namespace dxvk {
       // Wine's implementation of these functions is a stub as of 6.10, which is fine
       // since it uses select() in NtDelayExecution. This is only relevant for Windows.
       if (NtQueryTimerResolution && !NtQueryTimerResolution(&min, &max, &cur)) {
-        m_sleepGranularity = TimerDuration(1ms);
-
-        if (NtSetTimerResolution && !NtSetTimerResolution(10000, TRUE, &cur)) {
-          Logger::info(str::format("Setting timer interval to 1000 us"));
-          m_sleepGranularity = TimerDuration(1ms);
+        if (NtSetTimerResolution && !NtSetTimerResolution(20000, TRUE, &cur)) {
+          Logger::info(str::format("NtSetTimerResolution: Setting timer interval to 2000 us"));
         }
       }
-    } else {
-      // Assume 1ms sleep granularity by default
-      m_sleepGranularity = TimerDuration(1ms);
     }
-#else
-    // Assume 1ms sleep granularity by default
-    m_sleepGranularity = TimerDuration(1ms);
 #endif
   }
 
@@ -93,17 +80,20 @@ namespace dxvk {
     if (!m_initialized.load(std::memory_order_acquire)) 
         initialize();
 
-    TimerDuration sleepThreshold = m_sleepThreshold;
+    // Compile-time constant sleepGranularity = 2 ms
+    // Optimal precision and energy efficiency for most systems.
+    constexpr TimerDuration sleepGranularity = TimerDuration(2ms);
     const TimePoint targetTime = t0 + duration;
 
     TimePoint t1 = t0;
     TimerDuration remaining = duration;
 
-    while (remaining > sleepThreshold) {
-      TimerDuration sleepDuration = remaining - sleepThreshold;
+    // Use sleepGranularity as a sleepThreshold
+    while (remaining > sleepGranularity) {
+      TimerDuration sleepDuration = remaining - sleepGranularity;
 
-      // Try long sleep, only if sleepDuration is
-      // longer than sleepThreshold, which equals to 2 ms
+      // For high precision, try long sleep, only if sleepDuration is
+      // longer than sleepGranularity, which equals to 2 ms
       if (sleepDuration > 2ms)
         systemSleep(sleepDuration);
 
@@ -112,7 +102,8 @@ namespace dxvk {
       t0 = t1;
     }
 
-    uint32_t loopCounter = 0;
+    // Counter for intervals between wake up checks
+    uint16_t loopCounter = 0;
 
     // Busy-wait until we have slept long enough
     while (remaining > TimerDuration::zero()) {
@@ -120,8 +111,10 @@ namespace dxvk {
       // to save energy during busy-waiting
       CPU_PAUSE();
 
-      // Intervals between wake up checks
-      if (++loopCounter >= 256) {
+      // Intervals between wake up checks, i.e.
+      // Amount of times to do CPU_PAUSE();
+      // Before checking if we need to wake up.
+      if (++loopCounter >= 1000) {
         t1 = dxvk::high_resolution_clock::now();
         remaining = std::chrono::duration_cast<TimerDuration>(targetTime - t1);
         loopCounter = 0;

--- a/src/util/util_sleep.h
+++ b/src/util/util_sleep.h
@@ -56,12 +56,9 @@ namespace dxvk {
     using NtDelayExecutionProc = LONG (NTAPI *) (BOOLEAN, LARGE_INTEGER*);
     NtDelayExecutionProc NtDelayExecution = nullptr;
 #else
-    // On other platforms, we use the std library, which calls through to nanosleep -- which is ns.
+    // On other platforms, we use the std library, which calls through to nanosleep - which is ns.
     using TimerDuration = std::chrono::nanoseconds;
 #endif
-
-    TimerDuration m_sleepGranularity = TimerDuration::zero();
-    TimerDuration m_sleepThreshold   = TimerDuration::zero();
 
     Sleep();
 

--- a/src/util/util_vector.h
+++ b/src/util/util_vector.h
@@ -1,25 +1,45 @@
 #pragma once
 
 #include <iostream>
+#include <cmath>
+#include <cstddef>
+
+#if defined(__SSE4_1__) || defined(__SSE2__)
+  #include <emmintrin.h>
+#endif
+#if defined(__SSE4_1__)
+  #include <smmintrin.h> // _mm_dp_ps
+#endif
 
 #include "util_bit.h"
 #include "util_math.h"
 
 namespace dxvk {
 
+  /*
+  IMPORTANT: 
+  1. Use unaligned loads/stores (_mm_loadu_ps/_mm_storeu_ps) for safety,
+  because Matrix4/Vector4 may be placed in memory without guaranteed
+  16-byte alignment in all places (mapped buffers, packed structs, etc).
+  2. DO NOT USE alignas(16), because with a Windows target platform, 
+  GCC will just not align rsp at all and silently generate code that can explode at any time.
+  Info: https://github.com/doitsujin/dxvk/pull/4448
+  */
+
+  // PRIMARY TEMPLATE
+
   template <typename T>
   struct Vector4Base {
-    Vector4Base()
-      : x{ }, y{ }, z{ }, w{ } { }
+    union {
+      T data[4];
+      struct { T x, y, z, w; };
+      struct { T r, g, b, a; };
+    };
 
-    Vector4Base(T splat)
-      : x(splat), y(splat), z(splat), w(splat) { }
-
-    Vector4Base(T x, T y, T z, T w)
-      : x(x), y(y), z(z), w(w) { }
-
-    Vector4Base(const T xyzw[4])
-      : x(xyzw[0]), y(xyzw[1]), z(xyzw[2]), w(xyzw[3]) { }
+    Vector4Base() : x{ }, y{ }, z{ }, w{ } { }
+    Vector4Base(T splat) : x(splat), y(splat), z(splat), w(splat) { }
+    Vector4Base(T x, T y, T z, T w) : x(x), y(y), z(z), w(w) { }
+    Vector4Base(const T xyzw[4]) : x(xyzw[0]), y(xyzw[1]), z(xyzw[2]), w(xyzw[3]) { }
 
     Vector4Base(const Vector4Base<T>& other) = default;
     Vector4Base& operator=(const Vector4Base<T>& other) = default;
@@ -30,9 +50,8 @@ namespace dxvk {
     bool operator==(const Vector4Base<T>& other) const {
       for (uint32_t i = 0; i < 4; i++) {
         if (data[i] != other.data[i])
-        return false;
+          return false;
       }
-
       return true;
     }
 
@@ -73,74 +92,198 @@ namespace dxvk {
     }
 
     Vector4Base& operator+=(const Vector4Base<T>& other) {
-      x += other.x;
-      y += other.y;
-      z += other.z;
-      w += other.w;
-
-      return *this;
+      x += other.x; y += other.y; z += other.z; w += other.w; return *this;
     }
-
     Vector4Base& operator-=(const Vector4Base<T>& other) {
-      x -= other.x;
-      y -= other.y;
-      z -= other.z;
-      w -= other.w;
-
-      return *this;
+      x -= other.x; y -= other.y; z -= other.z; w -= other.w; return *this;
     }
-
     Vector4Base& operator*=(T scalar) {
-      x *= scalar;
-      y *= scalar;
-      z *= scalar;
-      w *= scalar;
-
-      return *this;
+      x *= scalar; y *= scalar; z *= scalar; w *= scalar; return *this;
     }
-
     Vector4Base& operator/=(T scalar) {
-      x /= scalar;
-      y /= scalar;
-      z /= scalar;
-      w /= scalar;
-
-      return *this;
+      x /= scalar; y /= scalar; z /= scalar; w /= scalar; return *this;
     }
+  };
 
+  // FLOAT TEMPLATES
+  // SSE, which depends CPU support, or
+  // scalar fallback.
+
+#if defined(__SSE2__) || defined(__SSE4_1__)
+  // SSE2/SSE4.1 implementation (uses unaligned loads/stores for safety)
+  template <>
+  struct Vector4Base<float> {
     union {
-      T data[4];
-      struct {
-        T x, y, z, w;
-      };
-      struct {
-        T r, g, b, a;
-      };
+      float data[4];
+      struct { float x, y, z, w; };
+      struct { float r, g, b, a; };
     };
 
+    Vector4Base() : x{0.0f}, y{0.0f}, z{0.0f}, w{0.0f} { }
+    Vector4Base(float splat) : x(splat), y(splat), z(splat), w(splat) { }
+    Vector4Base(float x, float y, float z, float w) : x(x), y(y), z(z), w(w) { }
+    Vector4Base(const float xyzw[4]) : x(xyzw[0]), y(xyzw[1]), z(xyzw[2]), w(xyzw[3]) { }
+
+    Vector4Base(const Vector4Base<float>& other) = default;
+    Vector4Base& operator=(const Vector4Base<float>& other) = default;
+
+    inline       float& operator[](size_t index)       { return data[index]; }
+    inline const float& operator[](size_t index) const { return data[index]; }
+
+    bool operator==(const Vector4Base<float>& other) const {
+      __m128 a = _mm_loadu_ps(data);
+      __m128 b = _mm_loadu_ps(other.data);
+      __m128 cmp = _mm_cmpeq_ps(a, b);
+      return _mm_movemask_ps(cmp) == 0xF;
+    }
+    bool operator!=(const Vector4Base<float>& other) const { return !operator==(other); }
+
+    Vector4Base operator-() const {
+      Vector4Base result;
+      _mm_storeu_ps(result.data, _mm_sub_ps(_mm_setzero_ps(), _mm_loadu_ps(data)));
+      return result;
+    }
+
+    Vector4Base operator+(const Vector4Base<float>& o) const {
+      Vector4Base result;
+      _mm_storeu_ps(result.data, _mm_add_ps(_mm_loadu_ps(data), _mm_loadu_ps(o.data)));
+      return result;
+    }
+
+    Vector4Base operator-(const Vector4Base<float>& o) const {
+      Vector4Base result;
+      _mm_storeu_ps(result.data, _mm_sub_ps(_mm_loadu_ps(data), _mm_loadu_ps(o.data)));
+      return result;
+    }
+
+    Vector4Base operator*(float scalar) const {
+      Vector4Base result;
+      __m128 s = _mm_set1_ps(scalar);
+      _mm_storeu_ps(result.data, _mm_mul_ps(_mm_loadu_ps(data), s));
+      return result;
+    }
+
+    Vector4Base operator*(const Vector4Base<float>& o) const {
+      Vector4Base result;
+      _mm_storeu_ps(result.data, _mm_mul_ps(_mm_loadu_ps(data), _mm_loadu_ps(o.data)));
+      return result;
+    }
+
+    Vector4Base operator/(const Vector4Base<float>& o) const {
+      Vector4Base result;
+      _mm_storeu_ps(result.data, _mm_div_ps(_mm_loadu_ps(data), _mm_loadu_ps(o.data)));
+      return result;
+    }
+
+    Vector4Base operator/(float scalar) const {
+      return (*this) * (1.0f / scalar);
+    }
+
+    Vector4Base& operator+=(const Vector4Base<float>& o) {
+      _mm_storeu_ps(data, _mm_add_ps(_mm_loadu_ps(data), _mm_loadu_ps(o.data)));
+      return *this;
+    }
+
+    Vector4Base& operator-=(const Vector4Base<float>& o) {
+      _mm_storeu_ps(data, _mm_sub_ps(_mm_loadu_ps(data), _mm_loadu_ps(o.data)));
+      return *this;
+    }
+
+    Vector4Base& operator*=(float scalar) {
+      __m128 s = _mm_set1_ps(scalar);
+      _mm_storeu_ps(data, _mm_mul_ps(_mm_loadu_ps(data), s));
+      return *this;
+    }
+
+    Vector4Base& operator/=(float scalar) {
+      return (*this) *= (1.0f / scalar);
+    }
   };
+#else
+  // Scalar implemenation
+  template <>
+  struct Vector4Base<float> {
+    union {
+      float data[4];
+      struct { float x, y, z, w; };
+      struct { float r, g, b, a; };
+    };
+
+    Vector4Base() : x{0.0f}, y{0.0f}, z{0.0f}, w{0.0f} { }
+    Vector4Base(float splat) : x(splat), y(splat), z(splat), w(splat) { }
+    Vector4Base(float x, float y, float z, float w) : x(x), y(y), z(z), w(w) { }
+    Vector4Base(const float xyzw[4]) : x(xyzw[0]), y(xyzw[1]), z(xyzw[2]), w(xyzw[3]) { }
+
+    Vector4Base(const Vector4Base<float>& other) = default;
+    Vector4Base& operator=(const Vector4Base<float>& other) = default;
+
+    inline       float& operator[](size_t index)       { return data[index]; }
+    inline const float& operator[](size_t index) const { return data[index]; }
+
+    bool operator==(const Vector4Base<float>& other) const {
+      return (x == other.x && y == other.y && z == other.z && w == other.w);
+    }
+    bool operator!=(const Vector4Base<float>& other) const { return !operator==(other); }
+
+    Vector4Base operator-() const { return {-x, -y, -z, -w}; }
+    Vector4Base operator+(const Vector4Base<float>& o) const { return {x + o.x, y + o.y, z + o.z, w + o.w}; }
+    Vector4Base operator-(const Vector4Base<float>& o) const { return {x - o.x, y - o.y, z - o.z, w - o.w}; }
+    Vector4Base operator*(float scalar) const { return {x * scalar, y * scalar, z * scalar, w * scalar}; }
+    Vector4Base operator*(const Vector4Base<float>& o) const { return {x * o.x, y * o.y, z * o.z, w * o.w}; }
+    Vector4Base operator/(const Vector4Base<float>& o) const { return {x / o.x, y / o.y, z / o.z, w / o.w}; }
+    Vector4Base operator/(float scalar) const { return (*this) * (1.0f / scalar); }
+
+    Vector4Base& operator+=(const Vector4Base<float>& o) { x += o.x; y += o.y; z += o.z; w += o.w; return *this; }
+    Vector4Base& operator-=(const Vector4Base<float>& o) { x -= o.x; y -= o.y; z -= o.z; w -= o.w; return *this; }
+    Vector4Base& operator*=(float scalar) { x *= scalar; y *= scalar; z *= scalar; w *= scalar; return *this; }
+    Vector4Base& operator/=(float scalar) { return (*this) *= (1.0f / scalar); }
+  };
+#endif
+
+  // NON-MEMBER FUNCTIONS
 
   template <typename T>
   inline Vector4Base<T> operator*(T scalar, const Vector4Base<T>& vector) {
     return vector * scalar;
   }
 
-  template <typename T>
-  float dot(const Vector4Base<T>& a, const Vector4Base<T>& b) {
-    return a.x * b.x + a.y * b.y + a.z * b.z + a.w * b.w;
+  // Optimized dot product for float: prefer SSE4.1 dp, else SSE2 reduction, else scalar.
+#if defined(__SSE4_1__)
+  inline float dot(const Vector4Base<float>& a, const Vector4Base<float>& b) {
+    __m128 res = _mm_dp_ps(_mm_loadu_ps(a.data), _mm_loadu_ps(b.data), 0xF1);
+    float out;
+    _mm_store_ss(&out, res);
+    return out;
   }
+#elif defined(__SSE2__)
+  inline float dot(const Vector4Base<float>& a, const Vector4Base<float>& b) {
+    __m128 mul = _mm_mul_ps(_mm_loadu_ps(a.data), _mm_loadu_ps(b.data));
+    __m128 shuf = _mm_shuffle_ps(mul, mul, _MM_SHUFFLE(1, 0, 3, 2));
+    __m128 sums = _mm_add_ps(mul, shuf);
+    shuf = _mm_shuffle_ps(sums, sums, _MM_SHUFFLE(2, 3, 0, 1));
+    __m128 total = _mm_add_ps(sums, shuf);
+    float out;
+    _mm_store_ss(&out, total);
+    return out;
+  }
+#else
+  template <typename T>
+  inline float dot(const Vector4Base<T>& a, const Vector4Base<T>& b) {
+    return float(a.x * b.x + a.y * b.y + a.z * b.z + a.w * b.w);
+  }
+#endif
 
   template <typename T>
-  T lengthSqr(const Vector4Base<T>& a) { return dot(a, a); }
+  inline T lengthSqr(const Vector4Base<T>& a) { return dot(a, a); }
 
   template <typename T>
-  float length(const Vector4Base<T>& a) { return std::sqrt(float(lengthSqr(a))); }
+  inline float length(const Vector4Base<T>& a) { return std::sqrt(float(lengthSqr(a))); }
 
   template <typename T>
-  Vector4Base<T> normalize(const Vector4Base<T>& a) { return a * T(1.0f / length(a)); }
+  inline Vector4Base<T> normalize(const Vector4Base<T>& a) { return a * T(1.0f / length(a)); }
 
   template <typename T>
-  std::ostream& operator<<(std::ostream& os, const Vector4Base<T>& v) {
+  inline std::ostream& operator<<(std::ostream& os, const Vector4Base<T>& v) {
     return os << "Vector4(" << v[0] << ", " << v[1] << ", " << v[2] << ", " << v[3] << ")";
   }
 
@@ -150,19 +293,22 @@ namespace dxvk {
   static_assert(sizeof(Vector4)  == sizeof(float) * 4);
   static_assert(sizeof(Vector4i) == sizeof(int)   * 4);
 
+  // replaceNaN: SSE2 implementation or scalar fallback
+#if defined(__SSE2__) || defined(__SSE4_1__)
   inline Vector4 replaceNaN(Vector4 a) {
-    #ifdef DXVK_ARCH_X86
     Vector4 result;
     __m128 value = _mm_loadu_ps(a.data);
-    __m128 mask  = _mm_cmpeq_ps(value, value);
-           value = _mm_and_ps(value, mask);
+    __m128 mask  = _mm_cmpeq_ps(value, value); // NaN != NaN -> mask zero
+           value = _mm_and_ps(value, mask);    // zero-out NaNs
     _mm_storeu_ps(result.data, value);
     return result;
-    #else
+  }
+#else
+  inline Vector4 replaceNaN(Vector4 a) {
     for (int i = 0; i < 4; i++)
       a[i] = std::isnan(a[i]) ? 0.0f : a[i];
     return a;
-    #endif
   }
+#endif
 
 }

--- a/src/util/util_win32_compat.h
+++ b/src/util/util_win32_compat.h
@@ -27,7 +27,9 @@ inline HANDLE CreateSemaphoreA(
         LONG                  lInitialCount,
         LONG                  lMaximumCount,
         LPCSTR                lpName) {
+/*
   dxvk::Logger::warn("CreateSemaphoreA not implemented.");
+*/
   return nullptr;
 }
 #define CreateSemaphore CreateSemaphoreA
@@ -36,12 +38,16 @@ inline BOOL ReleaseSemaphore(
         HANDLE hSemaphore,
         LONG   lReleaseCount,
         LONG*  lpPreviousCount) {
+/*
   dxvk::Logger::warn("ReleaseSemaphore not implemented.");
+*/
   return FALSE;
 }
 
 inline BOOL SetEvent(HANDLE hEvent) {
+/*
   dxvk::Logger::warn("SetEvent not implemented.");
+*/
   return FALSE;
 }
 
@@ -53,22 +59,30 @@ inline BOOL DuplicateHandle(
         DWORD dwDesiredAccess,
         BOOL bInheritHandle,
         DWORD dwOptions) {
+/*
   dxvk::Logger::warn("DuplicateHandle not implemented.");
+*/
   return FALSE;
 }
 
 inline BOOL CloseHandle(HANDLE hObject) {
+/*
   dxvk::Logger::warn("CloseHandle not implemented.");
+*/
   return FALSE;
 }
 
 inline HANDLE GetCurrentProcess() {
+/*
   dxvk::Logger::warn("GetCurrentProcess not implemented.");
+*/
   return nullptr;
 }
 
 inline HDC CreateCompatibleDC(HDC hdc) {
+/*
   dxvk::Logger::warn("CreateCompatibleDC not implemented.");
+*/
   return nullptr;
 }
 

--- a/src/vulkan/vulkan_loader.cpp
+++ b/src/vulkan/vulkan_loader.cpp
@@ -33,7 +33,9 @@ namespace dxvk::vk {
         continue;
       }
 
+/*
       Logger::info(str::format("Vulkan: Found vkGetInstanceProcAddr in ", dllName, " @ 0x", std::hex, reinterpret_cast<uintptr_t>(proc)));
+*/
       return std::make_pair(library, reinterpret_cast<PFN_vkGetInstanceProcAddr>(proc));
     }
 

--- a/src/vulkan/vulkan_util.h
+++ b/src/vulkan/vulkan_util.h
@@ -163,7 +163,9 @@ namespace dxvk::vk {
       case VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL:
         return 0;
       default:
+/*
         Logger::err(str::format("Unhandled image layout ", layout));
+*/
         return 0;
     }
   }


### PR DESCRIPTION
Build Improvements:

- Disabled Debug explicitly everywhere;
- Added GCC optmizations flags - GCC is now fastest and preffered build type;
- Added minor MSVC/Clang compiler flags;
- Changed DXVK Native build container from SteamRT-Sniper to SteamRT4 - SteamRT4 uses GCC 14.2.0 vs GCC10 on SteamRT3, so DXVK Native gets most of improvements from new compiler flags.

Reduced amount of logs:

- In every part, except dxvk-part since it will be changed;
- Minor increases to CPU-bound performance, reduces DLLs sizes and shader compilation times a little.

Sleep Improvements_v2:

- Removed sleepThreshold and used sleepGranularity, which now equals to 2ms for all systems;
- Optimized existing logic and removed redundant logic;
- Increased amount of time between wake-up checks.

As a result, power efficiency is improved, precision is same or higher, due to more optimal sleepGranularity.

SIMD:

- Implemented SSE2/SSE4.1 intrinsics in appropriate functions, where applicable and possible. Scalar fallbacks for non-x86 are present.
- Unaligned operations are used due to inherent problems with alignment in DXVK.
- AVX is not used because of inherent problems with AVX in DXVK and questionable efficiency.

As a result, improves CPU-bound performance and energy efficiency in D3D8/D3D9 applications.

MSAA Improvements_v2:

- Implemented skipping of very-small-weight fetches;
- Implemented precomputed sample base index for RESOLVE_AVERAGE and linear path;
- Replaced expensive alpha-all-zero test with a cheaper comparison;
- FILTER_NEAREST is handled as a separate, cheap path;
- Implemented fast compute path for common masks;
- Other minor optimizations.

As a result, increases GPU-bound performance in applications that use MSAA, without any visible change in quality, but with minor increase in MSAA shader compile time.