### PR TITLE
Sleep Improvements_v3 and FPS Limiter Improvements

### DIFF
--- a/src/util/util_fps_limiter.cpp
+++ b/src/util/util_fps_limiter.cpp
@@ -62,7 +62,14 @@ namespace dxvk {
 
     auto frameTime = std::chrono::duration_cast<TimerDuration>(t1 - t0);
 
-    if (frameTime * 100 > m_targetInterval * 103 - m_deviation * 100) {
+    // FPS-dependent slow frame threshold - improves precision on different FPS
+    // m_targetInterval - a frame time to lock to - FPS Limit
+    // thresholdPercent -  how far a frame time can slip, before resetting deviation
+    // if m_targetInterval is Less than 83.3FPS - thresholdPercent=101; 
+    // if m_targetInterval is More than 83.3FPS - thresholdPercent=104;
+    int thresholdPercent = (m_targetInterval < 12ms) ? 104 : 101;
+
+    if (frameTime * 100 > m_targetInterval * thresholdPercent - m_deviation * 100) {
       // If we have a slow frame, reset the deviation since we
       // do not want to compensate for low performance later on
       m_deviation = TimerDuration::zero();
@@ -72,12 +79,22 @@ namespace dxvk {
       TimerDuration sleepDuration = m_targetInterval - m_deviation - frameTime;
       t1 = Sleep::sleepFor(t1, sleepDuration);
 
-      // Compensate for any sleep inaccuracies in the next frame, and
-      // limit cumulative deviation in order to avoid stutter in case we
-      // have a number of slow frames immediately followed by a fast one.
+      // Recalculate interval to figure out exact delivery error
       frameTime = std::chrono::duration_cast<TimerDuration>(t1 - t0);
-      m_deviation += frameTime - m_targetInterval;
-      m_deviation = std::min(m_deviation, m_targetInterval / 16);
+      TimerDuration currentError = frameTime - m_targetInterval;
+
+      // EWMA-based deviation calculation
+      // 0.05/0.95 - prefer smoothness and jitter suppression, instead of adjustment speed
+      m_deviation = std::chrono::duration_cast<TimerDuration>((m_deviation * 0.95) + (currentError * 0.05));
+
+      // Total correction window - percentage of target interval.
+      // Percentage depends on m_targetInterval
+      // if m_targetInterval is Less than 83.3FPS - correctionWindow=32 - 3.125%; 
+      // if m_targetInterval is More than 83.3FPS - correctionWindow=8 - 12.5%;
+      int correctionWindow = (m_targetInterval < 12ms) ? 8 : 32;
+
+      TimerDuration maxCap = m_targetInterval / correctionWindow;
+      m_deviation = std::max(-maxCap, std::min(m_deviation, maxCap));
     }
 
     m_lastFrame = t1;

--- a/src/util/util_sleep.cpp
+++ b/src/util/util_sleep.cpp
@@ -21,6 +21,7 @@ using namespace std::chrono_literals;
 
 namespace dxvk {
 
+  std::once_flag Sleep::s_initFlag;
   Sleep Sleep::s_instance;
 
 
@@ -34,15 +35,10 @@ namespace dxvk {
   }
 
   void Sleep::initialize() {
-    std::lock_guard lock(m_mutex);
-
-    if (m_initialized.load())
-      return;
-
-    // NtSetTimerResolution to 2ms by default
-    initializePlatformSpecifics();
-
-    m_initialized.store(true, std::memory_order_release);
+    // Thread-safe platform initialization guaranteed by the runtime library
+    std::call_once(s_initFlag, [this]() {
+        this->initializePlatformSpecifics(); // NtSetTimerResolution to 1ms by default
+    });
 }
 
 
@@ -63,8 +59,8 @@ namespace dxvk {
       // Wine's implementation of these functions is a stub as of 6.10, which is fine
       // since it uses select() in NtDelayExecution. This is only relevant for Windows.
       if (NtQueryTimerResolution && !NtQueryTimerResolution(&min, &max, &cur)) {
-        if (NtSetTimerResolution && !NtSetTimerResolution(20000, TRUE, &cur)) {
-          Logger::info(str::format("NtSetTimerResolution: Setting timer interval to 2000 us"));
+        if (NtSetTimerResolution && !NtSetTimerResolution(10000, TRUE, &cur)) {
+          Logger::info(str::format("NtSetTimerResolution: Setting timer interval to 1000 us (1 ms, 1000 Hz)"));
         }
       }
     }
@@ -76,29 +72,27 @@ namespace dxvk {
     if (duration <= TimerDuration::zero())
       return t0;
 
-    // if necessary, initialize function pointers and some values
-    if (!m_initialized.load(std::memory_order_acquire)) 
-        initialize();
+    initialize();
 
-    // Compile-time constant sleepGranularity = 2 ms
+    // Compile-time constant sleepGranularity = 1 ms
     // Optimal precision and energy efficiency for most systems.
-    constexpr TimerDuration sleepGranularity = TimerDuration(2ms);
-    const TimePoint targetTime = t0 + duration;
+    constexpr TimerDuration sleepGranularity = TimerDuration(1ms);
 
-    TimePoint t1 = t0;
+    // Compile-time constant sleepThreshold = 2 ms
+    // Optimal precision and energy efficiency for most systems.
+    constexpr TimerDuration sleepThreshold = TimerDuration(2ms);
+
     TimerDuration remaining = duration;
+    TimePoint t1 = t0;
 
-    // Use sleepGranularity as a sleepThreshold
-    while (remaining > sleepGranularity) {
+    // Use 2 * sleepGranularity as a sleepThreshold
+    while (remaining > sleepThreshold) {
       TimerDuration sleepDuration = remaining - sleepGranularity;
 
-      // For high precision, try long sleep, only if sleepDuration is
-      // longer than sleepGranularity, which equals to 2 ms
-      if (sleepDuration > 2ms)
-        systemSleep(sleepDuration);
+      systemSleep(sleepDuration);
 
       t1 = dxvk::high_resolution_clock::now();
-      remaining = std::chrono::duration_cast<TimerDuration>(targetTime - t1);
+      remaining -= std::chrono::duration_cast<TimerDuration>(t1 - t0);
       t0 = t1;
     }
 
@@ -107,8 +101,10 @@ namespace dxvk {
 
     // Busy-wait until we have slept long enough
     while (remaining > TimerDuration::zero()) {
-      // CPU arch-specific pause macros 
-      // to save energy during busy-waiting
+      // CPU arch-specific pause macros, which
+      // saves energy during busy-waiting.
+      // Windows Task Manager will show CPU Load, 
+      // but CPU is actually doing less/nothing.
       CPU_PAUSE();
 
       // Intervals between wake up checks, i.e.
@@ -116,21 +112,24 @@ namespace dxvk {
       // Before checking if we need to wake up.
       if (++loopCounter >= 1000) {
         t1 = dxvk::high_resolution_clock::now();
-        remaining = std::chrono::duration_cast<TimerDuration>(targetTime - t1);
+        remaining -= std::chrono::duration_cast<TimerDuration>(t1 - t0);
+        t0 = t1;
         loopCounter = 0;
       }
     }
 
-    return dxvk::high_resolution_clock::now();
+    return t1;
 }
 
   void Sleep::systemSleep(TimerDuration duration) {
 #ifdef _WIN32
-    if (NtDelayExecution) {
+    // Protection from thread loading anomalies
+    auto proc = NtDelayExecution.load(std::memory_order_acquire);
+    if (proc) {
       LARGE_INTEGER ticks;
       ticks.QuadPart = -duration.count();
 
-      NtDelayExecution(FALSE, &ticks);
+      proc(FALSE, &ticks);
     } else {
       std::this_thread::sleep_for(duration);
     }

--- a/src/util/util_sleep.h
+++ b/src/util/util_sleep.h
@@ -43,10 +43,10 @@ namespace dxvk {
 
   private:
 
-    static Sleep s_instance;
+    // Global static flag to handle safe execution once across all threads
+    static std::once_flag s_initFlag;
 
-    dxvk::mutex       m_mutex;
-    std::atomic<bool> m_initialized = { false };
+    static Sleep s_instance;
 
 #ifdef _WIN32
     // On Windows, we use NtDelayExecution which has units of 100ns.
@@ -54,7 +54,8 @@ namespace dxvk {
     using NtQueryTimerResolutionProc = LONG (NTAPI *) (ULONG*, ULONG*, ULONG*);
     using NtSetTimerResolutionProc = LONG (NTAPI *) (ULONG, BOOLEAN, ULONG*);
     using NtDelayExecutionProc = LONG (NTAPI *) (BOOLEAN, LARGE_INTEGER*);
-    NtDelayExecutionProc NtDelayExecution = nullptr;
+    // Make the function pointer atomic because we load it across threads.
+    std::atomic<NtDelayExecutionProc> NtDelayExecution;
 #else
     // On other platforms, we use the std library, which calls through to nanosleep - which is ns.
     using TimerDuration = std::chrono::nanoseconds;


### PR DESCRIPTION
Sleep Improvements_v3:

- Set `sleepGranularity` to 1 ms for all systems;
- Returned `sleepThreshold`, which is set to 2 ms (`sleepGranularity*2`) by default for all systems;
- Optimized existing logic and removed redundant logic.

As a result, power efficiency is improved and precision is higher, due to more optimal sleepGranularity.

FPS Limiter Improvements:

 - Implemented FPS-dependent slow frame threshold;
 - Implemented EWMA-based deviation calculation instead of previous implementation;
 - Implemented FPS-dependent total correction window.

As a result, significantly improved frame pacing, image smoothness, precision and robustness (FPS Limiter inherently tries to maintain stable frame pacing of the application, even if the application provides frames at uneven pace and DXVK's HUD shows uneven frametime graph of application) at wide range of target FPS (30-360).
Note: It does not mean that FPS Limiter will break beyond aformentioned range, but it was calibrated for this range.